### PR TITLE
[fix] Incorrect global declaration

### DIFF
--- a/www/index.ts
+++ b/www/index.ts
@@ -40,12 +40,7 @@ import {
 } from "./Subscription";
 
 // Suppress TS warnings about window.cordova
-declare global {
-    interface Window {
-        cordova: any; // turn off type checking
-        plugins: any;
-    }
-}
+declare let window: any; // turn off type checking
 
 // 0 = None, 1 = Fatal, 2 = Errors, 3 = Warnings, 4 = Info, 5 = Debug, 6 = Verbose
 export type LogLevel = 0 | 1 | 2 | 3 | 4 | 5 | 6;


### PR DESCRIPTION
# Description
## One Line Summary
Fix previous incorrect workaround for a TypeScript compiler error.

## Details

### Motivation
To remedy reported issue https://github.com/OneSignal/OneSignal-Cordova-SDK/issues/809.
* Background: Typescript gives errors because cordova is not part of the window object when we call for example `window.cordova.exec()`
* The error given is like: "Property 'cordova' does not exist on type 'Window & typeof globalThis'."
* The previous workaround of declaring globally the cordova and plugins property on Window to be of type any is incorrect, as this affects end users who may have a type for Cordova, etc.

### Scope
Affects TypeScript compiler and type checking only.

# Testing
## Unit testing
No unit testing

## Manual testing
1. Confirmed the reported incorrect behavior in an example app.
2. Check that this PR addresses the incorrect behavior in an example app. 

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-cordova-sdk/813)
<!-- Reviewable:end -->
