### PR TITLE
Updated native SDK code, Android data types, and iOS isAppInFocus

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Modified MIT License
 
-Copyright 2015 OneSignal
+Copyright 2016 OneSignal
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -32,21 +32,6 @@ Includes portions from the Google GcmClient demo project:
     You may obtain a copy of the License at
     
       http://www.apache.org/licenses/LICENSE-2.0
-    
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-	
-Includes Portions Copyright 2014 StackMob:
-    Copyright 2014 StackMob
-    
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-    
-    http://www.apache.org/licenses/LICENSE-2.0
     
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -1,7 +1,6 @@
 def manifest = new XmlSlurper().parse(file("AndroidManifest.xml"))
 android.defaultConfig {
    applicationId manifest.@package.text()
-   manifestPlaceholders = [manifestApplicationId: "${android.defaultConfig.applicationId}",
-                          onesignal_app_id: "", // Use from code for now.
-                          onesignal_google_project_number: ""]
+   manifestPlaceholders = [onesignal_app_id: "", // Use from code for now.
+                          onesignal_google_project_number: "REMOTE"]
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.6",
+  "version": "2.0.7",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="2.0.6">
+    version="2.0.7">
 
 
   <name>OneSignal Push Notifications</name>
@@ -25,7 +25,7 @@
   </engines>
   
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:3.3.0@aar" />
+    <framework src="com.onesignal:OneSignal:3.4.1@aar" />
 
     <framework src="com.google.android.gms:play-services-gcm:+" />
     <!-- play-services-analytics is only required when gms version 8.1.0 or older is used. -->
@@ -95,6 +95,9 @@
     <header-file src="src/ios/OneSignalTracker.h" />
     <header-file src="src/ios/OneSignalWebView.h" />
     <source-file src="src/ios/OneSignalPush.h" />
+    <source-file src="src/ios/OneSignalSelectorHelpers.h" />
+    <source-file src="src/ios/UNUserNotificationCenter+OneSignal.h" />
+    
 
     <!-- Implementation -->
     <source-file src="src/ios/OneSignal.m" />
@@ -111,6 +114,8 @@
     <source-file src="src/ios/OneSignalHelper.m" />
     <source-file src="src/ios/OneSignalWebView.m" />
     <source-file src="src/ios/OneSignalPush.m" />
+    <source-file src="src/ios/OneSignalSelectorHelpers.m" />
+    <source-file src="src/ios/UNUserNotificationCenter+OneSignal.m" />
 
     <header-file src="src/ios/OneSignal-Prefix.pch" />
 

--- a/src/android/com/plugin/gcm/OneSignalPush.java
+++ b/src/android/com/plugin/gcm/OneSignalPush.java
@@ -78,19 +78,8 @@ public class OneSignalPush extends CordovaPlugin {
 
   // This is to prevent an issue where if two Javascript calls are made to OneSignal expecting a callback then only one would fire.
   private static void callbackSuccess(CallbackContext callbackContext, JSONObject jsonObject) {
-    if(jsonObject == null){ // in case there are no data
+    if (jsonObject == null) // in case there are no data
       jsonObject = new JSONObject();
-    }
-
-    if(jsonObject.has("payload")) {
-      try {
-        JSONObject payload = jsonObject.getJSONObject("payload");
-        if (payload.has("additionalData")) {
-          payload.put("additionalData", new JSONObject(payload.getString("additionalData")));
-          jsonObject.put("payload", payload);
-        }
-      } catch (Throwable t) {t.printStackTrace();}
-    }
 
     PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, jsonObject);
     pluginResult.setKeepCallback(true);
@@ -98,9 +87,8 @@ public class OneSignalPush extends CordovaPlugin {
   }
   
   private static void callbackError(CallbackContext callbackContext, JSONObject jsonObject) {
-    if(jsonObject == null) { // in case there are no data
+    if (jsonObject == null) // in case there are no data
       jsonObject = new JSONObject();
-    }
     
     PluginResult pluginResult = new PluginResult(PluginResult.Status.ERROR, jsonObject);
     pluginResult.setKeepCallback(true);
@@ -169,12 +157,13 @@ public class OneSignalPush extends CordovaPlugin {
           try {
             jsonIds.put("userId", userId);
             if (registrationId != null)
-            jsonIds.put("pushToken", registrationId);
+              jsonIds.put("pushToken", registrationId);
             else
-            jsonIds.put("pushToken", "");
+              jsonIds.put("pushToken", "");
             
             callbackSuccess(jsIdsAvailableCallBack, jsonIds);
-            } catch (Throwable t) {
+          }
+          catch (Throwable t) {
             t.printStackTrace();
           }
         }
@@ -184,7 +173,8 @@ public class OneSignalPush extends CordovaPlugin {
     else if (SEND_TAGS.equals(action)) {
       try {
         OneSignal.sendTags(data.getJSONObject(0));
-        } catch (Throwable t) {
+      }
+      catch (Throwable t) {
         t.printStackTrace();
       }
       result = true;
@@ -193,10 +183,10 @@ public class OneSignalPush extends CordovaPlugin {
       try {
         Collection<String> list = new ArrayList<String>();
         for (int i = 0; i < data.length(); i++)
-        list.add(data.get(i).toString());
+          list.add(data.get(i).toString());
         OneSignal.deleteTags(list);
         result = true;
-        } catch (Throwable t) {
+      } catch (Throwable t) {
         t.printStackTrace();
       }
     }
@@ -208,7 +198,8 @@ public class OneSignalPush extends CordovaPlugin {
       try {
         OneSignal.enableVibrate(data.getBoolean(0));
         result = true;
-        } catch (Throwable t) {
+      }
+      catch (Throwable t) {
         t.printStackTrace();
       }
     }
@@ -216,7 +207,8 @@ public class OneSignalPush extends CordovaPlugin {
       try {
         OneSignal.enableSound(data.getBoolean(0));
         result = true;
-        } catch (Throwable t) {
+      }
+      catch (Throwable t) {
         t.printStackTrace();
       }
     }
@@ -224,7 +216,8 @@ public class OneSignalPush extends CordovaPlugin {
       try {
         OneSignal.setSubscription(data.getBoolean(0));
         result = true;
-        } catch (Throwable t) {
+      }
+      catch (Throwable t) {
         t.printStackTrace();
       }
     }
@@ -233,20 +226,21 @@ public class OneSignalPush extends CordovaPlugin {
         JSONObject jo = data.getJSONObject(0);
         final CallbackContext jsPostNotificationCallBack = callbackContext;
         OneSignal.postNotification(jo,
-        new PostNotificationResponseHandler() {
-          @Override
-          public void onSuccess(JSONObject response) {
-            callbackSuccess(jsPostNotificationCallBack, response);
-          }
-          
-          @Override
-          public void onFailure(JSONObject response) {
-            callbackError(jsPostNotificationCallBack, response);
-          }
-        });
+          new PostNotificationResponseHandler() {
+            @Override
+            public void onSuccess(JSONObject response) {
+              callbackSuccess(jsPostNotificationCallBack, response);
+            }
+            
+            @Override
+            public void onFailure(JSONObject response) {
+              callbackError(jsPostNotificationCallBack, response);
+            }
+          });
         
         result = true;
-        } catch (Throwable t) {
+      }
+      catch (Throwable t) {
         t.printStackTrace();
       }
     }
@@ -263,14 +257,16 @@ public class OneSignalPush extends CordovaPlugin {
       try {
         JSONObject jo = data.getJSONObject(0);
         OneSignal.setLogLevel(jo.getInt("logLevel"), jo.getInt("visualLevel"));
-        } catch(Throwable t) {
+      }
+      catch(Throwable t) {
         t.printStackTrace();
       }
     }
     else if (CLEAR_ONESIGNAL_NOTIFICATIONS.equals(action)) {
       try {
         OneSignal.clearOneSignalNotifications();
-        } catch(Throwable t) {
+      }
+      catch(Throwable t) {
         t.printStackTrace();
       }
     }
@@ -295,7 +291,8 @@ public class OneSignalPush extends CordovaPlugin {
     public void notificationReceived(OSNotification notification) {      
       try {
         callbackSuccess(jsNotificationReceivedCallBack, new JSONObject(notification.stringify()));
-        } catch (Throwable t) {
+      }
+      catch (Throwable t) {
         t.printStackTrace();
       }
     }
@@ -313,7 +310,8 @@ public class OneSignalPush extends CordovaPlugin {
     public void notificationOpened(OSNotificationOpenResult result) {      
       try {
         callbackSuccess(jsNotificationOpenedCallBack, new JSONObject(result.stringify()));
-        } catch (Throwable t) {
+      }
+      catch (Throwable t) {
         t.printStackTrace();
       }
     }

--- a/src/ios/OneSignal.h
+++ b/src/ios/OneSignal.h
@@ -44,7 +44,7 @@
  REST API: https://documentation.onesignal.com/docs/server-api-overview
  Create Notification API: https://documentation.onesignal.com/docs/notifications-create-notification
  
- ***/
+***/
 
 #import <Foundation/Foundation.h>
 
@@ -54,8 +54,8 @@
 
 @protocol OSUserNotificationCenterDelegate <NSObject>
 @optional
-- (void)userNotificationCenter:(id)center willPresentNotification:(id)notification withCompletionHandler:(void (^)(NSUInteger options))completionHandler;
-- (void)userNotificationCenter:(id)center didReceiveNotificationResponse:(id)response withCompletionHandler:(void (^)())completionHandler;
+- (void)userNotificationCenter:(id)center willPresentNotification:(id)notification withCompletionHandler:(void (^)(NSUInteger options))completionHandler __deprecated_msg("Can use your own delegate as normal.");
+- (void)userNotificationCenter:(id)center didReceiveNotificationResponse:(id)response withCompletionHandler:(void (^)())completionHandler __deprecated_msg("Can use your own delegate as normal.");
 @end
 
 #endif
@@ -148,6 +148,9 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
  Set to false when app is in focus and in-app alerts are disabled, or the remote notification is silent. */
 @property(readonly, getter=wasShown)BOOL shown;
 
+/* Set to true if the app was in focus when the notification  */
+@property(readonly, getter=wasAppInFocus)BOOL isAppInFocus;
+
 /* Set to true when the received notification is silent
  Silent means there is no alert, sound, or badge payload in the aps dictionary
  requires remote-notification within UIBackgroundModes array of the Info.plist */
@@ -155,7 +158,7 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 
 /* iOS 10+: Indicates wether or not the received notification has mutableContent : 1 assigned to its payload
  Used for UNNotificationServiceExtension to launch extension.
- */
+*/
 #if XC8_AVAILABLE
 @property(readonly, getter=hasMutableContent)BOOL mutableContent;
 #endif
@@ -190,27 +193,27 @@ typedef void (^OSHandleNotificationReceivedBlock)(OSNotification* notification);
 typedef void (^OSHandleNotificationActionBlock)(OSNotificationOpenedResult * result);
 
 /*Dictionary of keys to pass alongside the init serttings*/
-
+    
 /*Let OneSignal directly promt for push notifications on init*/
 extern NSString * const kOSSettingsKeyAutoPrompt;
-
+    
 /*Enable the default in-app alerts*/
 extern NSString * const kOSSettingsKeyInAppAlerts;
 
 /*Enable In-App display of Launch URLs*/
 extern NSString * const kOSSettingsKeyInAppLaunchURL;
 
-/* iOS10+ -
+/* iOS10+ - 
  Set notificaion's in-focus display option.
  Value must be an OSNotificationDisplayType enum
- */
+*/
 extern NSString * const kOSSettingsKeyInFocusDisplayOption;
 
 /**
- OneSignal provides a high level interface to interact with OneSignal's push service.
- OneSignal is a singleton for applications which use a globally available client to share configuration settings.
- You should avoid creating instances of this class at all costs. Instead, access its instance methods.
- Include `#import <OneSignal/OneSignal.h>` in your application files to access OneSignal's methods.
+    OneSignal provides a high level interface to interact with OneSignal's push service.
+    OneSignal is a singleton for applications which use a globally available client to share configuration settings.
+    You should avoid creating instances of this class at all costs. Instead, access its instance methods.
+    Include `#import <OneSignal/OneSignal.h>` in your application files to access OneSignal's methods.
  **/
 @interface OneSignal : NSObject
 
@@ -227,16 +230,16 @@ typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
 /**
  Initialize OneSignal. Sends push token to OneSignal so you can later send notifications.
  
- */
+*/
 
 // - Initialization
 + (id)initWithLaunchOptions:(NSDictionary*)launchOptions appId:(NSString*)appId;
 + (id)initWithLaunchOptions:(NSDictionary*)launchOptions appId:(NSString*)appId handleNotificationAction:(OSHandleNotificationActionBlock)actionCallback;
 + (id)initWithLaunchOptions:(NSDictionary*)launchOptions appId:(NSString*)appId handleNotificationAction:(OSHandleNotificationActionBlock)actionCallback settings:(NSDictionary*)settings;
-+ (id)initWithLaunchOptions:(NSDictionary*)launchOptions appId:(NSString*)appId handleNotificationReceived:(OSHandleNotificationReceivedBlock)receivedCallback handleNotificationAction:(OSHandleNotificationActionBlock)actionCallback settings:(NSDictionary*)settings;
++ (id)initWithLaunchOptions:(NSDictionary*)launchOptions appId:(NSString*)appId handleNotificationReceived:(OSHandleNotificationReceivedBlock)erceivedCallback handleNotificationAction:(OSHandleNotificationActionBlock)actionCallback settings:(NSDictionary*)settings;
 
 + (NSString*)app_id;
-
+    
 // Only use if you passed FALSE to autoRegister
 + (void)registerForPushNotifications;
 
@@ -276,10 +279,10 @@ typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
 // Optional method that sends us the user's email as an anonymized hash so that we can better target and personalize notifications sent to that user across their devices.
 + (void)syncHashedEmail:(NSString*)email;
 
-// - iOS 10 BETA features currently only available on XCode 8 & iOS 10.0+
+// - iOS 10 features currently only available on XCode 8 & iOS 10.0+
 #if XC8_AVAILABLE
-+ (void)setNotificationCenterDelegate:(id<OSUserNotificationCenterDelegate>)delegate;
-+ (id<OSUserNotificationCenterDelegate>)notificationCenterDelegate;
++ (void)setNotificationCenterDelegate:(id<OSUserNotificationCenterDelegate>)delegate __deprecated_msg("Can use your own delegate as normal.");
++ (id<OSUserNotificationCenterDelegate>)notificationCenterDelegate __deprecated_msg("Can use your own delegate as normal.");
 #endif
 
 @end

--- a/src/ios/OneSignal.m
+++ b/src/ios/OneSignal.m
@@ -37,6 +37,8 @@
 #import "OneSignalHelper.h"
 #import "NSObject+Extras.h"
 #import "NSString+Hash.h"
+#import "UNUserNotificationCenter+OneSignal.h"
+#import "OneSignalSelectorHelpers.h"
 
 #import <stdlib.h>
 #import <stdio.h>
@@ -74,8 +76,8 @@ NSString * const kOSSettingsKeyInAppLaunchURL = @"kOSSettingsKeyInAppLaunchURL";
 NSString * const kOSSettingsKeyInFocusDisplayOption = @"kOSSettingsKeyInFocusDisplayOption";
 
 @implementation OneSignal
-    
-NSString* const ONESIGNAL_VERSION = @"020116";
+
+NSString* const ONESIGNAL_VERSION = @"020201";
 static NSString* mSDKType = @"native";
 static BOOL coldStartFromTapOnNotification = NO;
 static BOOL registeredWithApple = NO; //Has attempted to register for push notifications with Apple.
@@ -228,12 +230,11 @@ BOOL mSubscriptionSet;
     if ([OneSignalTrackIAP canTrack])
         trackIAPPurchase = [[OneSignalTrackIAP alloc] init];
     
+    #if XC8_AVAILABLE
     if (NSClassFromString(@"UNUserNotificationCenter")) {
-        #if XC8_AVAILABLE
-        [OneSignalHelper registerAsUNNotificationCenterDelegate];
-        [OneSignalHelper clearCachedMedia];
-        #endif
+       [OneSignalHelper clearCachedMedia];
     }
+    #endif
     
     return self;
 }
@@ -662,9 +663,9 @@ bool nextRegistrationIsHighPriority = NO;
     if (ASIdentifierManagerClass) {
         id asIdManager = [ASIdentifierManagerClass valueForKey:@"sharedManager"];
         if ([[asIdManager valueForKey:@"advertisingTrackingEnabled"] isEqual:[NSNumber numberWithInt:1]])
-            dataDic[@"as_id"] = [[asIdManager valueForKey:@"advertisingIdentifier"] UUIDString];
+        dataDic[@"as_id"] = [[asIdManager valueForKey:@"advertisingIdentifier"] UUIDString];
         else
-            dataDic[@"as_id"] = @"OptedOut";
+        dataDic[@"as_id"] = @"OptedOut";
     }
     
     UIApplicationReleaseMode releaseMode = [OneSignalMobileProvision releaseMode];
@@ -781,6 +782,8 @@ bool nextRegistrationIsHighPriority = NO;
 }
     
 + (void)notificationOpened:(NSDictionary*)messageDict isActive:(BOOL)isActive {
+    // Should be called first, other methods relay on this global state below.
+    [OneSignalHelper lastMessageReceived:messageDict];
     
     NSDictionary* customDict = [messageDict objectForKey:@"os_data"];
     if (!customDict)
@@ -788,8 +791,7 @@ bool nextRegistrationIsHighPriority = NO;
     
     BOOL inAppAlert = false;
     if (isActive) {
-        
-        if(![[NSUserDefaults standardUserDefaults] objectForKey:@"ONESIGNAL_ALERT_OPTION"]) {
+        if (![[NSUserDefaults standardUserDefaults] objectForKey:@"ONESIGNAL_ALERT_OPTION"]) {
             [[NSUserDefaults standardUserDefaults] setObject:@(OSNotificationDisplayTypeInAppAlert) forKey:@"ONESIGNAL_ALERT_OPTION"];
             [[NSUserDefaults standardUserDefaults] synchronize];
         }
@@ -797,20 +799,18 @@ bool nextRegistrationIsHighPriority = NO;
         int iaaoption = [[[NSUserDefaults standardUserDefaults] objectForKey:@"ONESIGNAL_ALERT_OPTION"] intValue];
         inAppAlert = iaaoption == OSNotificationDisplayTypeInAppAlert;
         
-        [OneSignalHelper lastMessageReceived:messageDict];
-        
         //Make sure it is not a silent one do display, if inAppAlerts are enabled
         if (inAppAlert && ![OneSignalHelper isRemoteSilentNotification:messageDict]) {
             
-            NSArray<NSString*>* titleAndBody = [OneSignalHelper getPushTitleBody:messageDict];
+            NSDictionary* titleAndBody = [OneSignalHelper getPushTitleBody:messageDict];
             id oneSignalAlertViewDelegate = [[OneSignalAlertViewDelegate alloc] initWithMessageDict:messageDict];
             
-            UIAlertView* alertView = [[UIAlertView alloc] initWithTitle:titleAndBody[0] ? titleAndBody[0] : @""
-                                                                message:titleAndBody[1] ? titleAndBody[1] : @""
+            UIAlertView* alertView = [[UIAlertView alloc] initWithTitle:titleAndBody[@"title"]
+                                                                message:titleAndBody[@"body"]
                                                                delegate:oneSignalAlertViewDelegate
                                                       cancelButtonTitle:@"Close"
                                                       otherButtonTitles:nil, nil];
-            //Add Buttons
+            // Add Buttons
             NSArray *additionalData = [OneSignalHelper getActionButtons];
             if (additionalData) {
                 for(id button in additionalData)
@@ -819,8 +819,8 @@ bool nextRegistrationIsHighPriority = NO;
             
             [alertView show];
             
-            //Message received that was displayed (Foreground + InAppAlert is true)
-            //Call Received Block
+            // Message received that was displayed (Foreground + InAppAlert is true)
+            // Call Received Block
             [OneSignalHelper handleNotificationReceived:OSNotificationDisplayTypeInAppAlert];
             
             return;
@@ -843,12 +843,12 @@ bool nextRegistrationIsHighPriority = NO;
             actionSelected = messageDict[@"custom"][@"a"][@"actionSelected"];
             type = OSNotificationActionTypeActionTaken;
         }
-        if(messageDict[@"actionSelected"]) {
+        if (messageDict[@"actionSelected"]) {
             actionSelected = messageDict[@"actionSelected"];
             type = OSNotificationActionTypeActionTaken;
         }
         
-        //Call Action Block
+        // Call Action Block
         [OneSignalHelper handleNotificationAction:type actionID:actionSelected displayType:OSNotificationDisplayTypeNotification];
         [OneSignal handleNotificationOpened:messageDict isActive:isActive actionType:type displayType:OSNotificationDisplayTypeNotification];
     }
@@ -950,9 +950,9 @@ bool nextRegistrationIsHighPriority = NO;
     
     if (mDeviceToken) {
         if ([OneSignalHelper isCapableOfGettingNotificationTypes])
-            return [[UIApplication sharedApplication] currentUserNotificationSettings].types;
+        return [[UIApplication sharedApplication] currentUserNotificationSettings].types;
         else
-            return NOTIFICATION_TYPE_ALL;
+        return NOTIFICATION_TYPE_ALL;
     }
     
     return -1;
@@ -1093,11 +1093,10 @@ bool nextRegistrationIsHighPriority = NO;
 }
 
 #if XC8_AVAILABLE
-
 static id<OSUserNotificationCenterDelegate> notificationCenterDelegate;
 
 + (void) setNotificationCenterDelegate:(id<OSUserNotificationCenterDelegate>)delegate {
-    if(!NSClassFromString(@"UNNotification")) {
+    if (!NSClassFromString(@"UNNotification")) {
         onesignal_Log(ONE_S_LL_ERROR, @"Cannot assign delegate. Please make sure you are running on iOS 10+.");
         return;
     }
@@ -1108,119 +1107,6 @@ static id<OSUserNotificationCenterDelegate> notificationCenterDelegate;
     return notificationCenterDelegate;
 }
 
-
-- (void)userNotificationCenter:(id)center didReceiveNotificationResponse:(id)response withCompletionHandler:(void(^)())completionHandler {
-    
-    NSDictionary* usrInfo = [[[[response performSelector:@selector(notification)] valueForKey:@"request"] valueForKey:@"content"] valueForKey:@"userInfo"];
-    if (!usrInfo || [usrInfo count] == 0) {
-        [OneSignal tunnelToDelegate:center :response :completionHandler];
-        return;
-    }
-    
-    NSMutableDictionary *userInfo = [[NSMutableDictionary alloc] init],
-    *customDict = [[NSMutableDictionary alloc] init],
-    *additionalData = [[NSMutableDictionary alloc] init];
-    NSMutableArray *optionsDict = [[NSMutableArray alloc] init];
-    
-    NSMutableDictionary* buttonsDict = usrInfo[@"os_data"][@"buttons"];
-    NSMutableDictionary* custom = usrInfo[@"custom"];
-    if (buttonsDict) {
-        [userInfo addEntriesFromDictionary:usrInfo];
-        NSArray* o = buttonsDict[@"o"];
-        if (o)
-            [optionsDict addObjectsFromArray:o];
-    }
-    
-    else if (custom) {
-        [userInfo addEntriesFromDictionary:usrInfo];
-        [customDict addEntriesFromDictionary:custom];
-        NSDictionary *a = customDict[@"a"];
-        NSArray *o = userInfo[@"o"];
-        if (a)
-            [additionalData addEntriesFromDictionary:a];
-        if (o)
-            [optionsDict addObjectsFromArray:o];
-    }
-    
-    else {
-        BOOL isActive = [UIApplication sharedApplication].applicationState == UIApplicationStateActive &&
-        [[[NSUserDefaults standardUserDefaults] objectForKey:@"ONESIGNAL_ALERT_OPTION"] intValue] != OSNotificationDisplayTypeNotification;
-        [OneSignal notificationOpened:usrInfo isActive:isActive];
-        [OneSignal tunnelToDelegate:center :response :completionHandler];
-        return;
-    }
-    
-    NSMutableArray* buttonArray = [[NSMutableArray alloc] init];
-    for (NSDictionary* button in optionsDict) {
-        NSString * text = button[@"n"] != nil ? button[@"n"] : @"";
-        NSString * buttonID = button[@"i"] != nil ? button[@"i"] : text;
-        NSDictionary * buttonToAppend = [[NSDictionary alloc] initWithObjects:@[text, buttonID] forKeys:@[@"text", @"id"]];
-        [buttonArray addObject:buttonToAppend];
-    }
-    
-    additionalData[@"actionSelected"] = [response valueForKey:@"actionIdentifier"];
-    additionalData[@"actionButtons"] = buttonArray;
-    
-    NSDictionary* os_data = usrInfo[@"os_data"];
-    if (os_data) {
-        [userInfo addEntriesFromDictionary:os_data];
-        if(userInfo[@"os_data"][@"buttons"][@"m"])
-            userInfo[@"aps"] = @{@"alert" : userInfo[@"os_data"][@"buttons"][@"m"]};
-        [userInfo addEntriesFromDictionary:additionalData];
-    }
-    else {
-        customDict[@"a"] = additionalData;
-        userInfo[@"custom"] = customDict;
-        if(userInfo[@"m"])
-            userInfo[@"aps"] = @{ @"alert" : userInfo[@"m"] };
-    }
-
-    BOOL isActive = [UIApplication sharedApplication].applicationState == UIApplicationStateActive &&
-    [[[NSUserDefaults standardUserDefaults] objectForKey:@"ONESIGNAL_ALERT_OPTION"] intValue] != OSNotificationDisplayTypeNotification;
-
-    
-    [OneSignal notificationOpened:userInfo isActive:isActive];
-    [OneSignal tunnelToDelegate:center :response :completionHandler];
-    
-}
-
-+ (void)tunnelToDelegate:(id)center :(id)response :(void (^)())handler {
-
-    if ([[OneSignal notificationCenterDelegate] respondsToSelector:@selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:)])
-        [[OneSignal notificationCenterDelegate] userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:handler];
-    else
-        handler();
-}
-
--(void)userNotificationCenter:(id)center willPresentNotification:(id)notification withCompletionHandler:(void (^)(NSUInteger options))completionHandler {
-    
-    // Proxy to user if listening to delegate and overrides the method.
-    if ([[OneSignal notificationCenterDelegate] respondsToSelector:@selector(userNotificationCenter:willPresentNotification:withCompletionHandler:)])
-        [[OneSignal notificationCenterDelegate] userNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
-    else {
-        //Set the completionHandler options based on the ONESIGNAL_ALERT_OPTION value.
-        NSUInteger completionHandlerOptions = 0;
-        if(![[NSUserDefaults standardUserDefaults] objectForKey:@"ONESIGNAL_ALERT_OPTION"]) {
-            [[NSUserDefaults standardUserDefaults] setObject:@(OSNotificationDisplayTypeInAppAlert) forKey:@"ONESIGNAL_ALERT_OPTION"];
-            [[NSUserDefaults standardUserDefaults] synchronize];
-        }
-        
-        NSInteger alert_option = ((NSNumber*)[[NSUserDefaults standardUserDefaults] objectForKey:@"ONESIGNAL_ALERT_OPTION"]).integerValue;
-        switch (alert_option) {
-            case OSNotificationDisplayTypeNone: completionHandlerOptions = 0; break;
-            case OSNotificationDisplayTypeInAppAlert: completionHandlerOptions = 1; break;
-            case OSNotificationDisplayTypeNotification: completionHandlerOptions = 7; break;
-            default: break;
-        }
-        
-        completionHandler(completionHandlerOptions);
-     
-        //Call notificationOpened if no alert (MSB not set)
-        NSDictionary* usrInfo = [[[notification valueForKey:@"request"] valueForKey:@"content"] valueForKey:@"userInfo"];
-        [OneSignal notificationOpened:usrInfo isActive:YES];
-        
-    }
-}
 #endif
 
 + (void)syncHashedEmail:(NSString *)email {
@@ -1254,80 +1140,8 @@ static id<OSUserNotificationCenterDelegate> notificationCenterDelegate;
 
 @end
 
-static BOOL checkIfInstanceOverridesSelector(Class instance, SEL selector) {
-    Class instSuperClass = [instance superclass];
-    return [instance instanceMethodForSelector: selector] != [instSuperClass instanceMethodForSelector: selector];
-}
 
 
-static Class getClassWithProtocolInHierarchy(Class searchClass, Protocol* protocolToFind) {
-    if (!class_conformsToProtocol(searchClass, protocolToFind)) {
-        if ([searchClass superclass] == nil)
-            return nil;
-        Class foundClass = getClassWithProtocolInHierarchy([searchClass superclass], protocolToFind);
-        if (foundClass)
-            return foundClass;
-        return searchClass;
-    }
-    return searchClass;
-}
-
-static void injectSelector(Class newClass, SEL newSel, Class addToClass, SEL makeLikeSel) {
-    Method newMeth = class_getInstanceMethod(newClass, newSel);
-    IMP imp = method_getImplementation(newMeth);
-    const char* methodTypeEncoding = method_getTypeEncoding(newMeth);
-    BOOL successful = class_addMethod(addToClass, makeLikeSel, imp, methodTypeEncoding);
-    
-    if (!successful) {
-        class_addMethod(addToClass, newSel, imp, methodTypeEncoding);
-        newMeth = class_getInstanceMethod(addToClass, newSel);
-        Method orgMeth = class_getInstanceMethod(addToClass, makeLikeSel);
-        method_exchangeImplementations(orgMeth, newMeth);
-    }
-}
-
-//Try to find out which class to inject to
-static void injectToProperClass(SEL newSel, SEL makeLikeSel, NSArray* delegateSubclasses, Class myClass, Class delegateClass) {
-    
-    // Find out if we should inject in delegateClass or one of its subclasses.
-    //CANNOT use the respondsToSelector method as it returns TRUE to both implementing and inheriting a method
-    //We need to make sure the class actually implements the method (overrides) and not inherits it to properly perform the call
-    //Start with subclasses then the delegateClass
-    
-    for(Class subclass in delegateSubclasses)
-        if(checkIfInstanceOverridesSelector(subclass, makeLikeSel)) {
-            injectSelector(myClass, newSel, subclass, makeLikeSel);
-            return;
-        }
-    
-    //No subclass overrides the method, try to inject in delegate class
-    injectSelector(myClass, newSel, delegateClass, makeLikeSel);
-    
-}
-
-static NSArray* ClassGetSubclasses(Class parentClass) {
-    
-    int numClasses = objc_getClassList(NULL, 0);
-    Class *classes = NULL;
-    
-    classes = (Class *)malloc(sizeof(Class) * numClasses);
-    numClasses = objc_getClassList(classes, numClasses);
-    
-    NSMutableArray *result = [NSMutableArray array];
-    for (NSInteger i = 0; i < numClasses; i++) {
-        Class superClass = classes[i];
-        do {
-            superClass = class_getSuperclass(superClass);
-        } while(superClass && superClass != parentClass);
-        
-        if (superClass == nil) continue;
-        [result addObject:classes[i]];
-    }
-    
-    free(classes);
-    
-    return result;
-}
 
 @interface OneSignalTracker ()
 + (void)onFocus:(BOOL)toBackground;
@@ -1337,7 +1151,7 @@ static NSArray* ClassGetSubclasses(Class parentClass) {
 static Class delegateClass = nil;
 
 // Store an array of all UIAppDelegate subclasses to iterate over in cases where UIAppDelegate swizzled methods are not overriden in main AppDelegate
-//But rather in one of the subclasses
+// But rather in one of the subclasses
 static NSArray* delegateSubclasses = nil;
 
 +(Class)delegateClass {
@@ -1355,7 +1169,7 @@ static NSArray* delegateSubclasses = nil;
 
 - (void)oneSignalDidFailRegisterForRemoteNotification:(UIApplication*)app error:(NSError*)err {
     
-    if(err.code == 3000 && [(NSString*)[err.userInfo objectForKey:NSLocalizedDescriptionKey] containsString:@"no valid 'aps-environment'"]) {
+    if(err.code == 3000 && [((NSString*)[err.userInfo objectForKey:NSLocalizedDescriptionKey]) rangeOfString:@"no valid 'aps-environment'"].location != NSNotFound) {
         //User did not enable push notification capability
         [OneSignal setErrorNotificationType];
         [OneSignal onesignal_Log:ONE_S_LL_ERROR message:@"'Push Notification' capability not turned on. Make sure it is enabled by going to your Project Target -> Capability."];
@@ -1391,14 +1205,13 @@ static NSArray* delegateSubclasses = nil;
 // User Tap on Notification while app was in background - OR - Notification received (silent or not, foreground or background) on iOS 7+
 - (void) oneSignalRemoteSilentNotification:(UIApplication*)application UserInfo:(NSDictionary*)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult)) completionHandler {
     
-    if([OneSignal app_id]) {
-        
-        //Call notificationAction if app is active -> not a silent notification but rather user tap on notification
-        //Unless iOS 10+ then call remoteSilentNotification instead.
-        if([UIApplication sharedApplication].applicationState == UIApplicationStateActive && userInfo[@"aps"][@"alert"])
+    if ([OneSignal app_id]) {
+        // Call notificationAction if app is active -> not a silent notification but rather user tap on notification
+        // Unless iOS 10+ then call remoteSilentNotification instead.
+        if ([UIApplication sharedApplication].applicationState == UIApplicationStateActive && userInfo[@"aps"][@"alert"])
             [OneSignal notificationOpened:userInfo isActive:YES];
-        else [OneSignal remoteSilentNotification:application UserInfo:userInfo];
-        
+        else
+            [OneSignal remoteSilentNotification:application UserInfo:userInfo];
     }
     
     if ([self respondsToSelector:@selector(oneSignalRemoteSilentNotification:UserInfo:fetchCompletionHandler:)]) {
@@ -1406,7 +1219,7 @@ static NSArray* delegateSubclasses = nil;
         return;
     }
     
-    //Make sure not a cold start from tap on notification (OS doesn't call didReceiveRemoteNotification)
+    // Make sure not a cold start from tap on notification (OS doesn't call didReceiveRemoteNotification)
     if ([self respondsToSelector:@selector(oneSignalReceivedRemoteNotification:userInfo:)] && ![[OneSignal valueForKey:@"coldStartFromTapOnNotification"] boolValue])
         [self oneSignalReceivedRemoteNotification:application userInfo:userInfo];
     
@@ -1477,10 +1290,23 @@ static NSArray* delegateSubclasses = nil;
     if (SYSTEM_VERSION_LESS_THAN_OR_EQUAL_TO(@"7.0"))
         return;
     
-    NSLog(@"Loaded");
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"UIApplication(Swizzling) Loaded!"];
     
-    //Swizzle App delegate
+    // Swizzle UIApplication delegate
     method_exchangeImplementations(class_getInstanceMethod(self, @selector(setDelegate:)), class_getInstanceMethod(self, @selector(setOneSignalDelegate:)));
+    
+    
+    #if XC8_AVAILABLE
+    // Swizzle UNUserNotificationCenter delegate
+    Class UNUserNotificationCenterClass = NSClassFromString(@"UNUserNotificationCenter");
+    if (!UNUserNotificationCenterClass)
+        return;
+    
+    injectToProperClass(@selector(setOneSignalUNDelegate:),
+                        @selector(setDelegate:), @[], [sizzleUNUserNotif class], UNUserNotificationCenterClass);
+    
+    [OneSignalHelper registerAsUNNotificationCenterDelegate];
+    #endif
 }
 
 - (void) setOneSignalDelegate:(id<UIApplicationDelegate>)delegate {
@@ -1526,14 +1352,6 @@ static NSArray* delegateSubclasses = nil;
     //Used to track how long the app has been closed
     injectToProperClass(@selector(oneSignalApplicationWillTerminate:), @selector(applicationWillTerminate:), delegateSubclasses, self.class, delegateClass);
     
-    
-    /* iOS 10.0: UNUserNotificationCenterDelegate instead of UIApplicationDelegate for methods handling opening app from notification
-     Make sure AppDelegate does not conform to this protocol */
-#if XC8_AVAILABLE
-    if([OneSignalHelper isiOS10Plus])
-        [OneSignalHelper conformsToUNProtocol];
-#endif
-    
     [self setOneSignalDelegate:delegate];
 }
 
@@ -1554,6 +1372,7 @@ static NSArray* delegateSubclasses = nil;
 }
 
 @end
+
 
 #pragma clang diagnostic pop
 #pragma clang diagnostic pop

--- a/src/ios/OneSignalHelper.h
+++ b/src/ios/OneSignalHelper.h
@@ -38,7 +38,7 @@
 + (void) displayWebView:(NSURL*)url;
 
 // - Notification Opened
-+ (NSArray<NSString*>*)getPushTitleBody:(NSDictionary*)messageDict;
++ (NSDictionary*)getPushTitleBody:(NSDictionary*)messageDict;
 + (NSArray*)getActionButtons;
 + (void)lastMessageReceived:(NSDictionary*)message;
 + (void)notificationBlocks:(OSHandleNotificationReceivedBlock)receivedBlock :(OSHandleNotificationActionBlock)actionBlock;
@@ -50,7 +50,6 @@
 #if XC8_AVAILABLE
 + (void)registerAsUNNotificationCenterDelegate;
 + (void) requestAuthorization;
-+ (void)conformsToUNProtocol;
 + (void)clearCachedMedia;
 + (id)prepareUNNotificationRequest:(NSDictionary *)data :(NSDictionary *)userInfo;
 #endif

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  * 
- * Copyright 2015 OneSignal
+ * Copyright 2016 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -232,7 +232,7 @@ static Class delegateClass = nil;
 
 - (void)setLogLevel:(CDVInvokedUrlCommand*)command {
     NSDictionary* options = command.arguments[0];
-    [OneSignal setLogLevel:(NSInteger)options[@"logLevel"] visualLevel:(NSInteger)options[@"visualLevel"]];
+    [OneSignal setLogLevel:[options[@"logLevel"] intValue] visualLevel:[options[@"visualLevel"] intValue]];
 }
 
 // Android only

--- a/src/ios/OneSignalSelectorHelpers.h
+++ b/src/ios/OneSignalSelectorHelpers.h
@@ -1,6 +1,6 @@
 /**
  * Modified MIT License
- * 
+ *
  * Copyright 2016 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -9,13 +9,13 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * 1. The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * 2. All copies of substantial portions of the Software may only be used in connection
  * with services provided by OneSignal.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,28 +25,12 @@
  * THE SOFTWARE.
  */
 
-#import <Foundation/Foundation.h>
-#import <Cordova/CDV.h>
-#import <Cordova/CDVPlugin.h>
+#ifndef OneSignalSelectorHelpers_h
+#define OneSignalSelectorHelpers_h
 
-@interface OneSignalPush : CDVPlugin {}
+BOOL checkIfInstanceOverridesSelector(Class instance, SEL selector);
+Class getClassWithProtocolInHierarchy(Class searchClass, Protocol* protocolToFind);
+NSArray* ClassGetSubclasses(Class parentClass);
+void injectToProperClass(SEL newSel, SEL makeLikeSel, NSArray* delegateSubclasses, Class myClass, Class delegateClass);
 
-- (void)setNotificationReceivedHandler:(CDVInvokedUrlCommand*)command;
-- (void)setNotificationOpenedHandler:(CDVInvokedUrlCommand*)command;
-- (void)init:(CDVInvokedUrlCommand*)command;
-- (void)getTags:(CDVInvokedUrlCommand*)command;
-- (void)getIds:(CDVInvokedUrlCommand*)command;
-- (void)sendTags:(CDVInvokedUrlCommand*)command;
-- (void)deleteTags:(CDVInvokedUrlCommand*)command;
-- (void)registerForPushNotifications:(CDVInvokedUrlCommand*)command;
-- (void)setSubscription:(CDVInvokedUrlCommand*)command;
-- (void)postNotification:(CDVInvokedUrlCommand*)command;
-- (void)setLogLevel:(CDVInvokedUrlCommand*)command;
-- (void)promptLocation:(CDVInvokedUrlCommand*)command;
-- (void)syncHashedEmail:(CDVInvokedUrlCommand*)command;
-
-// Android Only
-- (void)enableVibrate:(CDVInvokedUrlCommand*)command;
-- (void)enableSound:(CDVInvokedUrlCommand*)command;
-
-@end
+#endif /* OneSignalSelectorHelpers_h */

--- a/src/ios/OneSignalSelectorHelpers.m
+++ b/src/ios/OneSignalSelectorHelpers.m
@@ -1,0 +1,107 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2016 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+
+#import "OneSignalSelectorHelpers.h"
+
+BOOL checkIfInstanceOverridesSelector(Class instance, SEL selector) {
+    Class instSuperClass = [instance superclass];
+    return [instance instanceMethodForSelector: selector] != [instSuperClass instanceMethodForSelector: selector];
+}
+
+
+Class getClassWithProtocolInHierarchy(Class searchClass, Protocol* protocolToFind) {
+    if (!class_conformsToProtocol(searchClass, protocolToFind)) {
+        if ([searchClass superclass] == nil)
+            return nil;
+        Class foundClass = getClassWithProtocolInHierarchy([searchClass superclass], protocolToFind);
+        if (foundClass)
+            return foundClass;
+        return searchClass;
+    }
+    return searchClass;
+}
+
+void injectSelector(Class newClass, SEL newSel, Class addToClass, SEL makeLikeSel) {
+    Method newMeth = class_getInstanceMethod(newClass, newSel);
+    IMP imp = method_getImplementation(newMeth);
+    const char* methodTypeEncoding = method_getTypeEncoding(newMeth);
+    BOOL successful = class_addMethod(addToClass, makeLikeSel, imp, methodTypeEncoding);
+    
+    if (!successful) {
+        class_addMethod(addToClass, newSel, imp, methodTypeEncoding);
+        newMeth = class_getInstanceMethod(addToClass, newSel);
+        Method orgMeth = class_getInstanceMethod(addToClass, makeLikeSel);
+        method_exchangeImplementations(orgMeth, newMeth);
+    }
+}
+
+// Try to find out which class to inject to
+void injectToProperClass(SEL newSel, SEL makeLikeSel, NSArray* delegateSubclasses, Class myClass, Class delegateClass) {
+    
+    // Find out if we should inject in delegateClass or one of its subclasses.
+    // CANNOT use the respondsToSelector method as it returns TRUE to both implementing and inheriting a method
+    // We need to make sure the class actually implements the method (overrides) and not inherits it to properly perform the call
+    // Start with subclasses then the delegateClass
+    
+    for(Class subclass in delegateSubclasses) {
+        if (checkIfInstanceOverridesSelector(subclass, makeLikeSel)) {
+            injectSelector(myClass, newSel, subclass, makeLikeSel);
+            return;
+        }
+    }
+    
+    // No subclass overrides the method, try to inject in delegate class
+    injectSelector(myClass, newSel, delegateClass, makeLikeSel);
+    
+}
+
+NSArray* ClassGetSubclasses(Class parentClass) {
+    
+    int numClasses = objc_getClassList(NULL, 0);
+    Class *classes = NULL;
+    
+    classes = (Class *)malloc(sizeof(Class) * numClasses);
+    numClasses = objc_getClassList(classes, numClasses);
+    
+    NSMutableArray *result = [NSMutableArray array];
+    for (NSInteger i = 0; i < numClasses; i++) {
+        Class superClass = classes[i];
+        do {
+            superClass = class_getSuperclass(superClass);
+        } while(superClass && superClass != parentClass);
+        
+        if (superClass == nil) continue;
+        [result addObject:classes[i]];
+    }
+    
+    free(classes);
+    
+    return result;
+}

--- a/src/ios/UNUserNotificationCenter+OneSignal.h
+++ b/src/ios/UNUserNotificationCenter+OneSignal.h
@@ -1,6 +1,6 @@
 /**
  * Modified MIT License
- * 
+ *
  * Copyright 2016 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -9,13 +9,13 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * 1. The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * 2. All copies of substantial portions of the Software may only be used in connection
  * with services provided by OneSignal.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,28 +25,15 @@
  * THE SOFTWARE.
  */
 
-#import <Foundation/Foundation.h>
-#import <Cordova/CDV.h>
-#import <Cordova/CDVPlugin.h>
+#ifndef UNUserNotificationCenter_OneSignal_h
+#define UNUserNotificationCenter_OneSignal_h
 
-@interface OneSignalPush : CDVPlugin {}
+#import "OneSignal.h"
 
-- (void)setNotificationReceivedHandler:(CDVInvokedUrlCommand*)command;
-- (void)setNotificationOpenedHandler:(CDVInvokedUrlCommand*)command;
-- (void)init:(CDVInvokedUrlCommand*)command;
-- (void)getTags:(CDVInvokedUrlCommand*)command;
-- (void)getIds:(CDVInvokedUrlCommand*)command;
-- (void)sendTags:(CDVInvokedUrlCommand*)command;
-- (void)deleteTags:(CDVInvokedUrlCommand*)command;
-- (void)registerForPushNotifications:(CDVInvokedUrlCommand*)command;
-- (void)setSubscription:(CDVInvokedUrlCommand*)command;
-- (void)postNotification:(CDVInvokedUrlCommand*)command;
-- (void)setLogLevel:(CDVInvokedUrlCommand*)command;
-- (void)promptLocation:(CDVInvokedUrlCommand*)command;
-- (void)syncHashedEmail:(CDVInvokedUrlCommand*)command;
-
-// Android Only
-- (void)enableVibrate:(CDVInvokedUrlCommand*)command;
-- (void)enableSound:(CDVInvokedUrlCommand*)command;
-
+#if XC8_AVAILABLE
+@interface sizzleUNUserNotif : NSObject
 @end
+#endif
+
+
+#endif /* UNUserNotificationCenter_OneSignal_h */

--- a/src/ios/UNUserNotificationCenter+OneSignal.m
+++ b/src/ios/UNUserNotificationCenter+OneSignal.m
@@ -1,0 +1,226 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2016 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+#import "UNUserNotificationCenter+OneSignal.h"
+#import "OneSignal.h"
+#import "OneSignalSelectorHelpers.h"
+
+
+#if XC8_AVAILABLE
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+@interface OneSignal (UN_extra)
++ (void)notificationOpened:(NSDictionary*)messageDict isActive:(BOOL)isActive;
+@end
+
+// This class hooks into the following iSO 10 UNUserNotificationCenterDelegate selectors:
+// - userNotificationCenter:willPresentNotification:withCompletionHandler:
+//   - Reads kOSSettingsKeyInFocusDisplayOption to respect it's setting.
+// - userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:
+//   - Used to process opening a notifications.
+//   - The presents of this selector tells iOS to no longer fire `application:didReceiveRemoteNotification:fetchCompletionHandler:`.
+//       We call this to maintain existing behavior.
+
+@implementation sizzleUNUserNotif
+
+static Class delegateUNClass = nil;
+
+// Store an array of all UIAppDelegate subclasses to iterate over in cases where UIAppDelegate swizzled methods are not overriden in main AppDelegate
+// But rather in one of the subclasses
+static NSArray* delegateUNSubclasses = nil;
+
+// Take the received delegate and swizzle in our own hooks.
+//  - Selector will be called once if developer does not set a UNUserNotificationCenter delegate.
+//  - Selector will be called a 2nd time if the developer does set one.
+- (void) setOneSignalUNDelegate:(id)delegate {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"sizzleUNUserNotif setOneSignalUNDelegate Fired!"];
+    
+    delegateUNClass = getClassWithProtocolInHierarchy([delegate class], @protocol(UNUserNotificationCenterDelegate));
+    delegateUNSubclasses = ClassGetSubclasses(delegateUNClass);
+    
+    injectToProperClass(@selector(onesignalUserNotificationCenter:willPresentNotification:withCompletionHandler:),
+                        @selector(userNotificationCenter:willPresentNotification:withCompletionHandler:), delegateUNSubclasses, [sizzleUNUserNotif class], delegateUNClass);
+    
+    injectToProperClass(@selector(onesignalUserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:),
+                        @selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:), delegateUNSubclasses, [sizzleUNUserNotif class], delegateUNClass);
+    
+    [self setOneSignalUNDelegate:delegate];
+}
+
+// Apples docs - Called when a notification is delivered to a foreground app.
+- (void)onesignalUserNotificationCenter:(UNUserNotificationCenter *)center
+                willPresentNotification:(UNNotification *)notification
+                  withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"onesignalUserNotificationCenter:willPresentNotification:withCompletionHandler: Fired!"];
+    
+    // Depercated - [OneSignal notificationCenterDelegate] - Now handled by swizzling.
+    //    Proxy to user if listening to delegate and overrides the method.
+    if ([[OneSignal notificationCenterDelegate] respondsToSelector:@selector(userNotificationCenter:willPresentNotification:withCompletionHandler:)]) {
+        [[OneSignal notificationCenterDelegate] userNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
+        return;
+    }
+    
+    // Set the completionHandler options based on the ONESIGNAL_ALERT_OPTION value.
+    if (![[NSUserDefaults standardUserDefaults] objectForKey:@"ONESIGNAL_ALERT_OPTION"]) {
+        [[NSUserDefaults standardUserDefaults] setObject:@(OSNotificationDisplayTypeInAppAlert) forKey:@"ONESIGNAL_ALERT_OPTION"];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+    }
+    
+    NSUInteger completionHandlerOptions = 0;
+    NSInteger alert_option = [[NSUserDefaults standardUserDefaults] integerForKey:@"ONESIGNAL_ALERT_OPTION"];
+    switch (alert_option) {
+        case OSNotificationDisplayTypeNone: completionHandlerOptions = 0; break; // Nothing
+        case OSNotificationDisplayTypeInAppAlert: completionHandlerOptions = 3; break; // Badge + Sound
+        case OSNotificationDisplayTypeNotification: completionHandlerOptions = 7; break; // Badge + Sound + Notification
+        default: break;
+    }
+    
+    // Call notificationOpened if no alert (MSB not set)
+    [OneSignal notificationOpened:notification.request.content.userInfo isActive:YES];
+    
+    if ([self respondsToSelector:@selector(onesignalUserNotificationCenter:willPresentNotification:withCompletionHandler:)])
+        [self onesignalUserNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
+    
+    // Calling completionHandler for the following reasons:
+    //   App dev may have not implented userNotificationCenter:willPresentNotification.
+    //   App dev may have implemented this selector but forgot to call completionHandler().
+    // Note - iOS only uses the first call to completionHandler().
+    completionHandler(completionHandlerOptions);
+}
+
+// Apple's docs - Called to let your app know which action was selected by the user for a given notification.
+- (void)onesignalUserNotificationCenter:(id)center didReceiveNotificationResponse:(id)response withCompletionHandler:(void(^)())completionHandler {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"onesignalUserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler: Fired!"];
+    
+    NSDictionary* usrInfo = [[[[response performSelector:@selector(notification)] valueForKey:@"request"] valueForKey:@"content"] valueForKey:@"userInfo"];
+    if (!usrInfo || [usrInfo count] == 0) {
+        [sizzleUNUserNotif tunnelToDelegate:center response:response handler:completionHandler];
+        return;
+    }
+    
+    NSMutableDictionary *userInfo = [[NSMutableDictionary alloc] init],
+    *customDict = [[NSMutableDictionary alloc] init],
+    *additionalData = [[NSMutableDictionary alloc] init];
+    NSMutableArray *optionsDict = [[NSMutableArray alloc] init];
+    
+    NSMutableDictionary* buttonsDict = usrInfo[@"os_data"][@"buttons"];
+    NSMutableDictionary* custom = usrInfo[@"custom"];
+    if (buttonsDict) {
+        [userInfo addEntriesFromDictionary:usrInfo];
+        NSArray* o = buttonsDict[@"o"];
+        if (o)
+            [optionsDict addObjectsFromArray:o];
+    }
+    else if (custom) {
+        [userInfo addEntriesFromDictionary:usrInfo];
+        [customDict addEntriesFromDictionary:custom];
+        NSDictionary *a = customDict[@"a"];
+        NSArray *o = userInfo[@"o"];
+        if (a)
+            [additionalData addEntriesFromDictionary:a];
+        if (o)
+            [optionsDict addObjectsFromArray:o];
+    }
+    else {
+        BOOL isActive = [UIApplication sharedApplication].applicationState == UIApplicationStateActive &&
+        [[[NSUserDefaults standardUserDefaults] objectForKey:@"ONESIGNAL_ALERT_OPTION"] intValue] != OSNotificationDisplayTypeNotification;
+        [OneSignal notificationOpened:usrInfo isActive:isActive];
+        [sizzleUNUserNotif tunnelToDelegate:center response:response handler:completionHandler];
+        return;
+    }
+    
+    NSMutableArray* buttonArray = [[NSMutableArray alloc] init];
+    for (NSDictionary* button in optionsDict) {
+        NSString * text = button[@"n"] != nil ? button[@"n"] : @"";
+        NSString * buttonID = button[@"i"] != nil ? button[@"i"] : text;
+        NSDictionary * buttonToAppend = [[NSDictionary alloc] initWithObjects:@[text, buttonID] forKeys:@[@"text", @"id"]];
+        [buttonArray addObject:buttonToAppend];
+    }
+    
+    additionalData[@"actionSelected"] = [response valueForKey:@"actionIdentifier"];
+    additionalData[@"actionButtons"] = buttonArray;
+    
+    NSDictionary* os_data = usrInfo[@"os_data"];
+    if (os_data) {
+        [userInfo addEntriesFromDictionary:os_data];
+        if (userInfo[@"os_data"][@"buttons"][@"m"])
+            userInfo[@"aps"] = @{@"alert" : userInfo[@"os_data"][@"buttons"][@"m"]};
+        [userInfo addEntriesFromDictionary:additionalData];
+    }
+    else {
+        customDict[@"a"] = additionalData;
+        userInfo[@"custom"] = customDict;
+        if(userInfo[@"m"])
+            userInfo[@"aps"] = @{ @"alert" : userInfo[@"m"] };
+    }
+    
+    UIApplication *sharedApp = [UIApplication sharedApplication];
+    
+    BOOL isActive = sharedApp.applicationState == UIApplicationStateActive &&
+    [[[NSUserDefaults standardUserDefaults] objectForKey:@"ONESIGNAL_ALERT_OPTION"] intValue] != OSNotificationDisplayTypeNotification;
+    
+    if ([OneSignal app_id])
+       [OneSignal notificationOpened:userInfo isActive:isActive];
+    [sizzleUNUserNotif tunnelToDelegate:center response:response handler:completionHandler];
+    
+    // Call orginal selector if one was set.
+    if ([self respondsToSelector:@selector(onesignalUserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:)])
+        [self onesignalUserNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
+    else if ([sharedApp.delegate respondsToSelector:@selector(application:didReceiveRemoteNotification:fetchCompletionHandler:)]) {
+        // Call depercated pre-iOS 10 selector if one as set on the AppDelegate.
+        //   NOTE: Should always be true as our AppDelegate swizzling should be there unless something else unsizzled it.
+        [sharedApp.delegate application:sharedApp didReceiveRemoteNotification:usrInfo fetchCompletionHandler:^(UIBackgroundFetchResult result) {
+            // Call iOS 10's compleationHandler from iOS 9's completion handler.
+            completionHandler();
+        }];
+    }
+}
+
+// Depercated - [OneSignal notificationCenterDelegate] - Now handled by swizzling.
+//   Just need to keep the `handler();` call
++ (void)tunnelToDelegate:(id)center response:(id)response handler:(void (^)())handler {
+    
+    if ([[OneSignal notificationCenterDelegate] respondsToSelector:@selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:)])
+        [[OneSignal notificationCenterDelegate] userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:handler];
+    else
+        handler();
+}
+
+@end
+
+#pragma clang diagnostic pop
+#pragma clang diagnostic pop
+
+#endif


### PR DESCRIPTION
* iOS fixes
   - Added `isAppInFocus` field to notification callbacks.
   - Fixed rare case where opened callback could fire 2 times.
   - Some compatibility fixes when using other notification SDKs.
   - Fixed cases where body and title were not correctly set on OSNotification.
   - Fixed setLogLevel to correctly use integer value.

* Android updates
   - Google project number is now used from OneSignal instead of through startInit
   - Added priority and collapseId to OSNotificationPayload
     - collapseId (AKA collapse_key) will be used to replace notifications in a future update.

* Android fixes
   - Fixed issue with additionalData being a string
   - Added groupedNotifications field back since 2.0 release.
   - Fixed issue where disabling badges was not being respected in some cases.
   - If send priority was set to high(10), then the notification will be displayed with PRIORITY_MAX
   - Added syncHashedEmail validation.
   - Background images on notifications will now be top left aligned.
      - Background images are now only supported on Android 4.1+.