### PR TITLE
Refactored JS setExternalUserId code

### DIFF
--- a/www/OneSignal.js
+++ b/www/OneSignal.js
@@ -283,22 +283,41 @@ OneSignal.prototype.provideUserConsent = function(granted) {
     cordova.exec(function() {}, function() {}, "OneSignalPush", "provideUserConsent", [granted]);
 };
 
+/** Possible function usages
+  setExternalUserId(externalId: string?): void
+  setExternalUserId(externalId: string?, callback: function): void
+  setExternalUserId(externalId: string?, externalIdAuthHash: string?, callback: function): void
+*/
 OneSignal.prototype.setExternalUserId = function(externalId, varArg1, varArg2) {
     if (externalId == undefined)
         externalId = null;
 
+    var externalIdAuthHash = null;
+    var callback = function() {};
+
     if (typeof varArg1 === "function") {
-        cordova.exec(varArg1, function() {}, "OneSignalPush", "setExternalUserId", [externalId]);
-        return;
+        // Method was called like setExternalUserId(externalId: string?, callback: function)
+        callback = varArg1;
+    }
+    else if (typeof varArg1 === "string") {
+        // Method was called like setExternalUserId(externalId: string?, externalIdAuthHash: string?, callback: function)
+        externalIdAuthHash = varArg1;
+        callback = varArg2;
+    }
+    else if (typeof varArg1 === "undefined") {
+        // Method was called like setExternalUserId(externalId: string?)
+        // Defaults defined above for externalIdAuthHash and callback
+    }
+    else {
+      // This does not catch all possible wrongly typed params but prevents a good number of them
+      console.error("Invalid param types passed to OneSignal.setExternalUserId(). Definition is setExternalUserId(externalId: string?, externalIdAuthHash: string?, callback?: function): void")
+      return;
     }
 
-    if (varArg1 == undefined && varArg2 == undefined) {
-        varArg1 = function() {};
-        cordova.exec(varArg1, function() {}, "OneSignalPush", "setExternalUserId", [externalId]);
-        return;
-    }
-
-    cordova.exec(externalUserIdCallback, function() {}, "OneSignalPush", "setExternalUserId", [externalId, varArg1]);
+    var passToNativeParams = [externalId];
+    if (externalIdAuthHash !== null)
+        passToNativeParams.push(externalIdAuthHash)
+    cordova.exec(callback, function() {}, "OneSignalPush", "setExternalUserId", passToNativeParams);
 };
 
 OneSignal.prototype.removeExternalUserId = function(externalUserIdCallback) {


### PR DESCRIPTION
* Refactored by parsing into local vars
* Fixes an issue with `externalUserIdCallback` not being defined

## Tested
Tested with Cordova-CLI 9.0.0
### iOS
Tested on iOS 14.2, with `cordova-ios 5.1.1` 
- [X] `setExternalUserId("test1");`
- [X] `setExternalUserId("test1", "auth_hash");`
- [X] `setExternalUserId("test1", "auth_hash", callbackFunction);`
- [X] `setExternalUserId("test5", {key: "WRONG PARAMS!!"});`

### Android
Test on Android 8.1, with `cordova-android 8.1.0`
- [X] `setExternalUserId("test1");`
- [X] `setExternalUserId("test1", "auth_hash");`
- [X] `setExternalUserId("test1", "auth_hash", callbackFunction);`
- [X] `setExternalUserId("test5", {key: "WRONG PARAMS!!"});`