### PR TITLE
[Feat] Add Android 13 push permission prompting

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -30,7 +30,7 @@
   <js-module src="dist/OSNotification.js" name="OSNotification" />
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:4.7.3" />
+    <framework src="com.onesignal:OneSignal:4.8.1" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
 
     <config-file target="res/xml/config.xml" parent="/*">

--- a/src/android/com/onesignal/cordova/OneSignalController.java
+++ b/src/android/com/onesignal/cordova/OneSignalController.java
@@ -182,8 +182,21 @@ public class OneSignalController {
     return true;
   }
 
-  public static boolean promptForPushNotificationsWithUserResponse() {
-    // doesn't apply to Android
+  public static boolean promptForPushNotificationsWithUserResponse(CallbackContext callbackContext, JSONArray data) {
+    final CallbackContext jsPromptForPushNotificationsCallback = callbackContext;
+    boolean fallbackToSettings = false;
+    try {
+      fallbackToSettings = data.getBoolean(0);
+    } catch (JSONException e) {
+      e.printStackTrace();
+    }
+
+    OneSignal.promptForPushNotifications(fallbackToSettings, new OneSignal.PromptForPushNotificationPermissionResponseHandler() {
+      @Override
+      public void response(boolean accepted) {
+        CallbackHelper.callbackSuccessBoolean(callbackContext, accepted);
+      }
+    });
     return true;
   }
 

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -293,7 +293,7 @@ public class OneSignalPush extends CordovaPlugin {
         break;
 
       case PROMPT_FOR_PUSH_NOTIFICATIONS_WITH_USER_RESPONSE:
-        result = OneSignalController.promptForPushNotificationsWithUserResponse();
+        result = OneSignalController.promptForPushNotificationsWithUserResponse(callbackContext, data);
         break;
 
       case UNSUBSCRIBE_WHEN_NOTIFICATIONS_DISABLED:

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -308,7 +308,7 @@ static Class delegateClass = nil;
    promptForPushNotificationsWithUserResponseCallbackId = command.callbackId;
     [OneSignal promptForPushNotificationsWithUserResponse:^(BOOL accepted) {
         successCallbackBoolean(promptForPushNotificationsWithUserResponseCallbackId, accepted);
-    }];
+    } fallbackToSettings:[command.arguments[0] boolValue]];
 }
 
 - (void)registerForProvisionalAuthorization:(CDVInvokedUrlCommand *)command {

--- a/www/index.ts
+++ b/www/index.ts
@@ -318,18 +318,33 @@ class OneSignalPlugin {
     };
 
     /**
-     * Only applies to iOS (does nothing on Android).
-     * Prompts the iOS user for push notifications.
+     * Prompts the user for push notifications permission in iOS and Android 13+.
+     * In lower Android versions, it will return false, since notification permission is by default given.
+     * Call with promptForPushNotificationsWithUserResponse(fallbackToSettings?, handler?)
+     *
+     * @param  {boolean} fallbackToSettings
      * @param  {(response:boolean)=>void} handler
      * @returns void
      */
-    promptForPushNotificationsWithUserResponse(handler?: (response: boolean) => void): void {
+    promptForPushNotificationsWithUserResponse(fallbackToSettingsOrHandler?: boolean | ((response: boolean) => void), handler?: (response: boolean) => void): void {
+        var fallbackToSettings = false;
+
+        if (typeof fallbackToSettingsOrHandler === "function") {
+            // Method was called like promptForPushNotificationsWithUserResponse(handler: function)
+            handler = fallbackToSettingsOrHandler;
+        }
+        else if (typeof fallbackToSettingsOrHandler === "boolean") {
+            // Method was called like promptForPushNotificationsWithUserResponse(fallbackToSettings: boolean, handler?: function)
+            fallbackToSettings = fallbackToSettingsOrHandler;
+        }
+        // Else method was called like promptForPushNotificationsWithUserResponse(), no need to modify
+
         const internalCallback = (response: boolean) => {
             if (handler) {
                 handler(response);
             }
         };
-        window.cordova.exec(internalCallback, function(){}, "OneSignalPush", "promptForPushNotificationsWithUserResponse", []);
+        window.cordova.exec(internalCallback, function(){}, "OneSignalPush", "promptForPushNotificationsWithUserResponse", [fallbackToSettings]);
     };
 
     /**

--- a/www/index.ts
+++ b/www/index.ts
@@ -319,7 +319,8 @@ class OneSignalPlugin {
 
     /**
      * Prompts the user for push notifications permission in iOS and Android 13+.
-     * In lower Android versions, it will return false, since notification permission is by default given.
+     * Use the fallbackToSettings parameter to prompt to open the settings app if a user has already declined push permissions.
+     *
      * Call with promptForPushNotificationsWithUserResponse(fallbackToSettings?, handler?)
      *
      * @param  {boolean} fallbackToSettings


### PR DESCRIPTION
# Description
## One Line Summary
This PR implements push permission prompting in Android for Android 13 devices.

## Details

### Motivation
This is a new Android 13 features/requirement.

### Scope
Push permission prompting on Android 13 devices. In order to not immediately be prompted in Android 13, apps will need to set their Android target SDK version to 33+.

There is a public API addition to give users more control. The public method `promptForPushNotificationsWithUserResponse(handler?)` now includes the optional boolean parameter `fallbackToSettings`. Omitting it maintains the same current behavior of not fallback to settings.

```typescript
promptForPushNotificationsWithUserResponse(fallbackToSettings?: boolean, handler?: (response: boolean) => void)
```

# Testing

## Manual testing
I tested on physical iPhone 13 and Android emulator on API 33 using combinations of allowing, denying, changing the permission in settings, and re-prompting. These are the ways of calling the method tested.

```typescript
OneSignal.promptForPushNotificationsWithUserResponse();

OneSignal.promptForPushNotificationsWithUserResponse(true);

OneSignal.promptForPushNotificationsWithUserResponse(false);

OneSignal.promptForPushNotificationsWithUserResponse(res => console.log(res));

OneSignal.promptForPushNotificationsWithUserResponse(undefined, (res) => console.log(res));

OneSignal.promptForPushNotificationsWithUserResponse(true, (res) => console.log(res));
```

There is some potentially undesirable behavior if a user taps outside the fallback to settings prompt to dismiss it. Since the SDK seems to be waiting on user interaction, the Android plugin's (and the user's) callback is not triggered until some definitive response is taken. Then they are all triggered. Included a short video to demonstrate.

https://user-images.githubusercontent.com/4022291/180971150-87ffc75d-4b2e-442a-a472-820a43b4e9dc.mov

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-cordova-sdk/803)
<!-- Reviewable:end -->
