### PR TITLE
iOS In-app messaging stubbing for unimplemented methods

### DIFF
--- a/src/ios/OneSignalPush.h
+++ b/src/ios/OneSignalPush.h
@@ -35,6 +35,7 @@
 
 - (void)setNotificationReceivedHandler:(CDVInvokedUrlCommand*)command;
 - (void)setNotificationOpenedHandler:(CDVInvokedUrlCommand*)command;
+- (void)setInAppMessageClickHandler:(CDVInvokedUrlCommand*)command;
 - (void)init:(CDVInvokedUrlCommand*)command;
 
 - (void)setInFocusDisplaying:(CDVInvokedUrlCommand*)command;

--- a/src/ios/OneSignalPush.h
+++ b/src/ios/OneSignalPush.h
@@ -35,7 +35,6 @@
 
 - (void)setNotificationReceivedHandler:(CDVInvokedUrlCommand*)command;
 - (void)setNotificationOpenedHandler:(CDVInvokedUrlCommand*)command;
-- (void)setInAppMessageClickHandler:(CDVInvokedUrlCommand*)command;
 - (void)init:(CDVInvokedUrlCommand*)command;
 
 - (void)setInFocusDisplaying:(CDVInvokedUrlCommand*)command;
@@ -73,5 +72,12 @@
 - (void)setRequiresUserPrivacyConsent:(CDVInvokedUrlCommand *)command;
 - (void)provideUserConsent:(CDVInvokedUrlCommand *)command;
     
-    
+
+// in app
+- (void)setInAppMessageClickHandler:(CDVInvokedUrlCommand*)command;
+- (void)addTriggers:(CDVInvokedUrlCommand*)command;
+- (void)removeTriggersForKeys:(CDVInvokedUrlCommand*)command;
+- (void)getTriggerValueForKey:(CDVInvokedUrlCommand*)command;
+- (void)pauseInAppMessages:(CDVInvokedUrlCommand*)command;
+
 @end

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -179,6 +179,9 @@ static Class delegateClass = nil;
 - (void)setNotificationOpenedHandler:(CDVInvokedUrlCommand*)command {
     notficationOpenedCallbackId = command.callbackId;
 }
+- (void)setInAppMessageClickHandler:(CDVInvokedUrlCommand*)command {
+    // unimplemented in ios
+}
 
 - (void)init:(CDVInvokedUrlCommand*)command {
     

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -179,9 +179,6 @@ static Class delegateClass = nil;
 - (void)setNotificationOpenedHandler:(CDVInvokedUrlCommand*)command {
     notficationOpenedCallbackId = command.callbackId;
 }
-- (void)setInAppMessageClickHandler:(CDVInvokedUrlCommand*)command {
-    // unimplemented in ios
-}
 
 - (void)init:(CDVInvokedUrlCommand*)command {
     
@@ -373,5 +370,24 @@ static Class delegateClass = nil;
     [OneSignal removeExternalUserId];
 }
 
+- (void)setInAppMessageClickHandler:(CDVInvokedUrlCommand*)command {
+    // unimplemented in ios
+}
+
+- (void)addTriggers:(CDVInvokedUrlCommand*)command {
+   // unimplemented in ios 
+}
+
+- (void)removeTriggersForKeys:(CDVInvokedUrlCommand*)command {
+   // unimplemented in ios 
+}
+
+- (void)getTriggerValueForKey:(CDVInvokedUrlCommand*)command {
+   // unimplemented in ios 
+}
+
+- (void)pauseInAppMessages:(CDVInvokedUrlCommand*)command {
+   // unimplemented in ios 
+}
 @end
 


### PR DESCRIPTION
In-app messaging is not yet implemented in iOS. Added missing stubbing to avoid warnings in console