### PR TITLE
Fix set location shared always sending true

### DIFF
--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -229,7 +229,7 @@ static Class delegateClass = nil;
 }
     
 - (void)setLocationShared:(CDVInvokedUrlCommand *)command {
-   [OneSignal setLocationShared:command.arguments[0]];
+   [OneSignal setLocationShared:[command.arguments[0] boolValue]];
 }
 
 - (void)promptForPushNotificationsWithUserResponse:(CDVInvokedUrlCommand*)command {


### PR DESCRIPTION
We were not sending the location shared as a bool value so it was always true in the native code.

