### PR TITLE
updated pod specs

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    id="onesignal-cordova-plugin"
-    version="3.0.0">
+  xmlns:android="http://schemas.android.com/apk/res/android" id="onesignal-cordova-plugin" version="3.0.0">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -35,7 +33,7 @@
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
 
     <config-file target="res/xml/config.xml" parent="/*">
-      <feature name="OneSignalPush" >
+      <feature name="OneSignalPush">
         <param name="android-package" value="com.onesignal.cordova.OneSignalPush" />
       </feature>
     </config-file>
@@ -73,13 +71,12 @@
     </config-file>
 
     <podspec>
-        <config>
-            <source url="https://github.com/CocoaPods/Specs.git"/>
-            <source url="https://github.com/OneSignal/OneSignal-iOS-SDK.git"/>
-        </config>
-        <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" spec="3.6.0" />
-        </pods>
+      <config>
+        <source url="https://cdn.cocoapods.org/"/>
+      </config>
+      <pods use-frameworks="true">
+        <pod name="OneSignalXCFramework" spec="3.6.0" />
+      </pods>
     </podspec>
 
     <header-file src="src/ios/OneSignalPush.h" />


### PR DESCRIPTION
Updated Cocoapods source URL according to the new CDN and long time issue:
apache/cordova-ios#738
The GitHub source is no longer supported (and was breaking the plugin setup). Tested on latest macOS and cordova-ios@6.1.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-cordova-sdk/748)
<!-- Reviewable:end -->
