### PR TITLE
Create .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+Example/
+*.zip


### PR DESCRIPTION
I've noticed on `1.13.1` npm package contents that you're including files that are useless for the functionality this module provides.

<img width="293" alt="captura de ecra 2016-09-09 as 13 21 18" src="https://cloud.githubusercontent.com/assets/3604053/18386725/a0b6682e-7690-11e6-9e61-327da668f268.png">

The first one is the `Example/` folder, which is great to have on the repo but is kind of useless to include on the npm package.
The second one is the `OneSignal-Cordova-SDK.zip`, which is a zip with all the contents of the package, which means the package is taking more than two times space it really needs. I assume you're creating the ZIP at some point of your CD pipelining, once you correct it, you can remove `*.zip` from this `.npmignore`.

Thanks.