### PR TITLE
Fix setLocationShared

### DIFF
--- a/www/OneSignal.js
+++ b/www/OneSignal.js
@@ -231,7 +231,7 @@ OneSignal.prototype.setLogLevel = function(logLevel) {
 };
 
 OneSignal.prototype.setLocationShared = function(shared) {
-   cordova.exec(function() {}, "OneSignalPush", "setLocationShared", [shared]);
+   cordova.exec(function() {}, function() {}, "OneSignalPush", "setLocationShared", [shared]);
 };
 
 //email


### PR DESCRIPTION
• The setLocationShared() function was incorrectly only passing in a single function to cordova.exec as a stub for a callback, however, cordova.exec() requires two callbacks.
• Fixed by adding a second stub callback.