### PR TITLE
Adding relevanceScore and interruptionLevel to OSNotification

### DIFF
--- a/types/Notification.d.ts
+++ b/types/Notification.d.ts
@@ -35,6 +35,8 @@ export interface OSNotification {
     attachments         ?: object;
     mutableContent      ?: boolean;
     contentAvailable    ?: string;
+    relevanceScore      ?: number;
+    interruptionLevel   ?: string;
 }
 
 /* N O T I F I C A T I O N   &   I A M   E V E N T S */

--- a/www/NotificationReceived.js
+++ b/www/NotificationReceived.js
@@ -190,6 +190,18 @@ function OSNotification (receivedEvent) {
     if (receivedEvent.contentAvailable) {
         this.contentAvailable = receivedEvent.contentAvailable;
     }
+    /// (iOS Only)
+    /// value between 0 and 1 for sorting notifications in a notification summary
+    if (receivedEvent.relevanceScore) {
+        this.relevanceScore = receivedEvent.relevanceScore;
+    }
+    /// (iOS Only)
+    /// The interruption level for the notification. This controls how the
+    /// notification will be displayed to the user if they are using focus modes
+    /// or notification summaries
+    if (receivedEvent.interruptionLevel) {
+        this.interruptionLevel = receivedEvent.interruptionLevel;
+    }
 }
   
 /// Represents a button sent as part of a push notification


### PR DESCRIPTION
iOS 15 notification properties are now available in the iOS native SDK. This PR adds them to the Cordova SDK's OSNotification object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-cordova-sdk/731)
<!-- Reviewable:end -->
