### PR TITLE
adding 3 issue templates for the Cordova SDK

### DIFF
--- a/.github/ISSUE_TEMPLATE/ask-question.yml
+++ b/.github/ISSUE_TEMPLATE/ask-question.yml
@@ -1,0 +1,27 @@
+name: 🙋‍♂️ Ask a question
+description: Tell us what's on your mind
+title: "[question]: "
+labels: ["question"]
+# assignees:
+#   - OneSignal/ios-sdk
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Having issues integrating this SDK?
+  - type: textarea
+    id: question
+    attributes:
+      label: How can we help?
+      description: Specific question regarding integrating this SDK.
+      placeholder: How do I...?
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/OneSignal/OneSignal-Cordova-SDK/blob/main/CONTRIBUTING.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,72 @@
+name: 🪳 Bug report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug", "triage"]
+# assignees:
+#   - OneSignal/ios-sdk
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Provide a thorough description of whats going on.
+      placeholder: e.g. The latest version of the SDK causes my screen to go blank when I tap on the screen three times.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to reproduce?
+      description: Provide as much detail as posible to reproduce the issue.
+      placeholder: |
+        1. Install vX.Y.Z of dependency
+        2. Launch the app on iOS device
+        3. Tap the screen three times
+        4. Note that the app crashes
+      render: Markdown
+    validations:
+      required: true
+  - type: textarea
+    id: what-are-expectations
+    attributes:
+      label: What did you expect to happen?
+      description: Also tell us, what did you expect to happen?
+      placeholder: I expected the app to continue running no matter how many times I tap the screen.
+    validations:
+      required: true
+  - type: input
+    id: cordova-sdk-version
+    attributes:
+      label: OneSignal Cordova SDK version
+      description: What version of the OneSignal Cordova SDK are you using?
+      placeholder: Release 3.1.1
+    validations:
+      required: true
+  - type: checkboxes
+    id: platforms
+    attributes:
+      label: Which platform(s) are affected?
+      description: Indicate which mobile platforms this issue is affecting
+      options:
+        - label: iOS
+          required: false
+        - label: Android
+          required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: Shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/OneSignal/OneSignal-Cordova-SDK/blob/main/CONTRIBUTING.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/general-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/general-feedback.yml
@@ -1,0 +1,27 @@
+name: 📣 General feedback
+description: Tell us what's on your mind
+title: "[Feedback]: "
+labels: ["triage"]
+# assignees:
+#   - OneSignal/ios-sdk
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing your valuable feedback!
+  - type: textarea
+    id: feedback
+    attributes:
+      label: What's on your mind?
+      description: Feedback regarding this SDK.
+      placeholder: Share your feedback...
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/OneSignal/OneSignal-Cordova-SDK/blob/main/CONTRIBUTING.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true


### PR DESCRIPTION
# Description
## One Line Summary
Using issue forms for the Cordova SDK

## Details
Upgrade from an issue template to use issue forms

### Motivation
Issue forms are a better user experience

### Scope
github issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-cordova-sdk/815)
<!-- Reviewable:end -->
