### PR TITLE
RPD 2909

### DIFF
--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -8,6 +8,10 @@ android.defaultConfig {
 allprojects {
     repositories {
         maven { url 'https://jitpack.io' }
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 }
 dependencies {

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -4,3 +4,12 @@ android.defaultConfig {
    manifestPlaceholders = [onesignal_app_id: "", // Use from code for now.
                           onesignal_google_project_number: "REMOTE"]
 }
+
+allprojects {
+    repositories {
+        maven { url 'https://jitpack.io' }
+    }
+}
+dependencies {
+    compile 'com.github.OutSystems:OneSignal-Android-SDK:3.6.5-OS'
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.12-OS2",
+  "version": "2.0.12-OS3",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.12.OS",
+  "version": "2.0.12-OS2",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.11",
+  "version": "2.0.12.OS",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -14,7 +14,8 @@
 
   <license>MIT</license>
   
-  <dependency id="cordova-android-support-gradle-release" url="https://github.com/dpa99c/cordova-android-support-gradle-release.git#1.1.5"/>
+  <!-- dependency required because some plugins conflict on major versions of libraries -->
+  <dependency id="cordova-android-support-gradle-release" url="https://github.com/OutSystems/cordova-android-support-gradle-release.git#1.1.5"/>
 
   <js-module src="www/OneSignal.js" name="OneSignal">
     <clobbers target="OneSignal" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="2.0.11">
+    version="2.0.11.OS">
 
 
   <name>OneSignal Push Notifications</name>
@@ -61,6 +61,9 @@
     </config-file>
     
     <source-file src="src/android/com/plugin/gcm/OneSignalPush.java" target-dir="src/com/plugin/gcm/" />
+
+    <hook type="before_compile" src="src/android/hooks/prepare_drawables.js"/>
+
   </platform>
   
   <!-- ios -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="2.0.12.OS">
+    version="2.0.12-OS2">
 
 
   <name>OneSignal Push Notifications</name>

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="2.0.11.OS">
+    version="2.0.12.OS">
 
 
   <name>OneSignal Push Notifications</name>

--- a/plugin.xml
+++ b/plugin.xml
@@ -124,7 +124,9 @@
     <source-file src="src/ios/UIApplicationDelegate+OneSignal.m" />
 
     <header-file src="src/ios/OneSignal-Prefix.pch" />
-
+    
+    <hook type="after_plugin_install" src="src/ios/hooks/install_prerequisites.js"/>
+    <hook type="after_plugin_install" src="src/ios/hooks/install_entitlements.js"/>
   </platform>
   
   <!-- Windows Phone 8.1 -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="2.0.12-OS2">
+    version="2.0.12-OS3">
 
 
   <name>OneSignal Push Notifications</name>

--- a/plugin.xml
+++ b/plugin.xml
@@ -13,6 +13,8 @@
   <keywords>push,notification,push notification,push notifications,apns,gcm,adm,retention,messaging,ios,android,windows phone</keywords>
 
   <license>MIT</license>
+  
+  <dependency id="cordova-android-support-gradle-release" url="https://github.com/dpa99c/cordova-android-support-gradle-release.git#1.1.5"/>
 
   <js-module src="www/OneSignal.js" name="OneSignal">
     <clobbers target="OneSignal" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -25,14 +25,12 @@
   </engines>
   
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:3.4.3@aar" />
+    <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
 
     <framework src="com.google.android.gms:play-services-gcm:+" />
     <!-- play-services-analytics is only required when gms version 8.1.0 or older is used. -->
     <framework src="com.google.android.gms:play-services-analytics:+" />
     <framework src="com.google.android.gms:play-services-location:+" />
-    
-    <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
 
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="OneSignalPush" >

--- a/src/android/hooks/prepare_drawables.js
+++ b/src/android/hooks/prepare_drawables.js
@@ -1,0 +1,69 @@
+var ICON_FILENAME = 'icon.png';
+
+var map_folders = [
+  {
+		src: "mipmap-hdpi",
+		dst: "drawable-hdpi"
+	},
+	{
+		src: "mipmap-ldpi",
+		dst: "drawable-ldpi"
+	},
+	{
+		src: "mipmap-mdpi",
+		dst: "drawable-mdpi"
+	},
+	{
+		src: "mipmap-xhdpi",
+		dst: "drawable-xhdpi"
+	},
+	{
+		src: "mipmap-xxhdpi",
+		dst: "drawable-xxhdpi"
+	},
+	{
+		src: "mipmap-xxxhdpi",
+		dst: "drawable-xxxhdpi"
+	}];
+
+module.exports = function (ctx) {
+
+  // make sure android platform is part of build
+  if (ctx.opts.platforms.indexOf('android') < 0) {
+    return;
+  }
+
+  console.error("Running hook to create drawables");
+
+  var fs = ctx.requireCordovaModule('fs');
+  var path = ctx.requireCordovaModule('path');
+
+  var res_dir = path.join(ctx.opts.projectRoot + '/platforms/android/res/')
+
+  map_folders.forEach(function(folder) {
+    var drawable_folder = path.join(res_dir, folder.dst);
+
+    if (!fs.existsSync(drawable_folder))
+      fs.mkdirSync(drawable_folder);
+    else
+      console.log("Folder " + folder.dst + " already exists");
+
+    var src = path.join(res_dir, folder.src, ICON_FILENAME);
+    var dst = path.join(res_dir, folder.dst, ICON_FILENAME);
+
+    copyFile(fs, src, dst);
+  });
+
+  console.log("All icons copied with success");
+};
+
+
+function copyFile(fs, src, dst) {
+  var rs = fs.createReadStream(src);
+
+  rs.on('error', function(err){
+    if (err) throw err;
+  });
+
+  rs.pipe(fs.createWriteStream(dst));
+}

--- a/src/ios/hooks/install_entitlements.js
+++ b/src/ios/hooks/install_entitlements.js
@@ -1,0 +1,169 @@
+console.error("Running hook to add push notifications capabilities");
+
+var fs = require('fs'),
+    xcode = require('xcode'),
+    xml2js = require('xml2js'),
+    path = require('path'),
+    plist = require('plist'),
+    util = require('util');
+
+var deferral = undefined;
+var parser = undefined;
+
+/******************************
+ * Get Preference
+ ******************************/
+function _getPreference(configXML, prefName, defaultValue){
+  fs.readFile(configXML, function(err, data) {
+    if (err) throw err;
+
+    parser.parseString(data, function (err, result) {
+      if (err) throw err;
+      
+      var preferenceList = result.widget.preference;
+
+      if (!preferenceList || !preferenceList.length)
+        return deferral.resolve(defaultValue);
+
+      for (var i=0; i<preferenceList.length; i++){
+        var xmlPreference = preferenceList[i];
+        
+        if (xmlPreference.$.name === prefName)
+          return deferral.resolve(xmlPreference.$.value);
+      }
+
+      deferral.resolve(defaultValue);
+    });
+  });
+
+  return deferral.promise;
+}
+
+/******************************
+ * Validate Preference
+ ******************************/
+function _validatePreference(value, defaultValue){
+  return value === "development" ? value : defaultValue;
+}
+
+/******************************
+ * Handle Entitlement File
+ ******************************/
+function _handleEntitlementFile(sourceFile, destFile, configXML){
+  var entitlementsFile = fs.readFileSync(sourceFile, 'utf8');
+  var obj = plist.parse(entitlementsFile);
+
+  _getPreference(configXML, "aps-environment", "production").then(function(value){
+    obj['aps-environment'] = _validatePreference(value, "production");
+
+    var xml = plist.build(obj);
+    fs.writeFileSync(destFile, xml, { encoding: 'utf8' });
+
+    deferral.resolve();
+  });
+  
+  return deferral.promise;
+}
+
+/******************************
+ * Create Entitlement File
+ ******************************/
+function _createEntitlementFile(iosFolder, projFolder, projName, configXML, context) {
+  var sourceFile = path.join(context.opts.plugin.pluginInfo.dir, 'src/ios/Resources/OutSystems.entitlements');
+  var destFile = path.join(iosFolder, projName, 'Resources', projName + '.entitlements');
+  
+  console.log("Will add ios push notifications entitlements to project '" + projName + "'");
+  console.log("Source Folder: " + sourceFile);
+  console.log("Destination Folder: " + destFile);
+  
+  _handleEntitlementFile(sourceFile, destFile, configXML).then(function(){
+    var projectPath = path.join(projFolder, 'project.pbxproj');
+    var pbxProject = undefined;
+
+    if (context.opts.cordova.project) {
+      pbxProject = context.opts.cordova.project.parseProjectFile(context.opts.projectRoot).xcode;
+    } else {
+      pbxProject = xcode.project(projectPath);
+      pbxProject.parseSync();
+    }
+    
+    pbxProject.addResourceFile(projName + ".entitlements");
+
+    var configGroups = pbxProject.hash.project.objects['XCBuildConfiguration'];
+
+    for (var key in configGroups) {
+      var config = configGroups[key];
+      if (config.buildSettings !== undefined) {
+        config.buildSettings.CODE_SIGN_ENTITLEMENTS = '"' + projName + '/Resources/' + projName + '.entitlements"';
+        //config.buildSettings.CODE_SIGN_ENTITLEMENTS = '"' + projName + '/' + projName + '.entitlements"';
+      }
+    }
+
+    // write the updated project file
+    fs.writeFileSync(projectPath, pbxProject.writeSync());
+    console.warn("OK, added ios push notifications entitlements to project '" + projName + "'");
+
+    deferral.resolve();
+  });
+
+  return deferral.promise;
+}
+
+/******************************
+ * Main
+ ******************************/
+module.exports = function (context) {
+  var Q = context.requireCordovaModule('q');
+
+  //NOT optional
+  deferral = new Q.defer();
+  parser = new xml2js.Parser();
+
+  if (context.opts.cordova.platforms.indexOf('ios') < 0) {
+    throw new Error('This plugin expects the ios platform to exist.');
+  }
+
+  var iosFolder = context.opts.cordova.project ? context.opts.cordova.project.root : path.join(context.opts.projectRoot, 'platforms/ios/');
+  console.log("iOS Platform Folder: " + iosFolder);
+
+  var promises = [];
+
+  var projFolder = undefined;
+  var projName = undefined;
+  
+  // Find the project folder by looking for *.xcodeproj
+  var dirFiles = fs.readdirSync(iosFolder);
+
+  dirFiles.forEach(function(file) {
+    if (file.match(/\.xcodeproj$/)) {
+      projFolder = path.join(iosFolder, file);
+      projName = path.basename(file, '.xcodeproj');
+    }
+  });
+
+  if (!projFolder || !projName) {
+    throw new Error("Could not find an .xcodeproj folder in: " + iosFolder);
+  }
+
+  var configXML = path.join(iosFolder, projName, 'config.xml');
+  
+  //OutSystems NativeShell Entitlements File
+  var entitlementsFile = path.join(iosFolder, projName, projName + '.entitlements');
+  
+  //Cordova 6.4.0 Entitlements Files
+  var entitlementsDebugFile = path.join(iosFolder, projName, 'Entitlements-Debug.plist');
+  var entitlementsReleaseFile = path.join(iosFolder, projName, 'Entitlements-Release.plist');
+
+  if (fs.existsSync(entitlementsFile)) {
+    promises.push(_handleEntitlementFile(entitlementsFile, entitlementsFile, configXML));
+  }
+  else if (fs.existsSync(entitlementsDebugFile) && fs.existsSync(entitlementsReleaseFile)) {
+    promises.push(_handleEntitlementFile(entitlementsDebugFile, entitlementsDebugFile, configXML));
+    promises.push(_handleEntitlementFile(entitlementsReleaseFile, entitlementsReleaseFile, configXML));
+  }
+  else {
+    promises.push(_createEntitlementFile(iosFolder, projFolder, projName, configXML, context));
+  }
+
+  return Q.all(promises);
+}

--- a/src/ios/hooks/install_prerequisites.js
+++ b/src/ios/hooks/install_prerequisites.js
@@ -1,0 +1,18 @@
+console.log("Running hook to install push notifications pre-requisites");
+
+module.exports = function (context) {
+  var child_process = context.requireCordovaModule('child_process'),
+      deferral = context.requireCordovaModule('q').defer();
+
+  var output = child_process.exec('npm install', {cwd: __dirname}, function (error) {
+    if (error !== null) {
+      console.log('exec error: ' + error);
+      deferral.reject('npm installation failed');
+    }
+    else {
+      deferral.resolve();
+    }
+  });
+
+  return deferral.promise;
+};

--- a/src/ios/hooks/package.json
+++ b/src/ios/hooks/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "xcode": "0.8.0",
+    "plist": "1.1.0",
+    "xml2js": "0.4.16"
+  }
+}


### PR DESCRIPTION
Adding another [dependency](https://github.com/OutSystems/cordova-android-support-gradle-release#purpose) is not good. However, considering:
- the ammount of plugins that can conflict with OneSignal
- the complexity of rebuilding the AndroidSDK
- the low impact of this addition (only has hooks to "pin" a gradle version)

It seems the best solution for now. Error in [RPD-2909](https://outsystemsrd.atlassian.net/browse/RPD-2909)