### PR TITLE
updated Cocoapods source URL from CDN

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -74,8 +74,7 @@
 
     <podspec>
         <config>
-            <source url="https://github.com/CocoaPods/Specs.git"/>
-            <source url="https://github.com/OneSignal/OneSignal-iOS-SDK.git"/>
+            <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
             <pod name="OneSignalXCFramework" spec="3.6.0" />
@@ -88,4 +87,3 @@
   </platform>
 
 </plugin>
-


### PR DESCRIPTION
Updated Cocoapods source URL according to the new CDN and long time issue:
apache/cordova-ios#738
The GitHub source is no longer supported (and was breaking the plugin setup). Tested on latest macOS and cordova-ios@6.1.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-cordova-sdk/749)
<!-- Reviewable:end -->
