### PR TITLE
Added "google()" repository

### DIFF
--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -16,6 +16,7 @@ repositories {
 buildscript {
   repositories {
     maven { url 'https://plugins.gradle.org/m2/'}
+    google()
   }
   dependencies {
     classpath 'gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.12.3, 0.99.99]'


### PR DESCRIPTION
Hi, I have an error while building, because plugin require google play services

`FAILURE: Build failed with an exception.
project :app > com.onesignal:OneSignal:3.10.8 > com.google.firebase:firebase-messaging:11.0.4 > com.google.android.gms:play-services-basement:11.0.4`

Fix taken from here
https://stackoverflow.com/a/50791999/9095286