### PR TITLE
Add iOS only `setLaunchURLsInApp` function

### DIFF
--- a/src/android/com/onesignal/cordova/OneSignalController.java
+++ b/src/android/com/onesignal/cordova/OneSignalController.java
@@ -160,6 +160,11 @@ public class OneSignalController {
     return true;
   }
 
+  public static boolean setLaunchURLsInApp() {
+    // doesn't apply to Android
+    return true;
+  }
+
   public static boolean unsubscribeWhenNotificationsAreDisabled(JSONArray data) {
     try {
       OneSignal.unsubscribeWhenNotificationsAreDisabled(data.getBoolean(0));

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -74,6 +74,7 @@ public class OneSignalPush extends CordovaPlugin {
 
   private static final String DISABLE_PUSH = "disablePush";
   private static final String POST_NOTIFICATION = "postNotification";
+  private static final String SET_LAUNCH_URLS_IN_APP = "setLaunchURLsInApp";
 
   private static final String SET_EMAIL = "setEmail";
   private static final String SET_UNAUTHENTICATED_EMAIL = "setUnauthenticatedEmail";
@@ -232,6 +233,10 @@ public class OneSignalPush extends CordovaPlugin {
 
       case POST_NOTIFICATION:
         result = OneSignalController.postNotification(callbackContext, data);
+        break;
+
+      case SET_LAUNCH_URLS_IN_APP:
+        result = OneSignalController.setLaunchURLsInApp();
         break;
 
       case SET_LOG_LEVEL:

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -455,7 +455,7 @@ static Class delegateClass = nil;
  */
 
 - (void)setLaunchURLsInApp:(CDVInvokedUrlCommand *)command {
-    BOOL launchInApp = command.arguments[0];
+    BOOL launchInApp = [command.arguments[0] boolValue];
     [OneSignal setLaunchURLsInApp:launchInApp];
 }
 

--- a/types/OneSignalPlugin.d.ts
+++ b/types/OneSignalPlugin.d.ts
@@ -219,6 +219,14 @@ export interface OneSignalPlugin {
     removeGroupedNotifications(id: string): void;
 
     /**
+     * iOS only.
+     * This method can be used to set if launch URLs should be opened within the application or in Safari.
+     * @param  {boolean} isEnabled - false will open the link in Safari or user's default browser
+     * @returns void
+     */
+    setLaunchURLsInApp(isEnabled: boolean): void;
+
+    /**
      * Allows you to use your own system's user ID's to send push notifications to your users.
      * @param  {string} externalId
      * @param  {(results:object)=>void} handler

--- a/www/OneSignalPlugin.js
+++ b/www/OneSignalPlugin.js
@@ -213,6 +213,11 @@ OneSignalPlugin.prototype.postNotification = function(jsonData, onSuccess, onFai
     window.cordova.exec(onSuccess, onFailure, "OneSignalPush", "postNotification", [jsonData]);
 };
 
+// Only applies to iOS
+OneSignalPlugin.prototype.setLaunchURLsInApp = function(isEnabled) {
+    window.cordova.exec(function(){}, function(){}, "OneSignalPush", "setLaunchURLsInApp", [isEnabled]);
+};
+
 OneSignalPlugin.prototype.setLogLevel = function(nsLogLevel, visualLogLevel) {
     window.cordova.exec(function(){}, function(){}, "OneSignalPush", "setLogLevel", [nsLogLevel, visualLogLevel]);
 };


### PR DESCRIPTION
# Description
## One Line Summary
Adds the `setLaunchURLsInApp` function that is for iOS only.

## Details
The function, previously only available via the native iOS SDK, does the following:
> This method can be used to set if launch URLs should be opened in Safari or within the application. The default value is `true` which opens an in-app browser. Setting this to `false` will open in Safari or user's default browser if different.

## Test
* **iOS**: Tested on iPhone 13 using an example app calling `setLaunchURLsInApp` with both `true` and `false` and confirming where the Launch URL is opened.
* **Android**: Tested on emulator that no effects occurred with both `true` and `false`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-cordova-sdk/774)
<!-- Reviewable:end -->
