### PR TITLE
Rename subscription state change keys

### DIFF
--- a/www/Subscription.ts
+++ b/www/Subscription.ts
@@ -62,12 +62,12 @@ export interface SubscriptionChange {
 export interface EmailSubscriptionChange {
     emailAddress        ?: string;
     emailUserId         ?: string;
-    isSubscribed        : boolean; // don't rename to isEmailSubscribed
+    isEmailSubscribed   : boolean; // renamed from isSubscribed
 }
 
 /// Represents the user's OneSignal SMS subscription state,
 export interface SMSSubscriptionChange {
     smsNumber         ?: string;
     smsUserId         ?: string;
-    isSubscribed      : boolean; // don't rename to isSMSSubscribed
+    isSMSSubscribed   : boolean; // renamed from isSubscribed
 }


### PR DESCRIPTION
# Description
## One Line Summary
This is a followup PR to https://github.com/OneSignal/OneSignal-Cordova-SDK/pull/798 that corrects the public interface for `EmailSubscriptionChange` and `SMSSubscriptionChange` to keep it the same as before.

## Details

### Motivation
Our interface for `EmailSubscriptionChange` renames the `isSubscribed` property received from the native SDK to `isEmailSubscribed`. Similarly for `SMSSubscriptionChange`, the `isSubscribed` property is renamed to `isSMSSubscribed`.

To make this rename is a tad ugly, by adding a helper method to the Android and iOS bridges called `renameStateChangesKey` which adds the new key and deletes the old key. Then use this helper method when processing the callback responses for the SMS and email subscription observers.

### Scope
Corrects a change made in the PR above and keeps these interfaces the same as before.

# Testing

## Manual testing
Tested callback responses in Android emulator and physical iPhone.
Examples of the response received in the callback.

```json
     {
      "from": {
        "smsUserId": null,
        "smsNumber": null,
        "isSMSSubscribed": false
      },
      "to": {
        "smsUserId": null,
        "smsNumber": "+15551237788",
        "isSMSSubscribed": false
      }
    }
```
```json
     {
      "from": {
        "emailUserId": null,
        "emailAddress": null,
        "isEmailSubscribed": false
      },
      "to": {
        "emailUserId": null,
        "emailAddress": "u@example.com",
        "isEmailSubscribed": false
      }
    }
```
# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes 👈🏼 not a change, but to keep it the same

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-cordova-sdk/801)
<!-- Reviewable:end -->
