### PR TITLE
Fix types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,3 @@
 import { OneSignalPlugin } from './OneSignalPlugin';
-export declare const OneSignal: OneSignalPlugin;
 export { OneSignalPlugin };
 export default OneSignal;


### PR DESCRIPTION
The types contain an incorrect type, declaring that this kind of import is possible:

`import { OneSignal } from 'onesignal-cordova-plugin'`

This statement is incorrect, as the javascript lib only exports the entire OneSignal object, so this statement is actually the correct one to use:

`import OneSignal from 'onesignal-cordova-plugin'`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-cordova-sdk/785)
<!-- Reviewable:end -->
