### PR TITLE
[User Model] Create pushSubscription Namespace

### DIFF
--- a/src/ios/OneSignalPush.h
+++ b/src/ios/OneSignalPush.h
@@ -52,6 +52,15 @@
 - (void)addTags:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)removeTags:(CDVInvokedUrlCommand* _Nonnull)command;
 
+// Push Subscription
+- (void)addPushSubscriptionObserver:(CDVInvokedUrlCommand* _Nonnull)command;
+- (void)removePushSubscriptionObserver:(CDVInvokedUrlCommand* _Nonnull)command;
+- (void)getId:(CDVInvokedUrlCommand* _Nonnull)command;
+- (void)getToken:(CDVInvokedUrlCommand* _Nonnull)command;
+- (void)getOptedIn:(CDVInvokedUrlCommand* _Nonnull)command;
+- (void)optIn:(CDVInvokedUrlCommand* _Nonnull)command;
+- (void)optOut:(CDVInvokedUrlCommand* _Nonnull)command;
+
 - (void)promptForPushNotificationsWithUserResponse:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)registerForProvisionalAuthorization:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)disablePush:(CDVInvokedUrlCommand* _Nonnull)command;

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -291,8 +291,8 @@ static Class delegateClass = nil;
     if (pushId) {
         NSDictionary *result = @{
             @"value" : pushId
-        };
-        successCallback(command.callbackId, result);
+    };
+    successCallback(command.callbackId, result);
     }
 }
 

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -275,11 +275,51 @@ static Class delegateClass = nil;
         [OneSignal addPermissionObserver:self];
 }
 
-- (void)addSubscriptionObserver:(CDVInvokedUrlCommand*)command {
+- (void)addPushSubscriptionObserver:(CDVInvokedUrlCommand*)command {
     bool first = subscriptionObserverCallbackId == nil;
     subscriptionObserverCallbackId = command.callbackId;
     if (first)
-        [OneSignal addSubscriptionObserver:self];
+        [OneSignal.User.pushSubscription addObserver:self];
+}
+
+- (void)removePushSubscriptionObserver:(CDVInvokedUrlCommand*)command {
+    [OneSignal.User.pushSubscription removeObserver:self];
+}
+
+- (void)getId:(CDVInvokedUrlCommand*)command {
+    NSString *pushId = OneSignal.User.pushSubscription.id;
+    if (pushId) {
+        NSDictionary *result = @{
+            @"value" : pushId
+        };
+        successCallback(command.callbackId, result);
+    }
+}
+
+- (void)getToken:(CDVInvokedUrlCommand*)command {
+    NSString *token = OneSignal.User.pushSubscription.token;
+    if (token) {
+        NSDictionary *result = @{
+            @"value" : token
+    };
+    successCallback(command.callbackId, result);
+    }
+}
+
+- (void)getOptedIn:(CDVInvokedUrlCommand*)command {
+    bool optedIn = OneSignal.User.pushSubscription.optedIn;
+    NSDictionary *result = @{
+            @"value" : @(optedIn)
+    };
+    successCallback(command.callbackId, result);
+}
+
+- (void)optIn:(CDVInvokedUrlCommand*)command {
+    [OneSignal.User.pushSubscription optIn];
+}
+
+- (void)optOut:(CDVInvokedUrlCommand*)command {
+    [OneSignal.User.pushSubscription optOut];
 }
 
 - (void)addEmailSubscriptionObserver:(CDVInvokedUrlCommand *)command {

--- a/www/PushSubscriptionNamespace.ts
+++ b/www/PushSubscriptionNamespace.ts
@@ -1,0 +1,107 @@
+import { ChangeEvent,
+    PushSubscriptionChange } from "./Subscription";
+
+// Suppress TS warnings about window.cordova
+declare let window: any; // turn off type checking
+
+export default class PushSubscription {
+    private _id?: string | null;
+    private _token?: string | null;
+    private _optedIn?: boolean;
+
+    private _subscriptionObserverList: ((event:ChangeEvent<PushSubscriptionChange>)=>void)[] = [];
+
+    private _processFunctionList<ObserverChangeEvent>(array: ((event:ChangeEvent<ObserverChangeEvent>)=>void)[], param: ChangeEvent<ObserverChangeEvent>): void {
+        for (let i = 0; i < array.length; i++) {
+            array[i](param);
+        }
+    }
+
+    /**
+     * Sets initial Push Subscription properties and adds observer for changes
+     */
+    setPropertiesAndObserver():void {
+        /**
+         * Receive push Id
+         * @param obj 
+         */
+        const getIdCallback = (obj: {value: string}) => {
+            this._id = obj.value;
+        };
+        window.cordova.exec(getIdCallback, function(){}, "OneSignalPush", "getId");
+
+        /**
+         * Receive token
+         * @param obj 
+         */
+        const getTokenCallback = (obj: {value: string}) => {
+            this._token = obj.value;
+        };
+        window.cordova.exec(getTokenCallback, function(){}, "OneSignalPush", "getToken");
+        
+        /**
+         * Receive opted-in status
+         * @param obj 
+         */
+        const getOptedInCallback = (obj: {value: boolean}) => {
+            this._optedIn = obj.value;
+        };
+        window.cordova.exec(getOptedInCallback, function(){}, "OneSignalPush", "getOptedIn");
+
+        this.addObserver(event => {
+            this._id = event.to.id;
+            this._token = event.to.token;
+            this._optedIn = event.to.optedIn;
+        });
+    }
+    
+    get id(): string | null | undefined {
+        return this._id;
+    }
+    
+    get token(): string | null | undefined {
+        return this._token;
+    }
+
+    get optedIn(): boolean {
+        return this._optedIn || false;
+    }  
+
+    /**
+     * The OSPushSubscriptionObserver.onOSPushSubscriptionChanged method will be fired on the passed-in object when the push subscription changes. 
+     * This method returns the current OSPushSubscriptionState at the time of adding this observer.
+     * @param  {(event:ChangeEvent<SubscriptionChange>)=>void} observer
+     * @returns void
+     */
+    addObserver(observer: (event: ChangeEvent<PushSubscriptionChange>) => void): void {
+        this._subscriptionObserverList.push(observer);
+        const subscriptionCallBackProcessor = (state: ChangeEvent<PushSubscriptionChange>) => {
+            this._processFunctionList(this._subscriptionObserverList, state);
+        };
+        window.cordova.exec(subscriptionCallBackProcessor, function(){}, "OneSignalPush", "addPushSubscriptionObserver", []);
+    };
+
+    /**
+     * Remove a push subscription observer that has been previously added.
+     * @returns void
+     */
+    removeObserver(): void {
+        window.cordova.exec(function(){}, function(){}, "OneSignalPush", "removePushSubscriptionObserver", []);
+    }
+    
+    /**
+     * Call this method to receive push notifications on the device or to resume receiving of push notifications after calling optOut. If needed, this method will prompt the user for push notifications permission.
+     * @returns void
+     */
+    optIn(): void {
+        window.cordova.exec(function(){}, function(){}, "OneSignalPush", "optIn");
+    }
+
+    /**
+     * If at any point you want the user to stop receiving push notifications on the current device (regardless of system-level permission status), you can call this method to opt out.
+     * @returns void
+     */
+    optOut(): void {
+        window.cordova.exec(function(){}, function(){}, "OneSignalPush", "optOut");
+    }
+}

--- a/www/Subscription.ts
+++ b/www/Subscription.ts
@@ -43,7 +43,7 @@ export interface ChangeEvent<ObserverChangeEvent> {
     to   : ObserverChangeEvent;
 }
 
-export type ObserverChangeEvent = PermissionChange | SubscriptionChange | EmailSubscriptionChange | SMSSubscriptionChange
+export type ObserverChangeEvent = PermissionChange | PushSubscriptionChange | EmailSubscriptionChange | SMSSubscriptionChange
 
 export interface PermissionChange {
     status                  : PermissionStatus;
@@ -52,10 +52,10 @@ export interface PermissionChange {
 }
 
 /// Represents the current user's push notification subscription state with OneSignal
-export interface SubscriptionChange {
-    userId                  ?: string;
-    pushToken               ?: string;
-    isSubscribed            : boolean;
+export interface PushSubscriptionChange {
+    id                  ?: string;
+    token               ?: string;
+    optedIn             : boolean;
 }
 
 /// Represents the user's OneSignal email subscription state,

--- a/www/index.ts
+++ b/www/index.ts
@@ -76,7 +76,11 @@ export class OneSignalPlugin {
     setAppId(appId: string): void {
         this._appID = appId;
 
-        window.cordova.exec(function() {}, function(){}, "OneSignalPush", "init", [this._appID]);
+        const observerCallback = () => {
+            this.User.pushSubscription.setPropertiesAndObserver();
+        }
+
+        window.cordova.exec(observerCallback, function(){}, "OneSignalPush", "init", [this._appID]);
     };
 
     /**


### PR DESCRIPTION
# Description
## One Line Summary
Create pushSubscription namespace to handle Push Subscription methods

## Details

### Motivation
User Model requires namespacing to decouple from god OneSignal class.

### Scope
Push Subscription methods have been moved to their own namespace and will be invoked as:
```
window.plugins.OneSignal.User.pushSubscription.addObserver(function (state){
          console.log("Push Subscription state changed: " + JSON.stringify(state));
    });
```
```
window.plugins.OneSignal.User.pushSubscription.removeObserver(function (state){
          console.log("Push Subscription state changed: " + JSON.stringify(state));
    });
```
`window.plugins.OneSignal.User.pushSubscription.optIn();`
`window.plugins.OneSignal.User.pushSubscription.optOut();`

Separate methods created in order to access pushSubscription properties with the following API:
`let pushId = window.plugins.OneSignal.User.pushSubscription.id;`
`let token = window.plugins.OneSignal.User.pushSubscription.token;`
`let optedIn = window.plugins.OneSignal.User.pushSubscription.optedIn;`

### OPTIONAL - Other
This PR only encompasses changes to the main plugin interface and iOS. Separate Android PR to follow.

# Testing
## Unit testing
No unit testing was used.

## Manual testing
**RECOMMEND - OPTIONAL -** Explain what scenarios were tested and the environment.
Successfully tested methods on iPad running iOS 15.2

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [X] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/852)
<!-- Reviewable:end -->
