### PR TITLE
Amazon AndroidManifest.xml permission fix

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -40,6 +40,11 @@
     </config-file>
 
     <!-- PhoneGap Build (PGB) does not have a amazon build target so it include the required manifest entries in all Android builds. -->
+    <config-file target="AndroidManifest.xml" parent="/manifest">
+      <uses-permission android:name="com.amazon.device.messaging.permission.RECEIVE" />
+      <permission android:name="$PACKAGE_NAME.permission.RECEIVE_ADM_MESSAGE" android:protectionLevel="signature" />
+      <uses-permission android:name="$PACKAGE_NAME.permission.RECEIVE_ADM_MESSAGE" />
+    </config-file>
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
       <amazon:enable-feature android:name="com.amazon.device.messaging" android:required="false" xmlns:amazon="http://schemas.amazon.com/apk/res/android" />
       <service android:name="com.onesignal.ADMMessageHandler" android:exported="false" />
@@ -52,7 +57,6 @@
           <category android:name="$PACKAGE_NAME" />
         </intent-filter>
       </receiver>
-      <uses-permission android:name="com.amazon.device.messaging.permission.RECEIVE" />
     </config-file>
     
     <source-file src="src/android/com/plugin/gcm/OneSignalPush.java" target-dir="src/com/plugin/gcm/" />


### PR DESCRIPTION
Applying https://github.com/OneSignal/OneSignal-Cordova-SDK/commit/cb852cd0f4092931ee5e92d3e36c0d647964736c

Should fix https://github.com/OneSignal/OneSignal-Cordova-SDK/issues/84 for 1.3.x