### PR TITLE
Fix build error related to outcome event callback

### DIFF
--- a/src/android/com/plugin/gcm/OneSignalOutcomeController.java
+++ b/src/android/com/plugin/gcm/OneSignalOutcomeController.java
@@ -1,5 +1,7 @@
 package com.plugin.gcm;
 
+import android.util.Log;
+
 import com.onesignal.OneSignal;
 import com.onesignal.OutcomeEvent;
 import com.onesignal.OneSignal.OutcomeCallback;
@@ -12,17 +14,24 @@ import org.json.JSONObject;
 
 public class OneSignalOutcomeController {
 
+  private static final String TAG = "OneSignalOutcome";
+
   public static boolean sendUniqueOutcome(CallbackContext callbackContext, JSONArray data) {
     try {
       final CallbackContext jsSendUniqueOutcomeCallback = callbackContext;
-      String name = data.getString(0);
+      final String name = data.getString(0);
       OneSignal.sendUniqueOutcome(name, new OutcomeCallback(){
         @Override
         public void onSuccess(OutcomeEvent outcomeEvent) {
           if (outcomeEvent == null)
             CallbackHelper.callbackSuccess(jsSendUniqueOutcomeCallback, new JSONObject());
-          else
-            CallbackHelper.callbackSuccess(jsSendUniqueOutcomeCallback, outcomeEvent.toJSONObject());
+          else {
+            try {
+              CallbackHelper.callbackSuccess(jsSendUniqueOutcomeCallback, outcomeEvent.toJSONObject());
+            } catch (JSONException e) {
+              Log.e(TAG, "sendUniqueOutcome with name: " + name + ", failed with message: " + e.getMessage());
+            }
+          }
         }
       });
       return true;
@@ -35,14 +44,19 @@ public class OneSignalOutcomeController {
   public static boolean sendOutcome(CallbackContext callbackContext, JSONArray data) {
     try {
       final CallbackContext jsSendOutcomeCallback = callbackContext;
-      String name = data.getString(0);
+      final String name = data.getString(0);
       OneSignal.sendOutcome(name, new OutcomeCallback() {
         @Override
         public void onSuccess(OutcomeEvent outcomeEvent) {
           if (outcomeEvent == null)
             CallbackHelper.callbackSuccess(jsSendOutcomeCallback, new JSONObject());
-          else
-            CallbackHelper.callbackSuccess(jsSendOutcomeCallback, outcomeEvent.toJSONObject());
+          else {
+            try {
+              CallbackHelper.callbackSuccess(jsSendOutcomeCallback, outcomeEvent.toJSONObject());
+            } catch (JSONException e) {
+              Log.e(TAG, "sendOutcome with name: " + name + ", failed with message: " + e.getMessage());
+            }
+          }
         }
       });
       return true;
@@ -55,15 +69,20 @@ public class OneSignalOutcomeController {
   public static boolean sendOutcomeWithValue(CallbackContext callbackContext, JSONArray data) {
     try {
       final CallbackContext jsSendOutcomeWithValueCallback = callbackContext;
-      String name = data.getString(0);
-      float value = Double.valueOf(data.optDouble(1)).floatValue();
+      final String name = data.getString(0);
+      final float value = Double.valueOf(data.optDouble(1)).floatValue();
       OneSignal.sendOutcomeWithValue(name, value, new OutcomeCallback() {
         @Override
         public void onSuccess(OutcomeEvent outcomeEvent) {
           if (outcomeEvent == null)
             CallbackHelper.callbackSuccess(jsSendOutcomeWithValueCallback, new JSONObject());
-          else
-            CallbackHelper.callbackSuccess(jsSendOutcomeWithValueCallback, outcomeEvent.toJSONObject());
+          else {
+            try {
+              CallbackHelper.callbackSuccess(jsSendOutcomeWithValueCallback, outcomeEvent.toJSONObject());
+            } catch (JSONException e) {
+              Log.e(TAG, "sendOutcomeWithValue with name: " + name + " and value: " + value + ", failed with message: " + e.getMessage());
+            }
+          }
         }
       });
       return true;


### PR DESCRIPTION
* `OutcomeEvent.java` class in native SDK has a `toJSONObject` method
  * The `toJSONObject` used to have try-catch built into it, but this was removed so that the native controllers could take responsibility for error logging
  * Adding try-catch to the wrapper bridge now so that the error logging is handle from the wrapper bridge

Fixes #644