### PR TITLE
iOS - Switch to OneSignalXCFramework

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -78,7 +78,7 @@
             <source url="https://github.com/OneSignal/OneSignal-iOS-SDK.git"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignal" spec="3.5.3" />
+            <pod name="OneSignalXCFramework" spec="3.6.0" />
         </pods>
     </podspec>
 


### PR DESCRIPTION
* This supports M1 mac simulator builds
* Tested on an x86 mac with Cordova CLI 10.0.0, Cordova iOS  6.2.0, and Xcode 12.5.1 on iOS 14.4.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-cordova-sdk/720)
<!-- Reviewable:end -->
