### PR TITLE
Release 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.4",
+  "version": "3.1.0",
 
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="3.0.4">
+    version="3.1.0">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -76,7 +76,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" spec="3.11.1" />
+            <pod name="OneSignalXCFramework" spec="3.11.2" />
         </pods>
     </podspec>
 


### PR DESCRIPTION
* Bump version from 3.0.4 to 3.1.0
* Bump iOS to 3.11.2
* Android was already bumped to 4.8.1 in a previous commit

- #803 
- #798
  - Please see the heading titled **"Summary of Public Interface Changes"** the above PR for all the public APIs that have changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-cordova-sdk/804)
<!-- Reviewable:end -->
