### PR TITLE
Remove the use of arrow functions to prevent breaking backward compatibility

### DIFF
--- a/www/OneSignal.js
+++ b/www/OneSignal.js
@@ -297,7 +297,7 @@ OneSignal.prototype.userProvidedPrivacyConsent = function(callback) {
  */
 
 OneSignal.prototype.addTriggers = function(triggers) {
-    Object.keys(triggers).forEach((key)=>{
+    Object.keys(triggers).forEach(function(key) {
         // forces values to be string types
         if (typeof triggers[key] !== "string") {
             triggers[key] = JSON.stringify(triggers[key]);


### PR DESCRIPTION
Release 2.6.0 contains the use of an arrow function which will break apps running on older version of android. I replaced it with a regular `function` notation.