### PR TITLE
[Feature] Set language callback

### DIFF
--- a/src/android/com/onesignal/cordova/OneSignalController.java
+++ b/src/android/com/onesignal/cordova/OneSignalController.java
@@ -3,6 +3,8 @@ package com.onesignal.cordova;
 import com.onesignal.OSDeviceState;
 import com.onesignal.OneSignal;
 import com.onesignal.OneSignal.PostNotificationResponseHandler;
+import com.onesignal.OneSignal.OSSetLanguageCompletionHandler;
+import com.onesignal.OneSignal.OSLanguageError;
 
 import org.apache.cordova.CallbackContext;
 import org.json.JSONArray;
@@ -48,9 +50,31 @@ public class OneSignalController {
     }
   }
 
-  public static boolean setLanguage(JSONArray data) {
+  public static boolean setLanguage(CallbackContext callbackContext, JSONArray data) {
     try {
-      OneSignal.setLanguage(data.getString(0));
+      final CallbackContext jsSetLanguageCallback = callbackContext;
+      OneSignal.setLanguage(data.getString(0), new OSSetLanguageCompletionHandler() {
+        @Override
+        public void onSuccess(String response) {
+          try{
+            JSONObject responseJson = new JSONObject(response);
+            CallbackHelper.callbackSuccess(jsSetLanguageCallback, new JSONObject());
+          }
+          catch (JSONException e) {
+            e.printStackTrace();
+          }
+        }
+
+        @Override
+        public void onFailure(OSLanguageError error) {
+          try {
+            JSONObject errorObject = new JSONObject("{'error' : '" + error.getMessage() + "'}");
+            CallbackHelper.callbackError(jsSetLanguageCallback, errorObject);
+          } catch (JSONException e) {
+              e.printStackTrace();
+          }
+        }
+      });
       return true;
     }
     catch (Throwable t) {

--- a/src/android/com/onesignal/cordova/OneSignalController.java
+++ b/src/android/com/onesignal/cordova/OneSignalController.java
@@ -57,8 +57,11 @@ public class OneSignalController {
         @Override
         public void onSuccess(String response) {
           try{
-            JSONObject responseJson = new JSONObject(response);
-            CallbackHelper.callbackSuccess(jsSetLanguageCallback, new JSONObject());
+            JSONObject responseJson = new JSONObject("{'success' : 'true'}");
+            if(response != null) {
+              responseJson = new JSONObject(response);
+            }
+            CallbackHelper.callbackSuccess(jsSetLanguageCallback, responseJson);
           }
           catch (JSONException e) {
             e.printStackTrace();

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -256,7 +256,7 @@ public class OneSignalPush extends CordovaPlugin {
         break;
 
       case SET_LANGUAGE:
-        result = OneSignalController.setLanguage(data);
+        result = OneSignalController.setLanguage(callbackContext, data);
         break;
 
       case ADD_PERMISSION_OBSERVER:

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -33,6 +33,7 @@
 
 NSString* notificationWillShowInForegoundCallbackId;
 NSString* notificationOpenedCallbackId;
+NSString* setLanguageCallbackId;
 NSString* getTagsCallbackId;
 NSString* getIdsCallbackId;
 NSString* postNotificationCallbackId;
@@ -241,7 +242,13 @@ static Class delegateClass = nil;
 }
 
 - (void)setLanguage:(CDVInvokedUrlCommand*)command {
-    [OneSignal setLanguage:command.arguments[0]];
+    setLanguageCallbackId = command.callbackId;
+    
+    [OneSignal setLanguage:command.arguments[0] withSuccess:^{
+        successCallback(setLanguageCallbackId, nil);
+    } withFailure:^(NSError *error) {
+        failureCallback(setLanguageCallbackId, error.userInfo);
+    }];
 }
 
 - (void)addPermissionObserver:(CDVInvokedUrlCommand*)command {

--- a/types/OneSignalPlugin.d.ts
+++ b/types/OneSignalPlugin.d.ts
@@ -117,9 +117,11 @@ export interface OneSignalPlugin {
     /**
      * Allows you to set the app defined language with the OneSignal SDK.
      * @param  {string} language
+     * @param  {(success:object)=>void} onSuccess
+     * @param  {(failure:object)=>void} onFailure
      * @returns void
      */
-    setLanguage(language: string): void;
+    setLanguage(language: string, onSuccess?: (success: object) => void, onFailure?: (failure: object) => void): void;
 
     /**
      * Tag a user based on an app event of your choosing so they can be targeted later via segments.

--- a/www/OneSignalPlugin.js
+++ b/www/OneSignalPlugin.js
@@ -152,8 +152,14 @@ OneSignalPlugin.prototype.getDeviceState = function(deviceStateReceivedCallBack)
     window.cordova.exec(deviceStateCallback, function(){}, "OneSignalPush", "getDeviceState", []);
 };
 
-OneSignalPlugin.prototype.setLanguage = function(language) {
-    window.cordova.exec(function(){}, function(){}, "OneSignalPush", "setLanguage", [language]);
+OneSignalPlugin.prototype.setLanguage = function(language, onSuccess, onFailure) {
+    if (onSuccess == null)
+        onSuccess = function() {};
+
+    if (onFailure == null)
+        onFailure = function() {};
+         
+    window.cordova.exec(onSuccess, onFailure, "OneSignalPush", "setLanguage", [language]);
 }
 
 OneSignalPlugin.prototype.addSubscriptionObserver = function(callback) {


### PR DESCRIPTION
# Description
## One Line Summary
Add SetLanguage callback

## Details

### Motivation
Added SetLanguage callbacks to Android and iOS implementation of Cordova

### Scope
* Add `setLanguage` `onSuccess` and `onFailure` callbacks to Android implementation of OneSignal plugin
* Add `setLanguage` `withSuccess` and `withFailure` callbacks to iOS implementation of OneSignal plugin
* Add `onSuccess` and `onFailure` for `setLanguage` on javascript and type files


# Testing

## Manual testing
* Tested setting a language on iOS and Android devices to received `onSuccess` callback responses

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-cordova-sdk/790)
<!-- Reviewable:end -->
