### PR TITLE
Release 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.2.0",
+  "version": "3.3.0",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="3.2.0">
+    version="3.3.0">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>


### PR DESCRIPTION
## What's Changed
- [Feature] Add iOS Live Activities support in [#824](https://github.com/OneSignal/OneSignal-Cordova-SDK/pull/824) that include 2 methods for associating and deleting a temporary push token with an Activity ID on the OneSignal server.
- Documentation to come
- Example usage:
    
    `window.plugins.OneSignal.enterLiveActivity("activity_id", "token");`

    `window.plugins.OneSignal.exitLiveActivity("activity_id");`

## Native SDK Updates
- Update to [OneSignal-iOS-SDK 3.12.3](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/3.12.3)
  - Includes the iOS Live Activities support
- No Android bump to 4.8.3, the SDK stays on 4.8.2

Full changelog: [3.2.0...3.3.0](https://github.com/OneSignal/OneSignal-Cordova-SDK/compare/3.2.0...feature/live-activities)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-cordova-sdk/828)
<!-- Reviewable:end -->
