### PR TITLE
Add in app message lifecycle handler

### DIFF
--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -144,42 +144,26 @@ public class OneSignalPush extends CordovaPlugin {
     OneSignal.setInAppMessageLifecycleHandler(new OSInAppMessageLifecycleHandler() {
       @Override
       public void onWillDisplayInAppMessage(OSInAppMessage message) {
-        try {
-          if (jsInAppMessageWillDisplayCallback != null) {
-            CallbackHelper.callbackSuccess(jsInAppMessageWillDisplayCallback, message.toJSONObject());
-          }
-        } catch (Throwable t) {
-          t.printStackTrace();
+        if (jsInAppMessageWillDisplayCallback != null) {
+          CallbackHelper.callbackSuccess(jsInAppMessageWillDisplayCallback, message.toJSONObject());
         }
       }
       @Override
       public void onDidDisplayInAppMessage(OSInAppMessage message) {
-        try {
-          if (jsInAppMessageDidDisplayCallBack != null) {
-            CallbackHelper.callbackSuccess(jsInAppMessageDidDisplayCallBack, message.toJSONObject());
-          }
-        } catch (Throwable t) {
-          t.printStackTrace();
+        if (jsInAppMessageDidDisplayCallBack != null) {
+          CallbackHelper.callbackSuccess(jsInAppMessageDidDisplayCallBack, message.toJSONObject());
         }
       }
       @Override
       public void onWillDismissInAppMessage(OSInAppMessage message) {
-        try {
-          if (jsInAppMessageWillDismissCallback != null) {
-            CallbackHelper.callbackSuccess(jsInAppMessageWillDismissCallback, message.toJSONObject());
-          }
-        } catch (Throwable t) {
-          t.printStackTrace();
+        if (jsInAppMessageWillDismissCallback != null) {
+          CallbackHelper.callbackSuccess(jsInAppMessageWillDismissCallback, message.toJSONObject());
         }
       }
       @Override
       public void onDidDismissInAppMessage(OSInAppMessage message) {
-        try {
-          if (jsInAppMessageDidDismissCallBack != null) {
-            CallbackHelper.callbackSuccess(jsInAppMessageDidDismissCallBack, message.toJSONObject());
-          }
-        } catch (Throwable t) {
-          t.printStackTrace();
+        if (jsInAppMessageDidDismissCallBack != null) {
+          CallbackHelper.callbackSuccess(jsInAppMessageDidDismissCallBack, message.toJSONObject());
         }
       }
     });

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -30,6 +30,8 @@ package com.onesignal.cordova;
 import android.util.Log;
 
 import com.onesignal.OSInAppMessageAction;
+import com.onesignal.OSInAppMessage;
+import com.onesignal.OSInAppMessageLifecycleHandler;
 import com.onesignal.OSNotification;
 import com.onesignal.OSNotificationOpenedResult;
 import com.onesignal.OSNotificationReceivedEvent;
@@ -48,6 +50,13 @@ public class OneSignalPush extends CordovaPlugin {
   private static final String SET_NOTIFICATION_WILL_SHOW_IN_FOREGROUND_HANDLER = "setNotificationWillShowInForegroundHandler";
   private static final String SET_NOTIFICATION_OPENED_HANDLER = "setNotificationOpenedHandler";
   private static final String SET_IN_APP_MESSAGE_CLICK_HANDLER = "setInAppMessageClickHandler";
+
+  private static final String SET_IN_APP_MESSAGE_LIFECYCLE_HANDLER = "setInAppMessageLifecycleHandler";
+  private static final String SET_ON_WILL_DISPLAY_IN_APP_MESSAGE_HANDLER = "setOnWillDisplayInAppMessageHandler";
+  private static final String SET_ON_DID_DISPLAY_IN_APP_MESSAGE_HANDLER = "setOnDidDisplayInAppMessageHandler";
+  private static final String SET_ON_WILL_DISMISS_IN_APP_MESSAGE_HANDLER = "setOnWillDismissInAppMessageHandler";
+  private static final String SET_ON_DID_DISMISS_IN_APP_MESSAGE_HANDLER = "setOnDidDismissInAppMessageHandler";
+
   private static final String COMPLETE_NOTIFICATION = "completeNotification";
   private static final String INIT = "init";
 
@@ -111,6 +120,11 @@ public class OneSignalPush extends CordovaPlugin {
 
   private static final HashMap<String, OSNotificationReceivedEvent> notificationReceivedEventCache = new HashMap<>();
 
+  private static CallbackContext jsInAppMessageWillDisplayCallback;
+  private static CallbackContext jsInAppMessageDidDisplayCallBack;
+  private static CallbackContext jsInAppMessageWillDismissCallback;
+  private static CallbackContext jsInAppMessageDidDismissCallBack;
+
   public boolean setNotificationWillShowInForegroundHandler(CallbackContext callbackContext) {
     OneSignal.setNotificationWillShowInForegroundHandler(new CordovaNotificationInForegroundHandler(callbackContext));
     return true;
@@ -123,6 +137,72 @@ public class OneSignalPush extends CordovaPlugin {
 
   public boolean setInAppMessageClickHandler(CallbackContext callbackContext) {
     OneSignal.setInAppMessageClickHandler(new CordovaInAppMessageClickHandler(callbackContext));
+    return true;
+  }
+
+  public boolean setInAppMessageLifecycleHandler() {
+    OneSignal.setInAppMessageLifecycleHandler(new OSInAppMessageLifecycleHandler() {
+      @Override
+      public void onWillDisplayInAppMessage(OSInAppMessage message) {
+        try {
+          if (jsInAppMessageWillDisplayCallback != null) {
+            CallbackHelper.callbackSuccess(jsInAppMessageWillDisplayCallback, message.toJSONObject());
+          }
+        } catch (Throwable t) {
+          t.printStackTrace();
+        }
+      }
+      @Override
+      public void onDidDisplayInAppMessage(OSInAppMessage message) {
+        try {
+          if (jsInAppMessageDidDisplayCallBack != null) {
+            CallbackHelper.callbackSuccess(jsInAppMessageDidDisplayCallBack, message.toJSONObject());
+          }
+        } catch (Throwable t) {
+          t.printStackTrace();
+        }
+      }
+      @Override
+      public void onWillDismissInAppMessage(OSInAppMessage message) {
+        try {
+          if (jsInAppMessageWillDismissCallback != null) {
+            CallbackHelper.callbackSuccess(jsInAppMessageWillDismissCallback, message.toJSONObject());
+          }
+        } catch (Throwable t) {
+          t.printStackTrace();
+        }
+      }
+      @Override
+      public void onDidDismissInAppMessage(OSInAppMessage message) {
+        try {
+          if (jsInAppMessageDidDismissCallBack != null) {
+            CallbackHelper.callbackSuccess(jsInAppMessageDidDismissCallBack, message.toJSONObject());
+          }
+        } catch (Throwable t) {
+          t.printStackTrace();
+        }
+      }
+    });
+    return true;
+  }
+
+  public boolean setOnWillDisplayInAppMessageHandler(CallbackContext callbackContext) {
+    jsInAppMessageWillDisplayCallback = callbackContext;
+    return true;
+  }
+
+  public boolean setOnDidDisplayInAppMessageHandler(CallbackContext callbackContext) {
+    jsInAppMessageDidDisplayCallBack = callbackContext;
+    return true;
+  }
+
+  public boolean setOnWillDismissInAppMessageHandler(CallbackContext callbackContext) {
+    jsInAppMessageWillDismissCallback = callbackContext;
+    return true;
+  }
+
+  public boolean setOnDidDismissInAppMessageHandler(CallbackContext callbackContext) {
+    jsInAppMessageDidDismissCallBack = callbackContext;
     return true;
   }
 
@@ -157,6 +237,26 @@ public class OneSignalPush extends CordovaPlugin {
 
       case SET_IN_APP_MESSAGE_CLICK_HANDLER:
         result = setInAppMessageClickHandler(callbackContext);
+        break;
+
+      case SET_IN_APP_MESSAGE_LIFECYCLE_HANDLER:
+        result = setInAppMessageLifecycleHandler();
+        break;
+
+      case SET_ON_WILL_DISPLAY_IN_APP_MESSAGE_HANDLER:
+        result = setOnWillDisplayInAppMessageHandler(callbackContext);
+        break;
+
+      case SET_ON_DID_DISPLAY_IN_APP_MESSAGE_HANDLER:
+        result = setOnDidDisplayInAppMessageHandler(callbackContext);
+        break;
+
+      case SET_ON_WILL_DISMISS_IN_APP_MESSAGE_HANDLER:
+        result = setOnWillDismissInAppMessageHandler(callbackContext);
+        break;
+
+      case SET_ON_DID_DISMISS_IN_APP_MESSAGE_HANDLER:
+        result = setOnDidDismissInAppMessageHandler(callbackContext);
         break;
 
       case COMPLETE_NOTIFICATION:

--- a/src/ios/OneSignalPush.h
+++ b/src/ios/OneSignalPush.h
@@ -31,7 +31,7 @@
 
 #import <OneSignal/OneSignal.h>
 
-@interface OneSignalPush : CDVPlugin <OSPermissionObserver, OSSubscriptionObserver, OSEmailSubscriptionObserver, OSSMSSubscriptionObserver>
+@interface OneSignalPush : CDVPlugin <OSPermissionObserver, OSSubscriptionObserver, OSEmailSubscriptionObserver, OSSMSSubscriptionObserver, OSInAppMessageLifecycleHandler>
 
 - (void)setProvidesNotificationSettingsView:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)setNotificationWillShowInForegroundHandler:(CDVInvokedUrlCommand* _Nonnull)command;
@@ -85,6 +85,11 @@
 // In App Message
 - (void)setLaunchURLsInApp:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)setInAppMessageClickHandler:(CDVInvokedUrlCommand* _Nonnull)command;
+- (void)setInAppMessageLifecycleHandler:(CDVInvokedUrlCommand* _Nonnull)command;
+- (void)setOnWillDisplayInAppMessageHandler:(CDVInvokedUrlCommand* _Nonnull)command;
+- (void)setOnDidDisplayInAppMessageHandler:(CDVInvokedUrlCommand* _Nonnull)command;
+- (void)setOnWillDismissInAppMessageHandler:(CDVInvokedUrlCommand* _Nonnull)command;
+- (void)setOnDidDismissInAppMessageHandler:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)addTriggers:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)removeTriggersForKeys:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)getTriggerValueForKey:(CDVInvokedUrlCommand* _Nonnull)command;

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -50,6 +50,11 @@ NSString* logoutSMSNumberCallbackId;
 NSString* emailSubscriptionCallbackId;
 NSString* smsSubscriptionCallbackId;
 
+NSString* inAppMessageWillDisplayCallbackId;
+NSString* inAppMessageDidDisplayCallbackId;
+NSString* inAppMessageWillDismissCallbackId;
+NSString* inAppMessageDidDismissCallbackId;
+
 OSNotificationOpenedResult* actionNotification;
 OSNotification *notification;
 
@@ -470,6 +475,50 @@ static Class delegateClass = nil;
             successCallback(command.callbackId, result);
         }
     ];
+}
+
+- (void)setInAppMessageLifecycleHandler:(CDVInvokedUrlCommand *)command {
+    [OneSignal setInAppMessageLifecycleHandler:self];
+}
+
+- (void)setOnWillDisplayInAppMessageHandler:(CDVInvokedUrlCommand*)command {
+    inAppMessageWillDisplayCallbackId = command.callbackId;
+}
+
+- (void)setOnDidDisplayInAppMessageHandler:(CDVInvokedUrlCommand*)command {
+    inAppMessageDidDisplayCallbackId = command.callbackId;
+}
+
+- (void)setOnWillDismissInAppMessageHandler:(CDVInvokedUrlCommand*)command {
+    inAppMessageWillDismissCallbackId = command.callbackId;
+}
+
+- (void)setOnDidDismissInAppMessageHandler:(CDVInvokedUrlCommand*)command {
+    inAppMessageDidDismissCallbackId = command.callbackId;
+}
+
+- (void)onWillDisplayInAppMessage:(OSInAppMessage * _Nonnull)message {
+    if (inAppMessageWillDisplayCallbackId != nil) {
+        successCallback(inAppMessageWillDisplayCallbackId, [message jsonRepresentation]);
+    }
+}
+
+- (void)onDidDisplayInAppMessage:(OSInAppMessage * _Nonnull)message {
+    if (inAppMessageDidDisplayCallbackId != nil) {
+        successCallback(inAppMessageDidDisplayCallbackId, [message jsonRepresentation]);
+    }
+}
+
+- (void)onWillDismissInAppMessage:(OSInAppMessage * _Nonnull)message {
+    if (inAppMessageWillDismissCallbackId != nil) {
+        successCallback(inAppMessageWillDismissCallbackId, [message jsonRepresentation]);
+    }
+}
+
+- (void)onDidDismissInAppMessage:(OSInAppMessage * _Nonnull)message {
+    if (inAppMessageDidDismissCallbackId != nil) {
+        successCallback(inAppMessageDidDismissCallbackId, [message jsonRepresentation]);
+    }
 }
 
 - (void)addTriggers:(CDVInvokedUrlCommand*)command {

--- a/types/InAppMessage.d.ts
+++ b/types/InAppMessage.d.ts
@@ -4,3 +4,14 @@ export interface InAppMessageAction {
     click_name      ?: string;
     click_url       ?: string;
 }
+
+export interface OSInAppMessage {
+    messageId : string
+}
+
+export interface InAppMessageLifecycleHandlerObject {
+    onWillDisplayInAppMessage       ?: (message: InAppMessage) => void;
+    onDidDisplayInAppMessage        ?: (message: InAppMessage) => void;
+    onWillDismissInAppMessage       ?: (message: InAppMessage) => void;
+    onDidDismissInAppMessage        ?: (message: InAppMessage) => void;
+}

--- a/types/OneSignalPlugin.d.ts
+++ b/types/OneSignalPlugin.d.ts
@@ -1,6 +1,6 @@
 import { NotificationReceivedEvent, OpenedEvent, OpenedEventAction } from './Notification';
 import { OutcomeEvent } from './Outcomes';
-import { InAppMessageAction } from './InAppMessage';
+import { InAppMessageAction, InAppMessageLifecycleHandlerObject } from './InAppMessage';
 import { PermissionChange, SubscriptionChange, EmailSubscriptionChange, SMSSubscriptionChange, DeviceState } from './Subscription';
 import { LogLevel, ChangeEvent } from './Extras';
 
@@ -247,6 +247,13 @@ export interface OneSignalPlugin {
      * @returns void
      */
     setInAppMessageClickHandler(handler: (action: InAppMessageAction) => void): void;
+
+    /**
+     * Sets the In-App Message lifecycle handler object to run on displaying and/or dismissing an In-App Message.
+     * @param  {InAppMessageLifecycleHandlerObject} handlerObject
+     * @returns void
+     */
+    setInAppMessageLifecycleHandler(handlerObject: InAppMessageLifecycleHandlerObject) : void;
 
     /**
      * Add an In-App Message Trigger.

--- a/www/InAppMessage.js
+++ b/www/InAppMessage.js
@@ -5,4 +5,11 @@ function OSInAppMessageAction (json) {
     this.closesMessage = json.closes_message;
 }
 
-module.exports = OSInAppMessageAction;
+function OSInAppMessage (json) {
+    this.messageId = json.messageId;
+}
+
+module.exports = {
+    OSInAppMessageAction: OSInAppMessageAction,
+    OSInAppMessage: OSInAppMessage
+};

--- a/www/OneSignalPlugin.js
+++ b/www/OneSignalPlugin.js
@@ -27,7 +27,8 @@
 
 var OSNotificationReceivedEvent = require('./NotificationReceived').OSNotificationReceivedEvent;
 var OSNotificationOpenedResult = require('./NotificationOpened');
-var OSInAppMessageAction = require('./InAppMessage');
+var OSInAppMessageAction = require('./InAppMessage').OSInAppMessageAction;
+var OSInAppMessage = require('./InAppMessage').OSInAppMessage;
 var OSDeviceState = require('./Subscription').OSDeviceState;
 var OSPermissionStateChanges = require('./Subscription').OSPermissionStateChanges;
 var OSSubscriptionStateChanges = require('./Subscription').OSSubscriptionStateChanges;
@@ -39,6 +40,10 @@ var OneSignalPlugin = function() {
     var _notificationWillShowInForegroundDelegate = function(notificationReceived) {};
     var _notificationOpenedDelegate = function(notificationOpened) {};
     var _inAppMessageClickDelegate = function (action) {};
+    var _onWillDisplayInAppMessageDelegate = function(message) {};
+    var _onDidDisplayInAppMessageDelegate = function(message) {};
+    var _onWillDismissInAppMessageDelegate = function(message) {};
+    var _onDidDismissInAppMessageDelegate = function(message) {};
 };
 
 OneSignalPlugin.prototype.OSNotificationPermission = {
@@ -88,6 +93,47 @@ OneSignalPlugin.prototype.setInAppMessageClickHandler = function(handler) {
     };
 
     window.cordova.exec(inAppMessageClickHandler, function() {}, "OneSignalPush", "setInAppMessageClickHandler", []);
+};
+
+OneSignalPlugin.prototype.setInAppMessageLifecycleHandler = function(handlerObject) {
+    if (handlerObject.onWillDisplayInAppMessage) {
+        OneSignalPlugin._onWillDisplayInAppMessageDelegate = handlerObject.onWillDisplayInAppMessage;
+
+        var onWillDisplayInAppMessageHandler = function(json) {
+            OneSignalPlugin._onWillDisplayInAppMessageDelegate(new OSInAppMessage(json));
+        };
+
+        window.cordova.exec(onWillDisplayInAppMessageHandler, function() {}, "OneSignalPush", "setOnWillDisplayInAppMessageHandler", []);
+    }
+    if (handlerObject.onDidDisplayInAppMessage) {
+        OneSignalPlugin._onDidDisplayInAppMessageDelegate = handlerObject.onDidDisplayInAppMessage;
+
+        var onDidDisplayInAppMessageHandler = function(json) {
+            OneSignalPlugin._onDidDisplayInAppMessageDelegate(new OSInAppMessage(json));
+        };
+
+        window.cordova.exec(onDidDisplayInAppMessageHandler, function() {}, "OneSignalPush", "setOnDidDisplayInAppMessageHandler", []);
+    }
+    if (handlerObject.onWillDismissInAppMessage) {
+        OneSignalPlugin._onWillDismissInAppMessageDelegate = handlerObject.onWillDismissInAppMessage;
+
+        var onWillDismissInAppMessageHandler = function(json) {
+            OneSignalPlugin._onWillDismissInAppMessageDelegate(new OSInAppMessage(json));
+        };
+
+        window.cordova.exec(onWillDismissInAppMessageHandler, function() {}, "OneSignalPush", "setOnWillDismissInAppMessageHandler", []);
+    }
+    if (handlerObject.onDidDismissInAppMessage) {
+        OneSignalPlugin._onDidDismissInAppMessageDelegate = handlerObject.onDidDismissInAppMessage;
+
+        var onDidDismissInAppMessageHandler = function(json) {
+            OneSignalPlugin._onDidDismissInAppMessageDelegate(new OSInAppMessage(json));
+        };
+
+        window.cordova.exec(onDidDismissInAppMessageHandler, function() {}, "OneSignalPush", "setOnDidDismissInAppMessageHandler", []);
+    }
+
+    window.cordova.exec(function() {}, function() {}, "OneSignalPush", "setInAppMessageLifecycleHandler", []);
 };
 
 OneSignalPlugin._processFunctionList = function(array, param) {


### PR DESCRIPTION
# Description
## One Line Summary
Adds the In-App Message Lifecycle Handler which includes up to 4 callbacks for the displaying and dismissing of In-App Messages.

## Details
### Motivation
This handler was added to give customers visibility into the display lifecycle of IAMs: when an IAM will be displayed, and also when it has been dismissed. 

### Scope
- Added the `OSInAppMessage` and `InAppMessageLifecycleHandlerObject` interfaces.
- Add the public function `setInAppMessageLifecycleHandler(InAppMessageLifecycleHandlerObject handlerObject)` which will internally call up to 4 handlers: 
  - `setOnWillDisplayInAppMessageHandler`
  - `setOnDidDisplayInAppMessageHandler`
  - `setOnWillDismissInAppMessageHandler`
  - `setOnDidDismissInAppMessageHandler`
- Setting these separate internal handlers seem to be needed as we don't simply send a string event name such as "OneSignal#onWillDisplayInAppMessage" for Flutter or "OneSignal-inAppMessageWillDisplay" for React Native over the bridge.

### Public API Changes
Yes, the documentation will need to be updated for the Cordova SDK to provide this new method `setInAppMessageLifecycleHandler(InAppMessageLifecycleHandlerObject handlerObject)` and the interfaces `OSInAppMessage` and `InAppMessageLifecycleHandlerObject`

# Testing
## Manual testing
Ran the code in a minimal Cordova example app on Android and iOS emulators.
- [x] Tested setting all 4 callbacks and seeing them triggered in order.
- [x] Tested setting only 2 of the 4 callbacks and seeing them triggered in order, and no other errors appear.
- [x] Tested swiping away the IAM and also clicking on a close button (this led me to find a native iOS issue below).

## Native iOS may trigger the willDismiss callback twice
When tapping on a close button on an IAM, `jsEventOccurredWithBody` appears to be called twice, and triggering `dismissCurrentInAppMessage` twice.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [X] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed (N/A)
   - [ ] All automated tests pass, or I explained why that is not possible (N/A)
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-cordova-sdk/782)
<!-- Reviewable:end -->
