### PR TITLE
Fixes more multidex resolution issues

### DIFF
--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -9,7 +9,7 @@ repositories {
    maven { url 'https://maven.google.com' }
 }
 
-// ## Align gms and support group versions on all dependencies 
+// ## Align gms and support group versions on all dependencies
 
 def versionGroupAligns = [
     // ### Google Play Services library
@@ -28,7 +28,7 @@ def versionGroupAligns = [
     'com.android.support': [
         'requiredCompileSdkVersion': 26,
         'version': '26.1.+',
-        'omitModules': ['multidex'],
+        'omitModules': ['multidex', 'multidex-instrumentation'],
 
         // Can't use 26 of com.android.support when compileSdkVersion 25 is set
         // The following error will be thrown if there is a mismatch here.

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/onesignal/OneSignal-Cordova-SDK.git"
+    "url": "git+https://github.com/NickMele/OneSignal-Cordova-SDK.git"
   },
   "author": "Josh Kasten",
   "bugs": {


### PR DESCRIPTION
The previous fix for omitting 'multidex' partially worked, but it raised another issue with resolving the support:multidex-instrumentation library. By adding this to the list of omitted modules as well i was able to get the build to work properly.