### PR TITLE
Add HMS support for Cordova applications

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -31,8 +31,8 @@
   <js-module src="www/Subscription.js" name="Subscription" />
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:4.6.7" />
-    <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
+    <framework src="com.onesignal:OneSignal:4.7.0" />
+    <framework src="src/android/build-extras.gradle" custom="true" type="gradleReference" />
 
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="OneSignalPush" >

--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -1,0 +1,5 @@
+gradle.afterProject { project ->
+   def androidManifest = new File("${project.rootDir}/app/src/main/AndroidManifest.xml")
+   String fileContentsReplaced = androidManifest.text.replaceFirst('<service .*android:name="com.huawei.hms.cordova.push.remote.HmsPushMessageService"(>[\\s]*<intent-filter>[\\s]*.*\\s]*<\\/intent-filter>[\\s]*<\\/service>|.*[\\s]\\/>){1}', "")
+   androidManifest.text = fileContentsReplaced
+}


### PR DESCRIPTION
* Since OneSignal relies on the HMS plugin to work, OneSignal SDK needs to remove the
com.huawei.hms.cordova.push.remote.HmsPushMessageService at build time from the
Manifest. Not removing this service avoid the notification being handled by OneSignal SDK
* Add build-extras.gradle file with Gradle task that removes the HMS plugin service