### PR TITLE
Add live activities support

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -76,7 +76,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" spec="3.11.2" />
+            <pod name="OneSignalXCFramework" spec="3.12.3" />
         </pods>
     </podspec>
 

--- a/src/ios/OneSignalPush.h
+++ b/src/ios/OneSignalPush.h
@@ -107,4 +107,8 @@
 
 - (void)setLanguage:(CDVInvokedUrlCommand* _Nonnull)command;
 
+// Live Activity
+- (void)enterLiveActivity:(CDVInvokedUrlCommand* _Nonnull)command;
+- (void)exitLiveActivity:(CDVInvokedUrlCommand* _Nonnull)command;
+
 @end

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -50,6 +50,8 @@ NSString* logoutEmailCallbackId;
 NSString* logoutSMSNumberCallbackId;
 NSString* emailSubscriptionCallbackId;
 NSString* smsSubscriptionCallbackId;
+NSString* enterLiveActivityCallbackId;
+NSString* exitLiveActivityCallbackId;
 
 NSString* inAppMessageWillDisplayCallbackId;
 NSString* inAppMessageDidDisplayCallbackId;
@@ -629,6 +631,35 @@ static Class delegateClass = nil;
     BOOL locationShared = [OneSignal isLocationShared];
     // TODO: Update the response in next major release to just boolean
     successCallback(command.callbackId, @{@"value" : @(locationShared)});
+}
+
+/**
+ * Live Activities
+ */
+
+- (void)enterLiveActivity:(CDVInvokedUrlCommand *)command {
+    enterLiveActivityCallbackId = command.callbackId;
+
+    NSString *activityId = command.arguments[0];
+    NSString *token = command.arguments[1];
+    
+    [OneSignal enterLiveActivity:activityId withToken:token withSuccess:^(NSDictionary* results){
+        successCallback(enterLiveActivityCallbackId, results);
+    } withFailure:^(NSError *error) {
+        failureCallback(enterLiveActivityCallbackId, error.userInfo);
+    }];
+}
+
+- (void)exitLiveActivity:(CDVInvokedUrlCommand *)command {
+    exitLiveActivityCallbackId = command.callbackId;
+
+    NSString *activityId = command.arguments[0];
+
+    [OneSignal exitLiveActivity:activityId withSuccess:^(NSDictionary* results){
+        successCallback(exitLiveActivityCallbackId, results);
+    } withFailure:^(NSError *error) {
+        failureCallback(exitLiveActivityCallbackId, error.userInfo);
+    }];
 }
 
 @end

--- a/www/index.ts
+++ b/www/index.ts
@@ -797,6 +797,49 @@ export class OneSignalPlugin {
         // TODO: Update the response in next major release to just boolean
         window.cordova.exec(handler, function() {}, "OneSignalPush", "isLocationShared", []);
     };
+
+    /**
+     * Live Activities
+     */
+
+    /**
+     * Enter a live activity
+     * @param  {string} activityId
+     * @param  {string} token
+     * @param  {Function} onSuccess
+     * @param  {Function} onFailure
+     * @returns void
+     */
+    enterLiveActivity(activityId: string, token: string, onSuccess?: Function, onFailure?: Function): void {
+        if (onSuccess == null) {
+            onSuccess = function() {};
+        }
+    
+        if (onFailure == null) {
+            onFailure = function() {};
+        }
+
+        window.cordova.exec(onSuccess, onFailure, "OneSignalPush", "enterLiveActivity", [activityId, token]);
+    };
+
+    /**
+     * Exit a live activity
+     * @param  {string} activityId
+     * @param  {Function} onSuccess
+     * @param  {Function} onFailure
+     * @returns void
+     */
+     exitLiveActivity(activityId: string, onSuccess?: Function, onFailure?: Function): void {
+        if (onSuccess == null) {
+            onSuccess = function() {};
+        }
+
+        if (onFailure == null) {
+            onFailure = function() {};
+        }
+
+        window.cordova.exec(onSuccess, onFailure, "OneSignalPush", "exitLiveActivity", [activityId]);
+    };
 }
 
 //-------------------------------------------------------------------


### PR DESCRIPTION
# Description
## One Line Summary
### Add Live Activities to Cordova SDK

## Details

### Motivation
Addition of two live activities methods, `enterLiveActivity` and `exitLiveActivity`.

### Scope
Adding bridging to access the two iOS SDK methods.

# Testing
Testing limited since no real push token is available. Tested that a Cordova example app can call these two methods and receive the onFailure response with a correct 404 error.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [X] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-cordova-sdk/824)
<!-- Reviewable:end -->
