### PR TITLE
Make IAM action data format consistent across iOS & Android

### DIFF
--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -377,10 +377,10 @@ static Class delegateClass = nil;
 - (void)setInAppMessageClickHandler:(CDVInvokedUrlCommand*)command {
     [OneSignal setInAppMessageClickHandler:^(OSInAppMessageAction* action) {
             NSDictionary *result = @{
-            @"clickName": action.clickName ?: [NSNull null],
-            @"clickUrl" : action.clickUrl.absoluteString ?: [NSNull null],
-            @"firstClick" : @(action.firstClick),
-            @"closesMessage" : @(action.closesMessage)
+            @"click_name": action.clickName ?: [NSNull null],
+            @"click_url" : action.clickUrl.absoluteString ?: [NSNull null],
+            @"first_click" : @(action.firstClick),
+            @"closes_message" : @(action.closesMessage)
             };
             successCallback(command.callbackId, result);
         }


### PR DESCRIPTION
### Motivation
IAM action data format should be the same across iOS & Android.
Before this change, the data format on iOS is:

```
{  
    "clickName": "somestring",  
    "firstClick": true,  
    "closesMessage": true,  
    "clickUrl": null  
}
```

It should be:

```
{  
    "click_name": "somestring",  
    "first_click": true,  
    "closes_message": true  
}
```

Closes #582 