### PR TITLE
fix: use applicationId instead of PACKAGE_NAME

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -38,8 +38,8 @@
     <!-- PhoneGap Build (PGB) does not have a amazon build target so it include the required manifest entries in all Android builds. -->
     <config-file target="AndroidManifest.xml" parent="/manifest">
       <uses-permission android:name="com.amazon.device.messaging.permission.RECEIVE" />
-      <permission android:name="$PACKAGE_NAME.permission.RECEIVE_ADM_MESSAGE" android:protectionLevel="signature" />
-      <uses-permission android:name="$PACKAGE_NAME.permission.RECEIVE_ADM_MESSAGE" />
+      <permission android:name="${applicationId}.permission.RECEIVE_ADM_MESSAGE" android:protectionLevel="signature" />
+      <uses-permission android:name="${applicationId}.permission.RECEIVE_ADM_MESSAGE" />
     </config-file>
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
       <amazon:enable-feature android:name="com.amazon.device.messaging" android:required="false" xmlns:amazon="http://schemas.amazon.com/apk/res/android" />
@@ -50,7 +50,7 @@
         <intent-filter>
           <action android:name="com.amazon.device.messaging.intent.REGISTRATION" />
           <action android:name="com.amazon.device.messaging.intent.RECEIVE" />
-          <category android:name="$PACKAGE_NAME" />
+          <category android:name="${applicationId}" />
         </intent-filter>
       </receiver>
     </config-file>


### PR DESCRIPTION
if the cordova app has flavors (like debug and release version with different applicationId value), the PACKAGE_NAME value remains fixed to the value of the `id` in `config.xml`, and that causes problems when you try to install a different flavor of the app as there is another app (the other flavor) that already declared a push permission for that package name. 
By using the applicationId variable, each flavor will have it's own permission matching the application Id.

This was fixed in other push plugins long ago, check 
https://github.com/phonegap/phonegap-plugin-push/blob/master/plugin.xml#L31
https://github.com/Azure/azure-mobile-engagement-cordova/blob/master/plugin.xml#L140

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-cordova-sdk/642)
<!-- Reviewable:end -->
