### PR TITLE
Email

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="2.2.5">
+    version="2.3.0">
 
 
   <name>OneSignal Push Notifications</name>
@@ -27,7 +27,7 @@
   </engines>
   
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:3.7.1" />
+    <framework src="com.onesignal:OneSignal:3.8.1" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
     
     <config-file target="res/xml/config.xml" parent="/*">
@@ -83,7 +83,7 @@
       <string>production</string>
     </config-file>
 
-    <framework src="OneSignal" type="podspec" spec="2.6.0" />
+    <framework src="OneSignal" type="podspec" spec="2.7.1" />
     <header-file src="src/ios/OneSignalPush.h" />
     <source-file src="src/ios/OneSignalPush.m" />
 

--- a/src/android/com/plugin/gcm/OneSignalPush.java
+++ b/src/android/com/plugin/gcm/OneSignalPush.java
@@ -362,6 +362,8 @@ public class OneSignalPush extends CordovaPlugin {
                 }
               }
             });
+
+          result = true;
         } catch(Throwable t) {
             t.printStackTrace();
         }
@@ -386,6 +388,8 @@ public class OneSignalPush extends CordovaPlugin {
                 }
               }
             });
+
+          result = true;
         } catch (Throwable t) {
             t.printStackTrace();
         }
@@ -408,6 +412,8 @@ public class OneSignalPush extends CordovaPlugin {
             }
           }
         });
+
+      result = true;
     }
     else {
       result = false;

--- a/src/android/com/plugin/gcm/OneSignalPush.java
+++ b/src/android/com/plugin/gcm/OneSignalPush.java
@@ -372,7 +372,7 @@ public class OneSignalPush extends CordovaPlugin {
               public void onFailure(EmailUpdateError error) {
                 try {
                   JSONObject errorObject = new JSONObject("{'error' : '" + error.getMessage() + "'}");
-                  callbackError(callbackContext, errorObject);
+                  callbackError(jsSetEmailContext, errorObject);
                 } catch (JSONException e) {
                   e.printStackTrace();
                 }
@@ -398,7 +398,7 @@ public class OneSignalPush extends CordovaPlugin {
               public void onFailure(EmailUpdateError error) {
                 try {
                   JSONObject errorObject = new JSONObject("{'error' : '" + error.getMessage() + "'}");
-                  callbackError(callbackContext, errorObject);
+                  callbackError(jsSetEmailContext, errorObject);
                 } catch (JSONException e) {
                   e.printStackTrace();
                 }
@@ -422,7 +422,7 @@ public class OneSignalPush extends CordovaPlugin {
           public void onFailure(EmailUpdateError error) {
             try {
               JSONObject errorObject = new JSONObject("{'error' : '" + error.getMessage() + "'}");
-              callbackError(callbackContext, errorObject);
+              callbackError(jsSetEmailContext, errorObject);
             } catch (JSONException e) {
               e.printStackTrace();
             }

--- a/src/android/com/plugin/gcm/OneSignalPush.java
+++ b/src/android/com/plugin/gcm/OneSignalPush.java
@@ -51,6 +51,8 @@ import com.onesignal.OneSignal.NotificationReceivedHandler;
 import com.onesignal.OneSignal.GetTagsHandler;
 import com.onesignal.OneSignal.IdsAvailableHandler;
 import com.onesignal.OneSignal.PostNotificationResponseHandler;
+import com.onesignal.OneSignal.EmailUpdateHandler;
+import com.onesignal.OneSignal.EmailUpdateError;
 
 import com.onesignal.OSPermissionObserver;
 import com.onesignal.OSSubscriptionObserver;
@@ -85,6 +87,10 @@ public class OneSignalPush extends CordovaPlugin {
   private static final String POST_NOTIFICATION = "postNotification";
   private static final String PROMPT_LOCATION = "promptLocation";
   private static final String CLEAR_ONESIGNAL_NOTIFICATIONS = "clearOneSignalNotifications";
+    
+  private static final String SET_EMAIL = "setEmail";
+  private static final String SET_UNAUTHENTICATED_EMAIL = "setUnauthenticatedEmail";
+  private static final String LOGOUT_EMAIL = "logoutEmail";
   
   private static final String SET_LOG_LEVEL = "setLogLevel";
 
@@ -336,6 +342,72 @@ public class OneSignalPush extends CordovaPlugin {
       catch(Throwable t) {
         t.printStackTrace();
       }
+    }
+    else if (SET_EMAIL.equals(action)) {
+      final CallbackContext jsSetEmailContext = callbackContext;
+        try {
+            OneSignal.setEmail(data.getString(0), data.getString(1), new EmailUpdateHandler() {
+              @Override
+              public void onSuccess() {
+                callbackSuccess(jsSetEmailContext, null);
+              }
+
+              @Override
+              public void onFailure(EmailUpdateError error) {
+                try {
+                  JSONObject errorObject = new JSONObject("{'error' : '" + error.getMessage() + "'}");
+                  callbackError(callbackContext, errorObject);
+                } catch (JSONException e) {
+                  e.printStackTrace();
+                }
+              }
+            });
+        } catch(Throwable t) {
+            t.printStackTrace();
+        }
+    }
+    else if (SET_UNAUTHENTICATED_EMAIL.equals(action)) {
+      final CallbackContext jsSetEmailContext = callbackContext;
+
+        try {
+            OneSignal.setEmail(data.getString(0), null, new EmailUpdateHandler() {
+              @Override
+              public void onSuccess() {
+                callbackSuccess(jsSetEmailContext, null);
+              }
+
+              @Override
+              public void onFailure(EmailUpdateError error) {
+                try {
+                  JSONObject errorObject = new JSONObject("{'error' : '" + error.getMessage() + "'}");
+                  callbackError(callbackContext, errorObject);
+                } catch (JSONException e) {
+                  e.printStackTrace();
+                }
+              }
+            });
+        } catch (Throwable t) {
+            t.printStackTrace();
+        }
+    }
+    else if (LOGOUT_EMAIL.equals(action)) {
+      final CallbackContext jsSetEmailContext = callbackContext;
+        OneSignal.logoutEmail(new EmailUpdateHandler() {
+          @Override
+          public void onSuccess() {
+            callbackSuccess(jsSetEmailContext, null);
+          }
+
+          @Override
+          public void onFailure(EmailUpdateError error) {
+            try {
+              JSONObject errorObject = new JSONObject("{'error' : '" + error.getMessage() + "'}");
+              callbackError(callbackContext, errorObject);
+            } catch (JSONException e) {
+              e.printStackTrace();
+            }
+          }
+        });
     }
     else {
       result = false;

--- a/src/android/com/plugin/gcm/OneSignalPush.java
+++ b/src/android/com/plugin/gcm/OneSignalPush.java
@@ -91,6 +91,7 @@ public class OneSignalPush extends CordovaPlugin {
   private static final String SET_EMAIL = "setEmail";
   private static final String SET_UNAUTHENTICATED_EMAIL = "setUnauthenticatedEmail";
   private static final String LOGOUT_EMAIL = "logoutEmail";
+  private static final String ADD_EMAIL_SUBSCRIPTION_OBSERVER = "addEmailSubscriptionObserver";
   
   private static final String SET_LOG_LEVEL = "setLogLevel";
 
@@ -100,9 +101,11 @@ public class OneSignalPush extends CordovaPlugin {
   
   private static CallbackContext jsPermissionObserverCallBack;
   private static CallbackContext jsSubscriptionObserverCallBack;
+  private static CallbackContext jsEmailSubscriptionObserverCallBack;
   
   private static OSPermissionObserver permissionObserver;
   private static OSSubscriptionObserver subscriptionObserver;
+  private static OSEmailSubscriptionObserver emailSubscriptionObserver;
 
   // This is to prevent an issue where if two Javascript calls are made to OneSignal expecting a callback then only one would fire.
   private static void callbackSuccess(CallbackContext callbackContext, JSONObject jsonObject) {
@@ -203,6 +206,19 @@ public class OneSignalPush extends CordovaPlugin {
           }
         };
         OneSignal.addSubscriptionObserver(subscriptionObserver);
+      }
+      result = true;
+    }
+    else if (ADD_EMAIL_SUBSCRIPTION_OBSERVER.equals(action)) {
+      jsEmailSubscriptionObserverCallBack = callbackContext;
+      if (emailSubscriptionObserver == null) {
+        emailSubscriptionObserver = new OSEmailSubscriptionObserver() {
+          @Override
+          public void onOSEmailSubscriptionChanged(OSEmailSubscriptionStateChanges stateChanges) {
+            callbackSuccess(jsEmailSubscriptionObserverCallBack, stateChanges.toJSONObject());
+          }
+        };
+        OneSignal.addEmailSubscriptionObserver(emailSubscriptionObserver);
       }
       result = true;
     }

--- a/src/ios/OneSignalPush.h
+++ b/src/ios/OneSignalPush.h
@@ -43,7 +43,7 @@
 
 - (void)addPermissionObserver:(CDVInvokedUrlCommand*)command;
 - (void)addSubscriptionObserver:(CDVInvokedUrlCommand*)command;
-
+- (void)addEmailSubscriptionObserver:(CDVInvokedUrlCommand *)command;
 
 - (void)getTags:(CDVInvokedUrlCommand*)command;
 - (void)getIds:(CDVInvokedUrlCommand*)command;

--- a/src/ios/OneSignalPush.h
+++ b/src/ios/OneSignalPush.h
@@ -57,6 +57,11 @@
 - (void)promptLocation:(CDVInvokedUrlCommand*)command;
 - (void)syncHashedEmail:(CDVInvokedUrlCommand*)command;
 
+//email
+- (void)setEmail:(CDVInvokedUrlCommand *)command;
+- (void)setUnauthenticatedEmail:(CDVInvokedUrlCommand *)command;
+- (void)logoutEmail:(CDVInvokedUrlCommand *)command;
+
 // Android Only
 - (void)enableVibrate:(CDVInvokedUrlCommand*)command;
 - (void)enableSound:(CDVInvokedUrlCommand*)command;

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -261,41 +261,39 @@ static Class delegateClass = nil;
 //email
 
 - (void)setEmail:(CDVInvokedUrlCommand *)command {
-    NSString *email = command.arguments[0];
-    NSString *emailAuthToken;
     setEmailCallbackId = command.callbackId;
     
-    if (command.arguments.count > 1)
-        emailAuthToken = command.arguments[1];
+    NSString *email = command.arguments[0];
+    NSString *emailAuthToken = command.arguments[1];
     
-    [OneSignal setEmail:email withEmailAuthHashToken:emailAuthToken withSuccess: ^() {
+    [OneSignal setEmail:email withEmailAuthHashToken:emailAuthToken withSuccess:^{
         successCallback(setEmailCallbackId, nil);
-    } withFailure: ^(NSError *error) {
-        failureCallback(setEmailCallbackId, error);
+    } withFailure:^(NSError *error) {
+        failureCallback(setEmailCallbackId, error.userInfo);
     }];
 }
 
 - (void)setUnauthenticatedEmail:(CDVInvokedUrlCommand *)command {
-    NSString *email = command.arguments[0];
     setUnauthenticatedEmailCallbackId = command.callbackId;
     
-    [OneSignal setUnauthenticatedEmail:email withSuccess: ^() {
+    NSString *email = command.arguments[0];
+    
+    [OneSignal setEmail:email withSuccess:^{
         successCallback(setUnauthenticatedEmailCallbackId, nil);
-    } withFailure: ^(NSError *error) {
-        failureCallback(setUnauthenticatedEmailCallbackId, error);
+    } withFailure:^(NSError *error) {
+        failureCallback(setUnauthenticatedEmailCallbackId, error.userInfo);
     }];
 }
 
 - (void)logoutEmail:(CDVInvokedUrlCommand *)command {
     logoutEmailCallbackId = command.callbackId;
     
-    [OneSignal logoutEmailWithSuccess: ^() {
+    [OneSignal logoutEmailWithSuccess:^{
         successCallback(logoutEmailCallbackId, nil);
-    } withFailure: ^(NSError *error) {
-        failureCallback(logoutEmailCallbackId, error);
+    } withFailure:^(NSError *error) {
+        failureCallback(logoutEmailCallbackId, error.userInfo);
     }];
 }
-
 // Android only
 - (void)enableVibrate:(CDVInvokedUrlCommand*)command {}
 - (void)enableSound:(CDVInvokedUrlCommand*)command {}

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -39,6 +39,10 @@ NSString* postNotificationCallbackId;
 NSString* permissionObserverCallbackId;
 NSString* subscriptionObserverCallbackId;
 NSString* promptForPushNotificationsWithUserResponseCallbackId;
+NSString* setEmailCallbackId;
+NSString* setUnauthenticatedEmailCallbackId;
+NSString* logoutEmailCallbackId;
+
 
 OSNotificationOpenedResult* actionNotification;
 OSNotification *notification;
@@ -252,6 +256,44 @@ static Class delegateClass = nil;
 - (void)setLogLevel:(CDVInvokedUrlCommand*)command {
     NSDictionary* options = command.arguments[0];
     [OneSignal setLogLevel:[options[@"logLevel"] intValue] visualLevel:[options[@"visualLevel"] intValue]];
+}
+
+//email
+
+- (void)setEmail:(CDVInvokedUrlCommand *)command {
+    NSString *email = command.arguments[0];
+    NSString *emailAuthToken;
+    setEmailCallbackId = command.callbackId;
+    
+    if (command.arguments.count > 1)
+        emailAuthToken = command.arguments[1];
+    
+    [OneSignal setEmail:email withEmailAuthHashToken:emailAuthToken withSuccess: ^() {
+        successCallback(setEmailCallbackId, nil);
+    } withFailure: ^(NSError *error) {
+        failureCallback(setEmailCallbackId, error);
+    }];
+}
+
+- (void)setUnauthenticatedEmail:(CDVInvokedUrlCommand *)command {
+    NSString *email = command.arguments[0];
+    setUnauthenticatedEmailCallbackId = command.callbackId;
+    
+    [OneSignal setUnauthenticatedEmail:email withSuccess: ^() {
+        successCallback(setUnauthenticatedEmailCallbackId, nil);
+    } withFailure: ^(NSError *error) {
+        failureCallback(setUnauthenticatedEmailCallbackId, error);
+    }];
+}
+
+- (void)logoutEmail:(CDVInvokedUrlCommand *)command {
+    logoutEmailCallbackId = command.callbackId;
+    
+    [OneSignal logoutEmailWithSuccess: ^() {
+        successCallback(logoutEmailCallbackId, nil);
+    } withFailure: ^(NSError *error) {
+        failureCallback(logoutEmailCallbackId, error);
+    }];
 }
 
 // Android only

--- a/www/OneSignal.js
+++ b/www/OneSignal.js
@@ -228,22 +228,22 @@ OneSignal.prototype.setEmail = function(email, emailAuthToken, onSuccess, onFail
     if (onSuccess == null)
         onSuccess = function() {};
 
-
     if (onFailure == null)
         onFailure = function() {};
     
-    cordova.exec(onSuccess, onFailure, "OneSignalPush", "setEmail", [email, emailAuthToken]);
-}
+    if (typeof emailAuthToken == 'function') {
+        onFailure = onSuccess;
+        onSuccess = emailAuthToken;
+        
+        cordova.exec(onSuccess, onFailure, "OneSignalPush", "setUnauthenticatedEmail", [email]);
+    } else if (emailAuthToken == undefined) {
+        cordova.exec(onSuccess, onFailure, "OneSignalPush", "setUnauthenticatedEmail", [email]);
+    } else {
+        onFailure = onSuccess;
+        onSuccess = emailAuthToken;
 
-OneSignal.prototype.setUnauthenticatedEmail = function(email, onSuccess, onFailure) {
-    if (onSuccess == null)
-        onSuccess = function() {};
-
-
-    if (onFailure == null)
-        onFailure = function() {};
-    
-    cordova.exec(onSuccess, onFailure, "OneSignalPush", "setUnauthenticatedEmail", [email]);
+        cordova.exec(onSuccess, onFailure, "OneSignalPush", "setEmail", [email, emailAuthToken]);
+    }
 }
 
 OneSignal.prototype.logoutEmail = function(onSuccess, onFailure) {

--- a/www/OneSignal.js
+++ b/www/OneSignal.js
@@ -239,9 +239,6 @@ OneSignal.prototype.setEmail = function(email, emailAuthToken, onSuccess, onFail
     } else if (emailAuthToken == undefined) {
         cordova.exec(onSuccess, onFailure, "OneSignalPush", "setUnauthenticatedEmail", [email]);
     } else {
-        onFailure = onSuccess;
-        onSuccess = emailAuthToken;
-
         cordova.exec(onSuccess, onFailure, "OneSignalPush", "setEmail", [email, emailAuthToken]);
     }
 }

--- a/www/OneSignal.js
+++ b/www/OneSignal.js
@@ -50,6 +50,7 @@ OneSignal._displayOption = OneSignal.prototype.OSInFocusDisplayOption.InAppAlert
 
 OneSignal._permissionObserverList = [];
 OneSignal._subscriptionObserverList = [];
+OneSignal._emailSubscriptionObserverList = [];
 
 
 // You must call init before any other OneSignal function.
@@ -125,6 +126,14 @@ OneSignal.prototype.addSubscriptionObserver = function(callback) {
   };
   cordova.exec(subscriptionCallBackProcessor, function(){}, "OneSignalPush", "addSubscriptionObserver", []);
 };
+
+OneSignal.prototype.addEmailSubscriptionObserver = function(callback) {
+    OneSignal._emailSubscriptionObserverList.push(callback);
+    var emailSubscriptionCallbackProcessor = function(state) {
+        OneSignal._processFunctionList(OneSignal._emailSubscriptionObserverList, state);
+    };
+    cordova.exec(emailSubscriptionCallbackProcessor, function(){}, "OneSignalPush", "addEmailSubscriptionObserver", []);
+}
 
 OneSignal.prototype.setInFocusDisplaying = function(displayType) {
   OneSignal._displayOption = displayType;

--- a/www/OneSignal.js
+++ b/www/OneSignal.js
@@ -222,6 +222,41 @@ OneSignal.prototype.setLogLevel = function(logLevel) {
     cordova.exec(function(){}, function(){}, "OneSignalPush", "setLogLevel", [logLevel]);
 };
 
+//email
+
+OneSignal.prototype.setEmail = function(email, emailAuthToken, onSuccess, onFailure) {
+    if (onSuccess == null)
+        onSuccess = function() {};
+
+
+    if (onFailure == null)
+        onFailure = function() {};
+    
+    cordova.exec(onSuccess, onFailure, "OneSignalPush", "setEmail", [email, emailAuthToken]);
+}
+
+OneSignal.prototype.setUnauthenticatedEmail = function(email, onSuccess, onFailure) {
+    if (onSuccess == null)
+        onSuccess = function() {};
+
+
+    if (onFailure == null)
+        onFailure = function() {};
+    
+    cordova.exec(onSuccess, onFailure, "OneSignalPush", "setUnauthenticatedEmail", [email]);
+}
+
+OneSignal.prototype.logoutEmail = function(onSuccess, onFailure) {
+    if (onSuccess == null)
+        onSuccess = function() {};
+
+
+    if (onFailure == null)
+        onFailure = function() {};
+    
+    cordova.exec(onSuccess, onFailure, "OneSignalPush", "logoutEmail", []);
+}
+
 
 //-------------------------------------------------------------------
 


### PR DESCRIPTION
• OneSignal is now introducing beta support for Email 
• Introduces two new public functions to the OneSignal Cordova SDK:

`setEmail(email, emailAuthToken, onSuccess, onFailure)` 
Allows you to set an email address for your users

`logoutEmail()` 
Allows your application to dissociate their email address from the device

• Uses the latest iOS and Android SDK's