### PR TITLE
Remove the inclusion of the OneSignal gradle plugin

### DIFF
--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -12,19 +12,6 @@ repositories {
   maven { url 'https://maven.google.com' }
 }
 
-// Adding Onesignal-Gradle-Plugin to align gms, android support library, and firebase
-//   dependencies between other plugins.
-// Source for Onesignal-Gradle-Plugin: https://github.com/OneSignal/OneSignal-Gradle-Plugin
-buildscript {
-  repositories {
-    maven { url 'https://plugins.gradle.org/m2/'}
-  }
-  dependencies {
-    classpath 'gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.12.3, 0.99.99]'
-  }
-}
-apply plugin: com.onesignal.androidsdk.GradleProjectPlugin
-
 gradle.afterProject { project ->
    def androidManifest = new File("${project.rootDir}/app/src/main/AndroidManifest.xml")
    String fileContentsReplaced = androidManifest.text.replaceFirst('<service .*android:name="com.huawei.hms.cordova.push.remote.HmsPushMessageService"(>[\\s]*<intent-filter>[\\s]*.*[\\s]*<\\/intent-filter>[\\s]*<\\/service>|.*[\\s]\\/>){1}', "")


### PR DESCRIPTION
# Description
## One Line Summary
Remove the inclusion of the OneSignal gradle plugin from the example app.

## Details

### Motivation
The OneSignal gradle plugin for Android is designed to (1) ensure the compileSdkVersion is 31 or higher and (2) ensure (mostly) firebase dependent libraries in use by the app & onesignal are compatible. The dependent library compatibility problem has been less of an issue, making the plugin less useful. However inclusion of the plugin itself can sometimes cause side-effect issues during build.

As a result, including the OneSignal Gradle plugin is no longer considered standard when configuring an app to use the OneSignal SDK.

### Scope
When including the plugin for Android, the OneSignal gradle plugin is no longer added into the build scripts, and is therefore no longer part of the build process.

# Testing
## Unit testing
None

## Manual testing
Built the example application (https://github.com/OneSignalDevelopers/OneSignal-Cordova-Example) and ensure proper functioning.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-cordova-sdk/811)
<!-- Reviewable:end -->
