### PR TITLE
Remove block-scoped variable declaration 'let'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.5.1",
+  "version": "2.5.2",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="2.5.1">
+    version="2.5.2">
 
 
   <name>OneSignal Push Notifications</name>

--- a/www/OneSignal.js
+++ b/www/OneSignal.js
@@ -301,7 +301,7 @@ OneSignal.prototype.addTriggers = function(triggers) {
 }
 
 OneSignal.prototype.addTrigger = function(key, value) {
-    let obj = {};
+    var obj = {};
     obj[key] = value;
     OneSignal.prototype.addTriggers(obj);
 }


### PR DESCRIPTION
Previous version included a variable declaration using "let", this commit fixes it by switching it to "var"

**Release:** 5.2.2

Closes #532 