### PR TITLE
Release 2.11.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.11.3",
+  "version": "2.11.4",
 
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="2.11.3">
+    version="2.11.4">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -26,7 +26,7 @@
   </engines>
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:3.15.7" />
+    <framework src="com.onesignal:OneSignal:3.16.0" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
 
     <config-file target="res/xml/config.xml" parent="/*">
@@ -88,7 +88,7 @@
       <string>production</string>
     </config-file>
 
-    <framework src="OneSignal" type="podspec" spec="2.16.2" />
+    <framework src="OneSignal" type="podspec" spec="2.16.5" />
     <header-file src="src/ios/OneSignalPush.h" />
     <source-file src="src/ios/OneSignalPush.m" />
 


### PR DESCRIPTION
## Release Notes

* Updated to native [OneSignal-Android-SDK 3.16.0](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/3.16.0)
  - Fixes Compatibility with FCM (Firebase Messaging) 22.0.0.
      - Fixes `Failed resolution of: Lcom/google/firebase/iid/FirebaseInstanceId;` error.
* Updated to native [OneSignal-iOS-SDK 2.16.5](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/2.16.5)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-cordova-sdk/705)
<!-- Reviewable:end -->
