### PR TITLE
NotificationReceived.js naming and map function bug

### DIFF
--- a/www/NotificationReceived.js
+++ b/www/NotificationReceived.js
@@ -132,7 +132,7 @@ function OSNotification (receivedEvent) {
     /// Summary notifications grouped
     /// Notification payload will have the most recent notification received.
     if (receivedEvent.groupedNotifications && receivedEvent.groupedNotifications.length) {
-        this.groupedNotifications = receivedEvent.groupedNotificationss.map(function(num) {
+        this.groupedNotifications = receivedEvent.groupedNotifications.map(function(item) {
             return new OSNotification(item);
         });
     }


### PR DESCRIPTION
**Description:**
- We faced the bug in the opening push notification process for grouped messages. The examination of the source code revealed 2 small issues that was preventing push opening handler to execute

**How to reproduce:**
- We were able to reproduce it any time we tapped on grouped push notification.

**Stack trace:**
- Not a stakc trace but the image but it is very self explanatory
<img width="670" alt="Снимок экрана 2021-11-11 в 15 38 16" src="https://user-images.githubusercontent.com/20440405/141318253-372381d9-08ae-4752-bf42-df61d2d57480.png">

**General notes:**
- I think not much needed to say here, you can just check out the code and see what those issues are because they are very simple. Please let me know if this is something already fixed or something addressed, this was breaking our experience with pushes.

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-cordova-sdk/747)
<!-- Reviewable:end -->
