### PR TITLE
Fix wrong `message` type

### DIFF
--- a/types/InAppMessage.d.ts
+++ b/types/InAppMessage.d.ts
@@ -10,8 +10,8 @@ export interface OSInAppMessage {
 }
 
 export interface InAppMessageLifecycleHandlerObject {
-    onWillDisplayInAppMessage       ?: (message: InAppMessage) => void;
-    onDidDisplayInAppMessage        ?: (message: InAppMessage) => void;
-    onWillDismissInAppMessage       ?: (message: InAppMessage) => void;
-    onDidDismissInAppMessage        ?: (message: InAppMessage) => void;
+    onWillDisplayInAppMessage       ?: (message: OSInAppMessage) => void;
+    onDidDisplayInAppMessage        ?: (message: OSInAppMessage) => void;
+    onWillDismissInAppMessage       ?: (message: OSInAppMessage) => void;
+    onDidDismissInAppMessage        ?: (message: OSInAppMessage) => void;
 }


### PR DESCRIPTION
Bug introduced on https://github.com/OneSignal/OneSignal-Cordova-SDK/pull/782, cc: @nan-li 

```zsh
Error: node_modules/onesignal-cordova-plugin/types/InAppMessage.d.ts:13:50 - error TS2552: Cannot find name 'InAppMessage'. Did you mean 'OSInAppMessage'?

13     onWillDisplayInAppMessage       ?: (message: InAppMessage) => void;
                                                    ~~~~~~~~~~~~


Error: node_modules/onesignal-cordova-plugin/types/InAppMessage.d.ts:14:50 - error TS2552: Cannot find name 'InAppMessage'. Did you mean 'OSInAppMessage'?

14     onDidDisplayInAppMessage        ?: (message: InAppMessage) => void;
                                                    ~~~~~~~~~~~~


Error: node_modules/onesignal-cordova-plugin/types/InAppMessage.d.ts:15:50 - error TS2552: Cannot find name 'InAppMessage'. Did you mean 'OSInAppMessage'?

15     onWillDismissInAppMessage       ?: (message: InAppMessage) => void;
                                                    ~~~~~~~~~~~~


Error: node_modules/onesignal-cordova-plugin/types/InAppMessage.d.ts:16:50 - error TS2552: Cannot find name 'InAppMessage'. Did you mean 'OSInAppMessage'?

16     onDidDismissInAppMessage        ?: (message: InAppMessage) => void;
                                                    ~~~~~~~~~~~~




✖ Failed to compile.
```
