### PR TITLE
iOS bridge for Outcomes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.6.0",
+  "version": "2.8.0",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="2.6.0">
+    version="2.8.0">
 
 
   <name>OneSignal Push Notifications</name>
@@ -27,7 +27,7 @@
   </engines>
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:3.12.2" />
+    <framework src="com.onesignal:OneSignal:3.12.3" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
 
     <config-file target="res/xml/config.xml" parent="/*">
@@ -83,7 +83,7 @@
       <string>production</string>
     </config-file>
 
-    <framework src="OneSignal" type="podspec" spec="2.11.0" />
+    <framework src="OneSignal" type="podspec" spec="2.12.1" />
     <header-file src="src/ios/OneSignalPush.h" />
     <source-file src="src/ios/OneSignalPush.m" />
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -82,7 +82,7 @@
       <string>production</string>
     </config-file>
 
-    <framework src="OneSignal" type="podspec" spec="2.12.1" />
+    <framework src="OneSignal" type="podspec" spec="2.12.2" />
     <header-file src="src/ios/OneSignalPush.h" />
     <source-file src="src/ios/OneSignalPush.m" />
 

--- a/src/ios/OneSignalPush.h
+++ b/src/ios/OneSignalPush.h
@@ -83,5 +83,4 @@
 - (void)sendOutcome:(CDVInvokedUrlCommand*)command;
 - (void)sendUniqueOutcome:(CDVInvokedUrlCommand*)command;
 - (void)sendOutcomeWithValue:(CDVInvokedUrlCommand*)command;
-
 @end

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -409,18 +409,18 @@ static Class delegateClass = nil;
    [OneSignal pauseInAppMessages:pause];
 }
 
-- (void)sendUniqueOutcome:(CDVInvokedUrlCommand*)command {
-    NSString *name = command.arguments[0];
-
-    [OneSignal sendUniqueOutcome:name onSuccess:^(OSOutcomeEvent *outcome){
-        successCallback(command.callbackId, [outcome jsonRepresentation]);
-    }];
-}
-
 - (void)sendOutcome:(CDVInvokedUrlCommand*)command {
     NSString *name = command.arguments[0];
 
     [OneSignal sendOutcome:name onSuccess:^(OSOutcomeEvent *outcome){
+        successCallback(command.callbackId, [outcome jsonRepresentation]);
+    }];
+}
+
+- (void)sendUniqueOutcome:(CDVInvokedUrlCommand*)command {
+    NSString *name = command.arguments[0];
+
+    [OneSignal sendUniqueOutcome:name onSuccess:^(OSOutcomeEvent *outcome){
         successCallback(command.callbackId, [outcome jsonRepresentation]);
     }];
 }

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -409,41 +409,29 @@ static Class delegateClass = nil;
    [OneSignal pauseInAppMessages:pause];
 }
 
-- (void)sendOutcome:(CDVInvokedUrlCommand*)command {
-    // NSString *name = command.arguments[0];
+- (void)sendUniqueOutcome:(CDVInvokedUrlCommand*)command {
+    NSString *name = command.arguments[0];
 
-    // [OneSignal sendOutcome:name onSuccess:^(NSDictionary *result){
-    //     successCallback(command.callbackId, result);
-    // } onFailure:^(NSError *error){
-    //     failureCallback(command.callbackId, error.userInfo);
-    // }]
-    [OneSignal onesignal_Log:ONE_S_LL_WARN message:@"Method sendOutcome() not yet implemented for iOS!"];
-    successCallback(command.callbackId, @{});
+    [OneSignal sendUniqueOutcome:name onSuccess:^(OSOutcomeEvent *outcome){
+        successCallback(command.callbackId, [outcome jsonRepresentation]);
+    }];
 }
 
-- (void)sendUniqueOutcome:(CDVInvokedUrlCommand*)command {
-    // NSString *name = command.arguments[0];
+- (void)sendOutcome:(CDVInvokedUrlCommand*)command {
+    NSString *name = command.arguments[0];
 
-    // [OneSignal sendUniqueOutcome:name onSuccess:^(NSDictionary *result){
-    //     successCallback(command.callbackId, result);
-    // } onFailure:^(NSError *error){
-    //     failureCallback(command.callbackId, error.userInfo);
-    // }]
-    [OneSignal onesignal_Log:ONE_S_LL_WARN message:@"Method sendUniqueOutcome() not yet implemented for iOS!"];
-    successCallback(command.callbackId, @{});
+    [OneSignal sendOutcome:name onSuccess:^(OSOutcomeEvent *outcome){
+        successCallback(command.callbackId, [outcome jsonRepresentation]);
+    }];
 }
 
 - (void)sendOutcomeWithValue:(CDVInvokedUrlCommand*)command {
-    // NSString *name = command.arguments[0];
-    // NSNumber *value = command.arguments[1];
+    NSString *name = command.arguments[0];
+    NSNumber *value = command.arguments[1];
 
-    // [OneSignal sendOutcomeWithValue:name value:value onSuccess:^(NSDictionary *result){
-    //     successCallback(command.callbackId, result);
-    // } onFailure:^(NSError *error){
-    //     failureCallback(command.callbackId, error.userInfo);
-    // }]
-    [OneSignal onesignal_Log:ONE_S_LL_WARN message:@"Method sendOutcomeWithValue() not yet implemented for iOS!"];
-    successCallback(command.callbackId, @{});
+    [OneSignal sendOutcomeWithValue:name value:value onSuccess:^(OSOutcomeEvent *outcome){
+        successCallback(command.callbackId, [outcome jsonRepresentation]);
+    }];
 }
 
 @end


### PR DESCRIPTION
Added iOS implementation for Outcomes in bridge

### New Methods
- `sendUniqueOutcome`
- `sendOutcome`
- `sendOutcomeWithValue`

Use `[outcome jsonRepresentation]` to convert the `OSOutcomeEvent` to `NSDictionary` (must be implemented on native side)