### PR TITLE
Major release 3.0.0 beta cut2 improvements

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -31,7 +31,7 @@
   <js-module src="www/Subscription.js" name="Subscription" />
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:4.3.3" />
+    <framework src="com.onesignal:OneSignal:4.4.1" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
 
     <config-file target="res/xml/config.xml" parent="/*">

--- a/plugin.xml
+++ b/plugin.xml
@@ -72,7 +72,16 @@
       <string>production</string>
     </config-file>
 
-    <framework src="OneSignal" type="podspec" spec="3.4.3" />
+    <podspec>
+        <config>
+            <source url="https://github.com/CocoaPods/Specs.git"/>
+            <source url="https://github.com/OneSignal/OneSignal-iOS-SDK.git"/>
+        </config>
+        <pods use-frameworks="true">
+            <pod name="OneSignal" spec="3.5.3" />
+        </pods>
+    </podspec>
+
     <header-file src="src/ios/OneSignalPush.h" />
     <source-file src="src/ios/OneSignalPush.m" />
 

--- a/types/Notification.d.ts
+++ b/types/Notification.d.ts
@@ -7,7 +7,7 @@ export interface OSNotification {
     sound           ?: string;
     title           ?: string;
     launchURL       ?: string;
-    rawPayload      : object | string; // platform bridges return different types
+    rawPayload      : object;
     actionButtons   ?: object[];
     additionalData  : object;
     notificationId  : string;

--- a/www/NotificationReceived.js
+++ b/www/NotificationReceived.js
@@ -10,7 +10,11 @@ function OSNotification (receivedEvent) {
     this.additionalData = receivedEvent.additionalData;
     /// A hashmap object representing the raw key/value
     /// properties of the push notification
-    this.rawPayload = receivedEvent.rawPayload;
+    if (typeof receivedEvent.rawPayload === 'string' || receivedEvent.rawPayload instanceof String) {
+        this.rawPayload = JSON.parse(receivedEvent.rawPayload);
+    } else {
+        this.rawPayload = receivedEvent.rawPayload;
+    }
     /// If set, he launch URL will be opened when the user
     /// taps on your push notification. You can control
     /// whether or not it opens in an in-app webview or


### PR DESCRIPTION
Remove framework deprecated config 
* Replace framework type="podspec" with <podspec> config

Standardize raw payload type to object
* Android was returning raw payload as String meanwhile iOS returned an object, make both return an object

Update Android version to 4.4.1
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-cordova-sdk/716)
<!-- Reviewable:end -->
