### PR TITLE
Align gms and support libraries versions

### DIFF
--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -8,3 +8,50 @@ android.defaultConfig {
 repositories {
    maven { url 'https://maven.google.com' }
 }
+
+// ## Align gms and support group versions on all dependencies 
+
+def versionGroupAligns = [
+    // ### Google Play Services library
+    'com.google.android.gms': [
+        'version': '11.2.+'
+    ],
+    
+    // ### Google Firebase library
+    // Although not used by OneSignal Firebase has some dependencies on gms
+    // If present, ensuring they are aligned
+    'com.google.firebase': [
+        'version': '11.2.+'
+    ],
+
+    // ### Android Support Library
+    'com.android.support': [
+        'version': '26.1.+',
+        'requiredCompileSdkVersion': 26,
+        
+        // Can't use 26 of com.android.support when compileSdkVersion 25 is set
+        // The following error will be thrown if there is a mismatch here.
+        // "No resource found that matches the given name: attr 'android:keyboardNavigationCluster'"
+        'versionFallback': '25.+'
+    ]
+]
+
+configurations.all { resolutionStrategy {
+
+    // Enable to find root causes of any remaining version mismatches
+    // failOnVersionConflict()
+
+    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        def curCompileSdkVersion = android.compileSdkVersion.split('-')[1].toInteger()
+        def versionOverride = versionGroupAligns[details.requested.group]
+
+        if (versionOverride) {
+            def requiredCompileSdk = versionOverride['requiredCompileSdkVersion']
+            def useVersion = versionOverride['version']
+
+            if (curCompileSdkVersion < requiredCompileSdk)
+                useVersion = versionOverride['versionFallback']
+            details.useVersion(useVersion)
+        }
+    }
+}}

--- a/plugin.xml
+++ b/plugin.xml
@@ -11,7 +11,7 @@
   <description>OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, A/B test, and automate notifications that you send.</description>
 
   <keywords>push,notification,push notification,push notifications,apns,gcm,adm,retention,messaging,ios,android,windows phone</keywords>
-
+  
   <license>MIT</license>
 
   <js-module src="www/OneSignal.js" name="OneSignal">
@@ -27,14 +27,8 @@
   </engines>
   
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:3.6.1" />
+    <framework src="com.onesignal:OneSignal:3.6.2" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
-    
-    <!-- Overrides com.onesignal:OneSignal dependencies to avoid GMS version conflicts with other plugins as most rely on + as well. -->
-    <framework src="com.google.android.gms:play-services-gcm:+" />
-    <framework src="com.google.android.gms:play-services-location:+" />
-    <framework src="com.android.support:support-v4:+" />
-    <framework src="com.android.support:customtabs:+" />
     
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="OneSignalPush" >


### PR DESCRIPTION
* This fixes capabilities with other Android Cordova plugins that use gms and support libraries through Gradle.
* It aligns all gms and support library groups to match to the versions required by OneSignal.
* Accounts for the compileSdkVersion version as well by using 25 or 26 of the support library where it is compatible.