### PR TITLE
2.4.7 release with updated native plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ---
 
-[OneSignal](https://onesignal.com/) is a free push notification service for mobile apps. This plugin makes it easy to integrate your [Cordova](http://cordova.apache.org/) based (e.g. [Ionic](http://ionicframework.com/), [PhoneGap](https://phonegap.com/), PhoneGap Build, [Intel XDK](https://software.intel.com/en-us/intel-xdk/documentation) or [Sencha Touch](https://www.sencha.com/products/touch/)) app with OneSignal. 
+[OneSignal](https://onesignal.com/) is a free push notification service for mobile apps. This plugin makes it easy to integrate your [Cordova](http://cordova.apache.org/) based (e.g. [Ionic](http://ionicframework.com/), [PhoneGap](https://phonegap.com/), and PhoneGap Build app with OneSignal. 
 
 ![alt text](https://onesignal.com/images/android_and_ios_notification_image.gif)
 
@@ -32,6 +32,6 @@ For account issues and support please contact OneSignal support from the [OneSig
 To make things easier, we have published demo projects for [Cordova](https://github.com/OneSignal/OneSignal-Cordova-Example) and [Ionic](https://github.com/OneSignal/OneSignal-Ionic-Example)
 
 #### Supports:
-* Cordova, Ionic (1 and 2), Phonegap, and Intel XDK
-* Android 4.0.3 (API Level 15) through 8.1 (API Level 27), and derivatives such as Amazon ADM
-* iOS 7 - 11.3
+* Cordova, Ionic (1 through 4), and Phonegap
+* Android 4.0.3 (API Level 15) through 9.0 (API Level 28), and Amazon FireOS
+* iOS 7 - 12.2

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -18,7 +18,7 @@ buildscript {
     maven { url 'https://plugins.gradle.org/m2/'}
   }
   dependencies {
-    classpath 'gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.10.0, 0.99.99]'
+    classpath 'gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.12.1, 0.99.99]'
   }
 }
 apply plugin: com.onesignal.androidsdk.GradleProjectPlugin
@@ -30,7 +30,7 @@ apply plugin: com.onesignal.androidsdk.GradleProjectPlugin
 //     maven { url uri('file:/full/paht/to/maven/repo/') }
 //   }
 //   dependencies {
-//     classpath 'com.onesignal:onesignal-gradle-plugin:[0.10.0, 0.99.99]'
+//     classpath 'com.onesignal:onesignal-gradle-plugin:[0.12.1, 0.99.99]'
 //   }
 // }
 // apply plugin: com.onesignal.androidsdk.GradleProjectPlugin

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.4.6",
+  "version": "2.4.7",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="2.4.6">
+    version="2.4.7">
 
 
   <name>OneSignal Push Notifications</name>
@@ -27,7 +27,7 @@
   </engines>
   
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:3.10.5" />
+    <framework src="com.onesignal:OneSignal:3.10.8" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
     
     <config-file target="res/xml/config.xml" parent="/*">
@@ -83,7 +83,7 @@
       <string>production</string>
     </config-file>
 
-    <framework src="OneSignal" type="podspec" spec="2.9.4" />
+    <framework src="OneSignal" type="podspec" spec="2.10.0" />
     <header-file src="src/ios/OneSignalPush.h" />
     <source-file src="src/ios/OneSignalPush.m" />
 


### PR DESCRIPTION
* Updated to latest Android OneSignal SDK 3.10.8 from 3.10.5
* Updated to latest iOS OneSignal SDK 2.10.0 from 2.9.4
* Small updates to readme, update version numbers and removed Intel XDK.