### PR TITLE
2.8.1 Release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.8.0",
+  "version": "2.8.1",
 
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="2.8.0">
+    version="2.8.1">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -26,7 +26,7 @@
   </engines>
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:3.12.3" />
+    <framework src="com.onesignal:OneSignal:3.12.4" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
 
     <config-file target="res/xml/config.xml" parent="/*">
@@ -88,7 +88,7 @@
       <string>production</string>
     </config-file>
 
-    <framework src="OneSignal" type="podspec" spec="2.12.2" />
+    <framework src="OneSignal" type="podspec" spec="2.12.3" />
     <header-file src="src/ios/OneSignalPush.h" />
     <source-file src="src/ios/OneSignalPush.m" />
 


### PR DESCRIPTION
Updated native SDK versions:
- Android SDK: 3.12.4
   - Sending custom outcome from notification opened handler will use the previous session instead of current
   - Updated Unity Proxy file

- iOS: 2.12.3
   - Fixed Carthage build issue
   - Fixed missing i386 for 32 bit iOS simulators
   - Fixed Confirmed Deliveries not sending for those updating from an older SDK.