### PR TITLE
Gdpr privacy

### DIFF
--- a/src/android/com/plugin/gcm/OneSignalPush.java
+++ b/src/android/com/plugin/gcm/OneSignalPush.java
@@ -98,6 +98,10 @@ public class OneSignalPush extends CordovaPlugin {
   private static final String SET_LOG_LEVEL = "setLogLevel";
 
   private static final String SET_LOCATION_SHARED = "setLocationShared";
+    
+  private static final String USER_PROVIDED_CONSENT = "userProvidedPrivacyConsent";
+  private static final String SET_REQUIRES_CONSENT = "setRequiresUserPrivacyConsent";
+  private static final String GRANT_CONSENT = "provideUserConsent";
   
   private static CallbackContext notifReceivedCallbackContext;
   private static CallbackContext notifOpenedCallbackContext;
@@ -116,6 +120,12 @@ public class OneSignalPush extends CordovaPlugin {
       jsonObject = new JSONObject();
 
     PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, jsonObject);
+    pluginResult.setKeepCallback(true);
+    callbackContext.sendPluginResult(pluginResult);
+  }
+    
+  private static void callbackSuccessBoolean(CallbackContext callbackContext, boolean param) {
+    PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, param);
     pluginResult.setKeepCallback(true);
     callbackContext.sendPluginResult(pluginResult);
   }
@@ -437,6 +447,25 @@ public class OneSignalPush extends CordovaPlugin {
     else if (SET_LOCATION_SHARED.equals(action)) {
       try {
          OneSignal.setLocationShared(data.getBoolean(0));
+      } catch (JSONException e) {
+         e.printStackTrace();
+      }
+    } else if (USER_PROVIDED_CONSENT.equals(action)) {
+      boolean providedConsent = OneSignal.userProvidedPrivacyConsent();
+      final CallbackContext jsUserProvidedConsentContext = callbackContext;
+      callbackSuccessBoolean(callbackContext, providedConsent);
+      result = true;
+    } else if (SET_REQUIRES_CONSENT.equals(action)) {
+      try {
+         OneSignal.setRequiresUserPrivacyConsent(data.getBoolean(0));
+         result = true;
+      } catch (JSONException e) {
+         e.printStackTrace();
+      }
+    } else if (GRANT_CONSENT.equals(action)) {
+      try {
+         Oneignal.provideUserConsent(data.getBoolean(0));
+         result = true;
       } catch (JSONException e) {
          e.printStackTrace();
       }

--- a/src/ios/OneSignalPush.h
+++ b/src/ios/OneSignalPush.h
@@ -68,4 +68,9 @@
 - (void)enableSound:(CDVInvokedUrlCommand*)command;
 - (void)clearOneSignalNotifications:(CDVInvokedUrlCommand*)command;
 
+- (void)userProvidedPrivacyConsent:(CDVInvokedUrlCommand *)command;
+- (void)setRequiresUserPrivacyConsent:(CDVInvokedUrlCommand *)command;
+- (void)provideUserConsent:(CDVInvokedUrlCommand *)command;
+    
+    
 @end

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -344,5 +344,21 @@ static Class delegateClass = nil;
     }];
 }
 
+- (void)userProvidedPrivacyConsent:(CDVInvokedUrlCommand *)command {
+    CDVPluginResult* commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:!OneSignal.requiresUserPrivacyConsent];
+    commandResult.keepCallback = @1;
+    [pluginCommandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
+}
+
+- (void)setRequiresUserPrivacyConsent:(CDVInvokedUrlCommand *)command {
+    if (command.arguments.count >= 1)
+        [OneSignal setRequiresUserPrivacyConsent:command.arguments[0]];
+}
+
+- (void)provideUserConsent:(CDVInvokedUrlCommand *)command {
+    if (command.arguments.count >= 1)
+        [OneSignal consentGranted:command.arguments[0]];
+}
+
 @end
 

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -349,15 +349,15 @@ static Class delegateClass = nil;
     commandResult.keepCallback = @1;
     [pluginCommandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
 }
-
+    
 - (void)setRequiresUserPrivacyConsent:(CDVInvokedUrlCommand *)command {
     if (command.arguments.count >= 1)
-        [OneSignal setRequiresUserPrivacyConsent:command.arguments[0]];
+    [OneSignal setRequiresUserPrivacyConsent:[command.arguments[0] boolValue]];
 }
-
+    
 - (void)provideUserConsent:(CDVInvokedUrlCommand *)command {
     if (command.arguments.count >= 1)
-        [OneSignal consentGranted:command.arguments[0]];
+    [OneSignal consentGranted:[command.arguments[0] boolValue]];
 }
 
 @end

--- a/www/OneSignal.js
+++ b/www/OneSignal.js
@@ -267,7 +267,7 @@ OneSignal.prototype.logoutEmail = function(onSuccess, onFailure) {
 }
 
 OneSignal.prototype.userProvidedPrivacyConsent = function(callback) {
-   cordova.exec(callback, function(){}, "OneSignalPush", "requiresUserPrivacyConsent", []);
+   cordova.exec(callback, function(){}, "OneSignalPush", "userProvidedPrivacyConsent", []);
  }
  
  OneSignal.prototype.setRequiresUserPrivacyConsent = function(required) {

--- a/www/OneSignal.js
+++ b/www/OneSignal.js
@@ -266,6 +266,18 @@ OneSignal.prototype.logoutEmail = function(onSuccess, onFailure) {
     cordova.exec(onSuccess, onFailure, "OneSignalPush", "logoutEmail", []);
 }
 
+OneSignal.prototype.userProvidedPrivacyConsent = function(callback) {
+   cordova.exec(callback, function(){}, "OneSignalPush", "requiresUserPrivacyConsent", []);
+ }
+ 
+ OneSignal.prototype.setRequiresUserPrivacyConsent = function(required) {
+   cordova.exec(function() {}, function() {}, "OneSignalPush", "setRequiresUserPrivacyConsent", [required]);
+ }
+ 
+ OneSignal.prototype.provideUserConsent = function(granted) {
+   cordova.exec(function() {}, function() {}, "OneSignalPush", "provideUserConsent", [granted]);
+ }
+
 
 //-------------------------------------------------------------------
 


### PR DESCRIPTION
• Adds GDPR consent methods to the Cordova SDK for both iOS and Android
• If developers call `OneSignal.setRequiresUserPrivacyConsent(true)`, the SDK will delay initialization until the user provides consent and the developer calls `OneSignal.provideUserConsent(true)`