### PR TITLE
Added methods for setLanguage feature

### DIFF
--- a/src/android/com/onesignal/cordova/OneSignalController.java
+++ b/src/android/com/onesignal/cordova/OneSignalController.java
@@ -48,6 +48,17 @@ public class OneSignalController {
     }
   }
 
+  public static boolean setLanguage(JSONArray data) {
+    try {
+      OneSignal.setLanguage(data.getString(0));
+      return true;
+    }
+    catch (Throwable t) {
+      t.printStackTrace();
+      return false;
+    }
+  }
+  
   /**
    * Tags
    */

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -53,6 +53,8 @@ public class OneSignalPush extends CordovaPlugin {
 
   private static final String GET_DEVICE_STATE = "getDeviceState";
 
+  private static final String SET_LANGUAGE = "setLanguage";
+
   private static final String ADD_PERMISSION_OBSERVER = "addPermissionObserver";
   private static final String ADD_SUBSCRIPTION_OBSERVER = "addSubscriptionObserver";
   private static final String ADD_EMAIL_SUBSCRIPTION_OBSERVER = "addEmailSubscriptionObserver";
@@ -166,6 +168,10 @@ public class OneSignalPush extends CordovaPlugin {
 
       case GET_DEVICE_STATE:
         result = OneSignalController.getDeviceState(callbackContext);
+        break;
+
+      case SET_LANGUAGE:
+        result = OneSignalController.setLanguage(language);
         break;
 
       case ADD_PERMISSION_OBSERVER:

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -171,7 +171,7 @@ public class OneSignalPush extends CordovaPlugin {
         break;
 
       case SET_LANGUAGE:
-        result = OneSignalController.setLanguage(language);
+        result = OneSignalController.setLanguage(data);
         break;
 
       case ADD_PERMISSION_OBSERVER:

--- a/src/ios/OneSignalPush.h
+++ b/src/ios/OneSignalPush.h
@@ -100,4 +100,6 @@
 - (void)setLocationShared:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)isLocationShared:(CDVInvokedUrlCommand* _Nonnull)command;
 
+- (void)setLanguage:(CDVInvokedUrlCommand* _Nonnull)command;
+
 @end

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -235,6 +235,10 @@ static Class delegateClass = nil;
     successCallback(command.callbackId, [[OneSignal getDeviceState] jsonRepresentation]);
 }
 
+- (void)setLanguage:(CDVInvokedUrlCommand*)command {
+    [OneSignal setLanguage:command.arguments[0]];
+}
+
 - (void)addPermissionObserver:(CDVInvokedUrlCommand*)command {
     bool first = permissionObserverCallbackId  == nil;
     permissionObserverCallbackId = command.callbackId;

--- a/types/OneSignalPlugin.d.ts
+++ b/types/OneSignalPlugin.d.ts
@@ -113,6 +113,13 @@ export interface OneSignalPlugin {
     getDeviceState(): Promise<DeviceState>;
 
     /**
+     * Allows you to set the app defined language with the OneSignal SDK.
+     * @param  {string} language
+     * @returns void
+     */
+    setLanguage(language: string): void;
+
+    /**
      * Tag a user based on an app event of your choosing so they can be targeted later via segments.
      * @param  {string} key
      * @param  {string} value

--- a/www/OneSignalPlugin.js
+++ b/www/OneSignalPlugin.js
@@ -106,6 +106,10 @@ OneSignalPlugin.prototype.getDeviceState = function(deviceStateReceivedCallBack)
     window.cordova.exec(deviceStateCallback, function(){}, "OneSignalPush", "getDeviceState", []);
 };
 
+OneSignalPlugin.prototype.setLanguage = function(language) {
+    window.cordova.exec(function(){}, function(){}, "OneSignalPush", "setLanguage", [language]);
+}
+
 OneSignalPlugin.prototype.addSubscriptionObserver = function(callback) {
     OneSignalPlugin._subscriptionObserverList.push(callback);
     var subscriptionCallBackProcessor = function(state) {


### PR DESCRIPTION
Add setLanguage methods

- based off major_release_3.0.0 branch

Modified files by adding setLanguage() or calling setLanguage()
- OneSignalController.java 
- OneSignalPush.java
- OneSignalPush.h / OneSignalPush.m
- OneSignalPlugin.d.ts
- OneSignalPlugin.js

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-cordova-sdk/715)
<!-- Reviewable:end -->
