### PR TITLE
Clear one signal notifications

### DIFF
--- a/Example/www/OneSignal.js
+++ b/Example/www/OneSignal.js
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  * 
- * Copyright 2015 OneSignal
+ * Copyright 2016 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -104,6 +104,14 @@ OneSignal.prototype.postNotification = function(jsonData, onSuccess, onFailure) 
         onFailure = function() {};
 
     cordova.exec(onSuccess, onFailure, "OneSignalPush", "postNotification", [jsonData]);
+};
+
+OneSignal.prototype.promptLocation = function() {
+  cordova.exec(function(){}, function(){}, "OneSignalPush", "promptLocation", []);
+};
+
+OneSignal.prototype.setEmail = function(email) {
+    cordova.exec(function(){}, function(){}, "OneSignalPush", "setEmail", [email]);
 };
 
 OneSignal.prototype.setLogLevel = function(logLevel) {

--- a/Example/www/OneSignal.js
+++ b/Example/www/OneSignal.js
@@ -118,6 +118,9 @@ OneSignal.prototype.setLogLevel = function(logLevel) {
     cordova.exec(function(){}, function(){}, "OneSignalPush", "setLogLevel", [logLevel]);
 };
 
+OneSignal.prototype.clearOneSignalNotifications = function() {
+    cordova.exec(function(){}, function(){}, "OneSignalPush", "clearOneSignalNotifications", []);
+};
 
 //-------------------------------------------------------------------
 

--- a/src/android/com/plugin/gcm/OneSignalPush.java
+++ b/src/android/com/plugin/gcm/OneSignalPush.java
@@ -68,6 +68,7 @@ public class OneSignalPush extends CordovaPlugin {
   public static final String PROMPT_LOCATION = "promptLocation";
   public static final String SET_EMAIL = "setEmail";
   public static final String SET_LOG_LEVEL = "setLogLevel";
+  public static final String CLEAR_ONE_SIGNAL_NOTIFICATIONS = "clearOneSignalNotifications";
   
   // This is to prevent an issue where if two Javascript calls are made to OneSignal expecting a callback then only one would fire.
   private static void callbackSuccess(CallbackContext callbackContext, JSONObject jsonObject) {
@@ -268,6 +269,8 @@ public class OneSignalPush extends CordovaPlugin {
         t.printStackTrace();
       }
     }
+    else if (CLEAR_ONE_SIGNAL_NOTIFICATIONS.equals(action))
+      OneSignal.clearOneSignalNotifications();
     else {
       result = false;
       Log.e(TAG, "Invalid action : " + action);

--- a/src/ios/OneSignalPush.h
+++ b/src/ios/OneSignalPush.h
@@ -49,5 +49,6 @@
 - (void)enableVibrate:(CDVInvokedUrlCommand*)command;
 - (void)enableSound:(CDVInvokedUrlCommand*)command;
 - (void)enableNotificationsWhenActive:(CDVInvokedUrlCommand*)command;
+- (void)clearOneSignalNotifications:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -222,5 +222,6 @@ static Class delegateClass = nil;
 - (void)enableVibrate:(CDVInvokedUrlCommand*)command {}
 - (void)enableSound:(CDVInvokedUrlCommand*)command {}
 - (void)enableNotificationsWhenActive:(CDVInvokedUrlCommand*)command {}
+- (void)clearOneSignalNotifications:(CDVInvokedUrlCommand*)command {}
 
 @end

--- a/www/OneSignal.js
+++ b/www/OneSignal.js
@@ -118,6 +118,9 @@ OneSignal.prototype.setLogLevel = function(logLevel) {
     cordova.exec(function(){}, function(){}, "OneSignalPush", "setLogLevel", [logLevel]);
 };
 
+OneSignal.prototype.clearOneSignalNotifications = function() {
+    cordova.exec(function(){}, function(){}, "OneSignalPush", "clearOneSignalNotifications", []);
+};
 
 //-------------------------------------------------------------------
 


### PR DESCRIPTION
Expose Android SDK `clearOneSignalNotifications` on Cordova SDK.

iOS implementation is an empty method.

Windows implementation not included.

