### PR TITLE
2.11.1 Release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.11.0",
+  "version": "2.11.1",
 
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="2.11.0">
+    version="2.11.1">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -26,7 +26,7 @@
   </engines>
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:3.15.1" />
+    <framework src="com.onesignal:OneSignal:3.15.3" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
 
     <config-file target="res/xml/config.xml" parent="/*">
@@ -88,7 +88,7 @@
       <string>production</string>
     </config-file>
 
-    <framework src="OneSignal" type="podspec" spec="2.14.3" />
+    <framework src="OneSignal" type="podspec" spec="2.15.2" />
     <header-file src="src/ios/OneSignalPush.h" />
     <source-file src="src/ios/OneSignalPush.m" />
 


### PR DESCRIPTION
## Release Notes
### Updated Native Android (`3.15.3`) and iOS (`2.15.2`) SDKs
* Android Native SDK Update `3.15.3`
  - [Release Notes 3.15.3](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/3.15.3)
  - [Release Notes 3.15.2](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/3.15.2)
* iOS Native SDK Update `2.15.2`
   - [Release Notes 2.15.2](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/2.15.2)