### PR TITLE
[User Model] Update PushSubscription methods

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -29,6 +29,7 @@
   <js-module src="dist/Subscription.js" name="Subscription" />
   <js-module src="dist/OSNotification.js" name="OSNotification" />
   <js-module src="dist/UserNamespace.js" name="UserNamespace" />
+  <js-module src="dist/PushSubscriptionNamespace.js" name="PushSubscriptionNamespace" />
   <js-module src="dist/DebugNamespace.js" name="DebugNamespace" />
   <js-module src="dist/InAppMessagesNamespace.js" name="InAppMessagesNamespace" />
   <js-module src="dist/SessionNamespace.js" name="SessionNamespace" />

--- a/src/android/com/onesignal/cordova/OneSignalController.java
+++ b/src/android/com/onesignal/cordova/OneSignalController.java
@@ -79,17 +79,17 @@ public class OneSignalController {
     return true;
   }
 
-  public static boolean optIn() {
+  public static boolean optInPushSubscription() {
     OneSignal.getUser().getPushSubscription().optIn();
     return true;
   }
 
-  public static boolean optOut() {
+  public static boolean optOutPushSubscription() {
     OneSignal.getUser().getPushSubscription().optOut();
     return true;
   }
 
-  public static boolean getId(CallbackContext callbackContext) {
+  public static boolean getPushSubscriptionId(CallbackContext callbackContext) {
     String pushId = OneSignal.getUser().getPushSubscription().getId();
     try {
       JSONObject subscriptionProperty = new JSONObject ();
@@ -102,7 +102,7 @@ public class OneSignalController {
     return true;
   }
 
-  public static boolean getToken(CallbackContext callbackContext) {
+  public static boolean getPushSubscriptionToken(CallbackContext callbackContext) {
     String token = OneSignal.getUser().getPushSubscription().getToken();
     try {
       JSONObject subscriptionProperty = new JSONObject ();
@@ -115,7 +115,7 @@ public class OneSignalController {
     return true;
   }
   
-  public static boolean getOptedIn(CallbackContext callbackContext) {
+  public static boolean getPushSubscriptionOptedIn(CallbackContext callbackContext) {
     boolean optedIn = OneSignal.getUser().getPushSubscription().getOptedIn();
     try {
     JSONObject subscriptionProperty = new JSONObject ();

--- a/src/android/com/onesignal/cordova/OneSignalController.java
+++ b/src/android/com/onesignal/cordova/OneSignalController.java
@@ -78,7 +78,57 @@ public class OneSignalController {
     OneSignal.logout();
     return true;
   }
+
+  public static boolean optIn() {
+    OneSignal.getUser().getPushSubscription().optIn();
+    return true;
+  }
+
+  public static boolean optOut() {
+    OneSignal.getUser().getPushSubscription().optOut();
+    return true;
+  }
+
+  public static boolean getId(CallbackContext callbackContext) {
+    String pushId = OneSignal.getUser().getPushSubscription().getId();
+    try {
+      JSONObject subscriptionProperty = new JSONObject ();
+      subscriptionProperty.put("value", pushId);
+
+      CallbackHelper.callbackSuccess(callbackContext, subscriptionProperty);
+    } catch (JSONException e){
+      e.printStackTrace();
+    }
+    return true;
+  }
+
+  public static boolean getToken(CallbackContext callbackContext) {
+    String token = OneSignal.getUser().getPushSubscription().getToken();
+    try {
+      JSONObject subscriptionProperty = new JSONObject ();
+      subscriptionProperty.put("value", token);
+
+      CallbackHelper.callbackSuccess(callbackContext, subscriptionProperty);
+    } catch (JSONException e){
+      e.printStackTrace();
+    }
+    return true;
+  }
   
+  public static boolean getOptedIn(CallbackContext callbackContext) {
+    boolean optedIn = OneSignal.getUser().getPushSubscription().getOptedIn();
+    try {
+    JSONObject subscriptionProperty = new JSONObject ();
+    subscriptionProperty.put("value", optedIn);
+
+    CallbackHelper.callbackSuccess(callbackContext, subscriptionProperty);
+  } catch (JSONException e){
+    e.printStackTrace();
+  }
+  return true;
+    
+  }
+
   /** 
   * Aliases
   */

--- a/src/android/com/onesignal/cordova/OneSignalObserverController.java
+++ b/src/android/com/onesignal/cordova/OneSignalObserverController.java
@@ -22,7 +22,7 @@ public class OneSignalObserverController {
 
   private static OSPermissionObserver permissionObserver;
 
-  private static ISubscriptionChangedHandler handler;
+  private static ISubscriptionChangedHandler pushSubscriptionChangedHandler;
 
   // This is to prevent an issue where if two Javascript calls are made to OneSignal expecting a callback then only one would fire.
   private static void callbackSuccess(CallbackContext callbackContext, JSONObject jsonObject) {
@@ -64,14 +64,10 @@ public class OneSignalObserverController {
     return true;
   }
 
-  public static boolean removePushSubscriptionObserver() {
-    OneSignal.getUser().getPushSubscription().removeChangeHandler(handler);
-    return true;    
-  }
-
   public static boolean addPushSubscriptionObserver(CallbackContext callbackContext) {
     jsSubscriptionObserverCallBack = callbackContext;
-      handler = new ISubscriptionChangedHandler() {
+    if (pushSubscriptionChangedHandler == null) {
+      pushSubscriptionChangedHandler = new ISubscriptionChangedHandler() {
         @Override
         public void onSubscriptionChanged(ISubscription subscription) {
           if (!(subscription instanceof IPushSubscription)){
@@ -92,6 +88,7 @@ public class OneSignalObserverController {
         }
       };
       OneSignal.getUser().getPushSubscription().addChangeHandler(handler);
+    }
     return true;      
   }
 }

--- a/src/android/com/onesignal/cordova/OneSignalObserverController.java
+++ b/src/android/com/onesignal/cordova/OneSignalObserverController.java
@@ -8,26 +8,21 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import com.onesignal.OneSignal;
+import com.onesignal.user.subscriptions.IPushSubscription;
+import com.onesignal.user.subscriptions.ISubscription;
+import com.onesignal.user.subscriptions.ISubscriptionChangedHandler;
+
 
 import com.onesignal.OSPermissionObserver;
-import com.onesignal.OSEmailSubscriptionObserver;
-import com.onesignal.OSSMSSubscriptionObserver;
-import com.onesignal.OSSubscriptionObserver;
 import com.onesignal.OSPermissionStateChanges;
-import com.onesignal.OSSubscriptionStateChanges;
-import com.onesignal.OSEmailSubscriptionStateChanges;
-import com.onesignal.OSSMSSubscriptionStateChanges;
 
 public class OneSignalObserverController {
   private static CallbackContext jsPermissionObserverCallBack;
   private static CallbackContext jsSubscriptionObserverCallBack;
-  private static CallbackContext jsEmailSubscriptionObserverCallBack;
-  private static CallbackContext jsSMSSubscriptionObserverCallBack;
 
   private static OSPermissionObserver permissionObserver;
-  private static OSSubscriptionObserver subscriptionObserver;
-  private static OSEmailSubscriptionObserver emailSubscriptionObserver;
-  private static OSSMSSubscriptionObserver smsSubscriptionObserver;
+
+  private static ISubscriptionChangedHandler handler;
 
   // This is to prevent an issue where if two Javascript calls are made to OneSignal expecting a callback then only one would fire.
   private static void callbackSuccess(CallbackContext callbackContext, JSONObject jsonObject) {
@@ -37,23 +32,6 @@ public class OneSignalObserverController {
     PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, jsonObject);
     pluginResult.setKeepCallback(true);
     callbackContext.sendPluginResult(pluginResult);
-  }
-
-  // Helper method to rename a property of subscription state changes.
-  // Currently used by email and SMS state changes to rename the `isSubscribed` key.
-  private static JSONObject renameStateChangesKey(JSONObject fromJSON, JSONObject toJSON, String oldKey, String newKey) {
-    JSONObject modifiedObj = new JSONObject();
-    try {
-      fromJSON.put(newKey, fromJSON.getBoolean(oldKey));
-      fromJSON.remove(oldKey);
-      toJSON.put(newKey, toJSON.getBoolean(oldKey));
-      toJSON.remove(oldKey);
-      modifiedObj.put("from", fromJSON);
-      modifiedObj.put("to", toJSON);
-    } catch (JSONException e) {
-      e.printStackTrace();
-    }
-    return modifiedObj;
   }
 
   public static boolean addPermissionObserver(CallbackContext callbackContext) {
@@ -86,57 +64,36 @@ public class OneSignalObserverController {
     return true;
   }
 
-  public static boolean addSubscriptionObserver(CallbackContext callbackContext) {
+  public static boolean removePushSubscriptionObserver() {
+    OneSignal.getUser().getPushSubscription().removeChangeHandler(handler);
+    return true;    
+  }
+
+  public static boolean addPushSubscriptionObserver(CallbackContext callbackContext) {
     jsSubscriptionObserverCallBack = callbackContext;
-      if (subscriptionObserver == null) {
-        subscriptionObserver = new OSSubscriptionObserver() {
-          @Override
-          public void onOSSubscriptionChanged(OSSubscriptionStateChanges stateChanges) {
-            callbackSuccess(jsSubscriptionObserverCallBack, stateChanges.toJSONObject());
+      handler = new ISubscriptionChangedHandler() {
+        @Override
+        public void onSubscriptionChanged(ISubscription subscription) {
+          if (!(subscription instanceof IPushSubscription)){
+            return;
           }
-        };
-        OneSignal.addSubscriptionObserver(subscriptionObserver);
-      }
-      return true;
-  }
+          IPushSubscription pushSubscription = (IPushSubscription) subscription;
 
-  public static boolean addEmailSubscriptionObserver(CallbackContext callbackContext) {
-    jsEmailSubscriptionObserverCallBack = callbackContext;
-      if (emailSubscriptionObserver == null) {
-        emailSubscriptionObserver = new OSEmailSubscriptionObserver() {
-          @Override
-          public void onOSEmailSubscriptionChanged(OSEmailSubscriptionStateChanges stateChanges) {
-            JSONObject fromJSON = stateChanges.getFrom().toJSONObject();
-            JSONObject toJSON = stateChanges.getTo().toJSONObject();
+          try {
+            JSONObject pushSubscriptionProperties = new JSONObject();
 
-            // rename the isSubscribed property to isEmailSubscribed
-            JSONObject modifiedObj = renameStateChangesKey(fromJSON, toJSON, "isSubscribed", "isEmailSubscribed");
+            pushSubscriptionProperties.put("id", pushSubscription.getId());
+            pushSubscriptionProperties.put("token", pushSubscription.getToken());
+            pushSubscriptionProperties.put("optedIn", pushSubscription.getOptedIn());
 
-            callbackSuccess(jsEmailSubscriptionObserverCallBack, modifiedObj);
+            callbackSuccess(jsSubscriptionObserverCallBack, pushSubscriptionProperties);
+            
+          } catch (JSONException e) {
+            e.printStackTrace();
           }
-        };
-        OneSignal.addEmailSubscriptionObserver(emailSubscriptionObserver);
-      }
-      return true;
-  }
-
-  public static boolean addSMSSubscriptionObserver(CallbackContext callbackContext) {
-    jsSMSSubscriptionObserverCallBack = callbackContext;
-      if (smsSubscriptionObserver == null) {
-        smsSubscriptionObserver = new OSSMSSubscriptionObserver() {
-          @Override
-          public void onSMSSubscriptionChanged(OSSMSSubscriptionStateChanges stateChanges) {
-            JSONObject fromJSON = stateChanges.getFrom().toJSONObject();
-            JSONObject toJSON = stateChanges.getTo().toJSONObject();
-
-            // rename the isSubscribed property to isSMSSubscribed
-            JSONObject modifiedObj = renameStateChangesKey(fromJSON, toJSON, "isSubscribed", "isSMSSubscribed");
-
-            callbackSuccess(jsSMSSubscriptionObserverCallBack, modifiedObj);
-          }
-        };
-        OneSignal.addSMSSubscriptionObserver(smsSubscriptionObserver);
-      }
-      return true;
+        }
+      };
+      OneSignal.getUser().getPushSubscription().addChangeHandler(handler);
+    return true;      
   }
 }

--- a/src/android/com/onesignal/cordova/OneSignalObserverController.java
+++ b/src/android/com/onesignal/cordova/OneSignalObserverController.java
@@ -85,12 +85,10 @@ public class OneSignalObserverController {
             pushSubscriptionProperties.put("id", pushSubscription.getId());
             pushSubscriptionProperties.put("token", pushSubscription.getToken());
             pushSubscriptionProperties.put("optedIn", pushSubscription.getOptedIn());
-
-            callbackSuccess(jsSubscriptionObserverCallBack, pushSubscriptionProperties);
-            
           } catch (JSONException e) {
             e.printStackTrace();
           }
+          callbackSuccess(jsSubscriptionObserverCallBack, pushSubscriptionProperties);
         }
       };
       OneSignal.getUser().getPushSubscription().addChangeHandler(handler);

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -73,11 +73,11 @@ public class OneSignalPush extends CordovaPlugin {
   private static final String ADD_PUSH_SUBSCRIPTION_OBSERVER = "addPushSubscriptionObserver";
   private static final String REMOVE_PUSH_SUBSCRIPTION_OBSERVER = "removePushSubscriptionObserver";
 
-  private static final String OPT_IN = "optIn";
-  private static final String OPT_OUT = "optOut";
-   private static final String GET_ID = "getId";
-  private static final String GET_TOKEN = "getToken";
-  private static final String GET_OPTED_IN = "getOptedIn";
+  private static final String OPT_IN = "optInPushSubscription";
+  private static final String OPT_OUT = "optOutPushSubscription";
+   private static final String GET_ID = "getPushSubscriptionId";
+  private static final String GET_TOKEN = "getPushSubscriptionToken";
+  private static final String GET_OPTED_IN = "getPushSubscriptionOptedIn";
   
   private static final String ADD_ALIASES = "addAliases";
   private static final String REMOVE_ALIASES = "removeAliases";
@@ -291,23 +291,23 @@ public class OneSignalPush extends CordovaPlugin {
         break;
 
       case OPT_IN:
-        result = OneSignalController.optIn();
+        result = OneSignalController.optInPushSubscription();
         break;
 
       case OPT_OUT:
-        result = OneSignalController.optOut();
+        result = OneSignalController.optOutPushSubscription();
         break;
       
       case GET_ID:
-        result = OneSignalController.getId(callbackContext);
+        result = OneSignalController.getPushSubscriptionId(callbackContext);
         break;
 
       case GET_TOKEN:
-        result = OneSignalController.getToken(callbackContext);
+        result = OneSignalController.getPushSubscriptionToken(callbackContext);
         break;
 
       case GET_OPTED_IN:
-        result = OneSignalController.getOptedIn(callbackContext);
+        result = OneSignalController.getPushSubscriptionOptedIn(callbackContext);
         break;
 
       case ADD_ALIASES:

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -71,7 +71,6 @@ public class OneSignalPush extends CordovaPlugin {
 
   private static final String ADD_PERMISSION_OBSERVER = "addPermissionObserver";
   private static final String ADD_PUSH_SUBSCRIPTION_OBSERVER = "addPushSubscriptionObserver";
-  private static final String REMOVE_PUSH_SUBSCRIPTION_OBSERVER = "removePushSubscriptionObserver";
 
   private static final String OPT_IN = "optInPushSubscription";
   private static final String OPT_OUT = "optOutPushSubscription";
@@ -284,10 +283,6 @@ public class OneSignalPush extends CordovaPlugin {
 
       case ADD_PUSH_SUBSCRIPTION_OBSERVER:
         result = OneSignalObserverController.addPushSubscriptionObserver(callbackContext);
-        break;
-      
-      case REMOVE_PUSH_SUBSCRIPTION_OBSERVER:
-        result = OneSignalObserverController.removePushSubscriptionObserver();
         break;
 
       case OPT_IN:

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -70,10 +70,15 @@ public class OneSignalPush extends CordovaPlugin {
   private static final String LOGOUT = "logout";
 
   private static final String ADD_PERMISSION_OBSERVER = "addPermissionObserver";
-  private static final String ADD_SUBSCRIPTION_OBSERVER = "addSubscriptionObserver";
-  private static final String ADD_EMAIL_SUBSCRIPTION_OBSERVER = "addEmailSubscriptionObserver";
-  private static final String ADD_SMS_SUBSCRIPTION_OBSERVER = "addSMSSubscriptionObserver";
+  private static final String ADD_PUSH_SUBSCRIPTION_OBSERVER = "addPushSubscriptionObserver";
+  private static final String REMOVE_PUSH_SUBSCRIPTION_OBSERVER = "removePushSubscriptionObserver";
 
+  private static final String OPT_IN = "optIn";
+  private static final String OPT_OUT = "optOut";
+   private static final String GET_ID = "getId";
+  private static final String GET_TOKEN = "getToken";
+  private static final String GET_OPTED_IN = "getOptedIn";
+  
   private static final String ADD_ALIASES = "addAliases";
   private static final String REMOVE_ALIASES = "removeAliases";
 
@@ -196,7 +201,7 @@ public class OneSignalPush extends CordovaPlugin {
     return true;
   }
 
-  public boolean init(JSONArray data) {
+  public boolean init(CallbackContext callbackContext, JSONArray data) {
     OneSignalWrapper.setSdkType("cordova");  
     // For 5.0.0-beta, hard code to reflect Cordova SDK version found in plugin.xml
     OneSignalWrapper.setSdkVersion("3.3.0");
@@ -204,7 +209,8 @@ public class OneSignalPush extends CordovaPlugin {
       String appId = data.getString(0);
 
       OneSignal.initWithContext(this.cordova.getActivity(), appId);
-      
+
+      CallbackHelper.callbackSuccessBoolean(callbackContext, true);
       return true;
     } catch (JSONException e) {
       Log.e(TAG, "execute: Got JSON Exception " + e.getMessage());
@@ -254,7 +260,7 @@ public class OneSignalPush extends CordovaPlugin {
         break;
 
       case INIT:
-        result = init(data);
+        result = init(callbackContext, data);
         break;
 
       case GET_DEVICE_STATE:
@@ -276,16 +282,32 @@ public class OneSignalPush extends CordovaPlugin {
         result = OneSignalObserverController.addPermissionObserver(callbackContext);
         break;
 
-      case ADD_SUBSCRIPTION_OBSERVER:
-        result = OneSignalObserverController.addSubscriptionObserver(callbackContext);
+      case ADD_PUSH_SUBSCRIPTION_OBSERVER:
+        result = OneSignalObserverController.addPushSubscriptionObserver(callbackContext);
+        break;
+      
+      case REMOVE_PUSH_SUBSCRIPTION_OBSERVER:
+        result = OneSignalObserverController.removePushSubscriptionObserver();
         break;
 
-      case ADD_EMAIL_SUBSCRIPTION_OBSERVER:
-        result = OneSignalObserverController.addEmailSubscriptionObserver(callbackContext);
+      case OPT_IN:
+        result = OneSignalController.optIn();
         break;
 
-      case ADD_SMS_SUBSCRIPTION_OBSERVER:
-        result = OneSignalObserverController.addSMSSubscriptionObserver(callbackContext);
+      case OPT_OUT:
+        result = OneSignalController.optOut();
+        break;
+      
+      case GET_ID:
+        result = OneSignalController.getId(callbackContext);
+        break;
+
+      case GET_TOKEN:
+        result = OneSignalController.getToken(callbackContext);
+        break;
+
+      case GET_OPTED_IN:
+        result = OneSignalController.getOptedIn(callbackContext);
         break;
 
       case ADD_ALIASES:

--- a/src/ios/OneSignalPush.h
+++ b/src/ios/OneSignalPush.h
@@ -57,7 +57,6 @@
 
 // Push Subscription
 - (void)addPushSubscriptionObserver:(CDVInvokedUrlCommand* _Nonnull)command;
-- (void)removePushSubscriptionObserver:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)getId:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)getToken:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)getOptedIn:(CDVInvokedUrlCommand* _Nonnull)command;

--- a/src/ios/OneSignalPush.h
+++ b/src/ios/OneSignalPush.h
@@ -57,11 +57,11 @@
 
 // Push Subscription
 - (void)addPushSubscriptionObserver:(CDVInvokedUrlCommand* _Nonnull)command;
-- (void)getId:(CDVInvokedUrlCommand* _Nonnull)command;
-- (void)getToken:(CDVInvokedUrlCommand* _Nonnull)command;
-- (void)getOptedIn:(CDVInvokedUrlCommand* _Nonnull)command;
-- (void)optIn:(CDVInvokedUrlCommand* _Nonnull)command;
-- (void)optOut:(CDVInvokedUrlCommand* _Nonnull)command;
+- (void)getPushSubscriptionId:(CDVInvokedUrlCommand* _Nonnull)command;
+- (void)getPushSubscriptionToken:(CDVInvokedUrlCommand* _Nonnull)command;
+- (void)getPushSubscriptionOptedIn:(CDVInvokedUrlCommand* _Nonnull)command;
+- (void)optInPushSubscription:(CDVInvokedUrlCommand* _Nonnull)command;
+- (void)optOutPushSubscription:(CDVInvokedUrlCommand* _Nonnull)command;
 
 - (void)promptForPushNotificationsWithUserResponse:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)registerForProvisionalAuthorization:(CDVInvokedUrlCommand* _Nonnull)command;

--- a/src/ios/OneSignalPush.h
+++ b/src/ios/OneSignalPush.h
@@ -31,7 +31,7 @@
 
 #import <OneSignalFramework/OneSignalFramework.h>
 
-@interface OneSignalPush : CDVPlugin <OSPermissionObserver, OSSubscriptionObserver, OSEmailSubscriptionObserver, OSSMSSubscriptionObserver, OSInAppMessageLifecycleHandler>
+@interface OneSignalPush : CDVPlugin <OSPermissionObserver, OSPushSubscriptionObserver, OSInAppMessageLifecycleHandler>
 
 - (void)setProvidesNotificationSettingsView:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)setNotificationWillShowInForegroundHandler:(CDVInvokedUrlCommand* _Nonnull)command;

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -72,20 +72,6 @@ void failureCallback(NSString* callbackId, NSDictionary* data) {
     [pluginCommandDelegate sendPluginResult:commandResult callbackId:callbackId];
 }
 
-// Helper method to rename a property of subscription state changes.
-// Currently used by email and SMS state changes to rename the `isSubscribed` key.
-NSDictionary* renameStateChangesKey(NSDictionary* oldFrom, NSDictionary* oldTo, NSString* oldKey, NSString* newKey) {
-    NSMutableDictionary *from = [oldFrom mutableCopy];
-    [from setObject: [from objectForKey: oldKey] forKey: newKey];
-    [from removeObjectForKey: oldKey];
-
-    NSMutableDictionary *to = [oldTo mutableCopy];
-    [to setObject: [to objectForKey: oldKey] forKey: newKey];
-    [to removeObjectForKey: oldKey];
-
-    return @{@"from": from, @"to": to};
-}
-
 void processNotificationWillShowInForeground(OSNotification* _notif) {
     NSString * data = [_notif stringify];
     NSError *jsonError;
@@ -182,26 +168,6 @@ static Class delegateClass = nil;
 
 - (void)onOSSubscriptionChanged:(OSSubscriptionStateChanges*)stateChanges {
     successCallback(subscriptionObserverCallbackId, [stateChanges toDictionary]);
-}
-
-- (void)onOSEmailSubscriptionChanged:(OSEmailSubscriptionStateChanges *)stateChanges {
-    NSDictionary *result = renameStateChangesKey(
-        [stateChanges.from toDictionary],
-        [stateChanges.to toDictionary],
-        @"isSubscribed",
-        @"isEmailSubscribed"
-    );
-    successCallback(emailSubscriptionCallbackId, result);
-}
-
-- (void)onOSSMSSubscriptionChanged:(OSSMSSubscriptionStateChanges *)stateChanges {
-    NSDictionary *result = renameStateChangesKey(
-        [stateChanges.from toDictionary],
-        [stateChanges.to toDictionary],
-        @"isSubscribed",
-        @"isSMSSubscribed"
-    );
-    successCallback(smsSubscriptionCallbackId, result);
 }
 
 - (void)setProvidesNotificationSettingsView:(CDVInvokedUrlCommand *)command {
@@ -323,20 +289,6 @@ static Class delegateClass = nil;
 
 - (void)optOut:(CDVInvokedUrlCommand*)command {
     [OneSignal.User.pushSubscription optOut];
-}
-
-- (void)addEmailSubscriptionObserver:(CDVInvokedUrlCommand *)command {
-    bool first = emailSubscriptionCallbackId == nil;
-    emailSubscriptionCallbackId = command.callbackId;
-    if (first)
-        [OneSignal addEmailSubscriptionObserver:self];
-}
-
-- (void)addSMSSubscriptionObserver:(CDVInvokedUrlCommand *)command {
-    bool first = smsSubscriptionCallbackId == nil;
-    smsSubscriptionCallbackId = command.callbackId;
-    if (first)
-        [OneSignal addSMSSubscriptionObserver:self];
 }
 
 - (void)setLogLevel:(CDVInvokedUrlCommand*)command {

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -251,7 +251,7 @@ static Class delegateClass = nil;
         [OneSignal.User.pushSubscription addObserver:self];
 }
 
-- (void)getId:(CDVInvokedUrlCommand*)command {
+- (void)getPushSubscriptionId:(CDVInvokedUrlCommand*)command {
     NSString *pushId = OneSignal.User.pushSubscription.id;
     if (pushId) {
         NSDictionary *result = @{
@@ -261,7 +261,7 @@ static Class delegateClass = nil;
     }
 }
 
-- (void)getToken:(CDVInvokedUrlCommand*)command {
+- (void)getPushSubscriptionToken:(CDVInvokedUrlCommand*)command {
     NSString *token = OneSignal.User.pushSubscription.token;
     if (token) {
         NSDictionary *result = @{
@@ -271,7 +271,7 @@ static Class delegateClass = nil;
     }
 }
 
-- (void)getOptedIn:(CDVInvokedUrlCommand*)command {
+- (void)getPushSubscriptionOptedIn:(CDVInvokedUrlCommand*)command {
     bool optedIn = OneSignal.User.pushSubscription.optedIn;
     NSDictionary *result = @{
             @"value" : @(optedIn)
@@ -279,11 +279,11 @@ static Class delegateClass = nil;
         successCallback(command.callbackId, result);
 }
 
-- (void)optIn:(CDVInvokedUrlCommand*)command {
+- (void)optInPushSubscription:(CDVInvokedUrlCommand*)command {
     [OneSignal.User.pushSubscription optIn];
 }
 
-- (void)optOut:(CDVInvokedUrlCommand*)command {
+- (void)optOutPushSubscription:(CDVInvokedUrlCommand*)command {
     [OneSignal.User.pushSubscription optOut];
 }
 

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -256,7 +256,7 @@ static Class delegateClass = nil;
     if (pushId) {
         NSDictionary *result = @{
             @"value" : pushId
-    };
+        };
         successCallback(command.callbackId, result);
     }
 }
@@ -266,7 +266,7 @@ static Class delegateClass = nil;
     if (token) {
         NSDictionary *result = @{
             @"value" : token
-    };
+        };
         successCallback(command.callbackId, result);
     }
 }
@@ -274,9 +274,9 @@ static Class delegateClass = nil;
 - (void)getPushSubscriptionOptedIn:(CDVInvokedUrlCommand*)command {
     bool optedIn = OneSignal.User.pushSubscription.optedIn;
     NSDictionary *result = @{
-            @"value" : @(optedIn)
+        @"value" : @(optedIn)
     };
-        successCallback(command.callbackId, result);
+    successCallback(command.callbackId, result);
 }
 
 - (void)optInPushSubscription:(CDVInvokedUrlCommand*)command {

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -251,17 +251,13 @@ static Class delegateClass = nil;
         [OneSignal.User.pushSubscription addObserver:self];
 }
 
-- (void)removePushSubscriptionObserver:(CDVInvokedUrlCommand*)command {
-    [OneSignal.User.pushSubscription removeObserver:self];
-}
-
 - (void)getId:(CDVInvokedUrlCommand*)command {
     NSString *pushId = OneSignal.User.pushSubscription.id;
     if (pushId) {
         NSDictionary *result = @{
             @"value" : pushId
     };
-    successCallback(command.callbackId, result);
+        successCallback(command.callbackId, result);
     }
 }
 
@@ -271,7 +267,7 @@ static Class delegateClass = nil;
         NSDictionary *result = @{
             @"value" : token
     };
-    successCallback(command.callbackId, result);
+        successCallback(command.callbackId, result);
     }
 }
 
@@ -280,7 +276,7 @@ static Class delegateClass = nil;
     NSDictionary *result = @{
             @"value" : @(optedIn)
     };
-    successCallback(command.callbackId, result);
+        successCallback(command.callbackId, result);
 }
 
 - (void)optIn:(CDVInvokedUrlCommand*)command {

--- a/www/PushSubscriptionNamespace.ts
+++ b/www/PushSubscriptionNamespace.ts
@@ -1,5 +1,4 @@
-import { ChangeEvent,
-    PushSubscriptionChange } from "./Subscription";
+import { PushSubscriptionState } from "./Subscription";
 
 // Suppress TS warnings about window.cordova
 declare let window: any; // turn off type checking
@@ -9,9 +8,9 @@ export default class PushSubscription {
     private _token?: string | null;
     private _optedIn?: boolean;
 
-    private _subscriptionObserverList: ((event:ChangeEvent<PushSubscriptionChange>)=>void)[] = [];
+    private _subscriptionObserverList: ((event:PushSubscriptionState)=>void)[] = [];
 
-    private _processFunctionList<ObserverChangeEvent>(array: ((event:ChangeEvent<ObserverChangeEvent>)=>void)[], param: ChangeEvent<ObserverChangeEvent>): void {
+    private _processFunctionList(array: ((event:PushSubscriptionState)=>void)[], param: PushSubscriptionState): void {
         for (let i = 0; i < array.length; i++) {
             array[i](param);
         }
@@ -49,9 +48,9 @@ export default class PushSubscription {
         window.cordova.exec(getOptedInCallback, function(){}, "OneSignalPush", "getPushSubscriptionOptedIn");
 
         this.addObserver(event => {
-            this._id = event.to.id;
-            this._token = event.to.token;
-            this._optedIn = event.to.optedIn;
+            this._id = event.id;
+            this._token = event.token;
+            this._optedIn = event.optedIn;
         });
     }
     
@@ -68,14 +67,13 @@ export default class PushSubscription {
     }  
 
     /**
-     * The OSPushSubscriptionObserver.onOSPushSubscriptionChanged method will be fired on the passed-in object when the push subscription changes. 
-     * This method returns the current OSPushSubscriptionState at the time of adding this observer.
-     * @param  {(event:ChangeEvent<SubscriptionChange>)=>void} observer
+     * Add a callback that fires when the OneSignal push subscription state changes.
+     * @param  {(event: PushSubscriptionState)=>void} observer
      * @returns void
      */
-    addObserver(observer: (event: ChangeEvent<PushSubscriptionChange>) => void): void {
+    addObserver(observer: (event: PushSubscriptionState) => void): void {
         this._subscriptionObserverList.push(observer);
-        const subscriptionCallBackProcessor = (state: ChangeEvent<PushSubscriptionChange>) => {
+        const subscriptionCallBackProcessor = (state: PushSubscriptionState) => {
             this._processFunctionList(this._subscriptionObserverList, state);
         };
         window.cordova.exec(subscriptionCallBackProcessor, function(){}, "OneSignalPush", "addPushSubscriptionObserver", []);
@@ -83,10 +81,10 @@ export default class PushSubscription {
 
     /**
      * Remove a push subscription observer that has been previously added.
-     * @param  {(event:ChangeEvent<PushSubscriptionChange>)=>void} observer
+     * @param  {(event: PushSubscriptionState)=>void} observer
      * @returns void
      */
-    removeObserver(observer: (event:ChangeEvent<PushSubscriptionChange>) => void): void {
+    removeObserver(observer: (event: PushSubscriptionState) => void): void {
         let index = this._subscriptionObserverList.indexOf(observer);
         if (index !== -1) {
             this._subscriptionObserverList.splice(index, 1);

--- a/www/PushSubscriptionNamespace.ts
+++ b/www/PushSubscriptionNamespace.ts
@@ -20,7 +20,7 @@ export default class PushSubscription {
     /**
      * Sets initial Push Subscription properties and adds observer for changes
      */
-    setPropertiesAndObserver():void {
+    _setPropertiesAndObserver():void {
         /**
          * Receive push Id
          * @param obj 

--- a/www/PushSubscriptionNamespace.ts
+++ b/www/PushSubscriptionNamespace.ts
@@ -83,11 +83,15 @@ export default class PushSubscription {
 
     /**
      * Remove a push subscription observer that has been previously added.
+     * @param  {(event:ChangeEvent<PushSubscriptionChange>)=>void} observer
      * @returns void
      */
-    removeObserver(): void {
-        window.cordova.exec(function(){}, function(){}, "OneSignalPush", "removePushSubscriptionObserver", []);
-    }
+    removeObserver(observer: (event:ChangeEvent<PushSubscriptionChange>) => void): void {
+        let index = this._subscriptionObserverList.indexOf(observer);
+        if (index !== -1) {
+            this._subscriptionObserverList.splice(index, 1);
+        }
+    };
     
     /**
      * Call this method to receive push notifications on the device or to resume receiving of push notifications after calling optOut. If needed, this method will prompt the user for push notifications permission.

--- a/www/PushSubscriptionNamespace.ts
+++ b/www/PushSubscriptionNamespace.ts
@@ -28,7 +28,7 @@ export default class PushSubscription {
         const getIdCallback = (obj: {value: string}) => {
             this._id = obj.value;
         };
-        window.cordova.exec(getIdCallback, function(){}, "OneSignalPush", "getId");
+        window.cordova.exec(getIdCallback, function(){}, "OneSignalPush", "getPushSubscriptionId");
 
         /**
          * Receive token
@@ -37,7 +37,7 @@ export default class PushSubscription {
         const getTokenCallback = (obj: {value: string}) => {
             this._token = obj.value;
         };
-        window.cordova.exec(getTokenCallback, function(){}, "OneSignalPush", "getToken");
+        window.cordova.exec(getTokenCallback, function(){}, "OneSignalPush", "getPushSubscriptionToken");
         
         /**
          * Receive opted-in status
@@ -46,7 +46,7 @@ export default class PushSubscription {
         const getOptedInCallback = (obj: {value: boolean}) => {
             this._optedIn = obj.value;
         };
-        window.cordova.exec(getOptedInCallback, function(){}, "OneSignalPush", "getOptedIn");
+        window.cordova.exec(getOptedInCallback, function(){}, "OneSignalPush", "getPushSubscriptionOptedIn");
 
         this.addObserver(event => {
             this._id = event.to.id;
@@ -98,7 +98,7 @@ export default class PushSubscription {
      * @returns void
      */
     optIn(): void {
-        window.cordova.exec(function(){}, function(){}, "OneSignalPush", "optIn");
+        window.cordova.exec(function(){}, function(){}, "OneSignalPush", "OptInPushSubscription");
     }
 
     /**
@@ -106,6 +106,6 @@ export default class PushSubscription {
      * @returns void
      */
     optOut(): void {
-        window.cordova.exec(function(){}, function(){}, "OneSignalPush", "optOut");
+        window.cordova.exec(function(){}, function(){}, "OneSignalPush", "optOutPushSubscription");
     }
 }

--- a/www/Subscription.ts
+++ b/www/Subscription.ts
@@ -43,7 +43,7 @@ export interface ChangeEvent<ObserverChangeEvent> {
     to   : ObserverChangeEvent;
 }
 
-export type ObserverChangeEvent = PermissionChange | PushSubscriptionChange | EmailSubscriptionChange | SMSSubscriptionChange
+export type ObserverChangeEvent = PermissionChange | PushSubscriptionState | EmailSubscriptionChange | SMSSubscriptionChange
 
 export interface PermissionChange {
     status                  : PermissionStatus;
@@ -52,7 +52,7 @@ export interface PermissionChange {
 }
 
 /// Represents the current user's push notification subscription state with OneSignal
-export interface PushSubscriptionChange {
+export interface PushSubscriptionState {
     id                  ?: string;
     token               ?: string;
     optedIn             : boolean;

--- a/www/index.ts
+++ b/www/index.ts
@@ -28,14 +28,6 @@
 import { OpenedEvent } from "./models/NotificationOpened";
 import NotificationReceivedEvent from "./NotificationReceivedEvent";
 import OSNotification from './OSNotification';
-import {
-    ChangeEvent,
-    DeviceState,
-    EmailSubscriptionChange,
-    PermissionChange,
-    SMSSubscriptionChange,
-    SubscriptionChange
-} from "./Subscription";
 
 import User from "./UserNamespace";
 import Debug from "./DebugNamespace";
@@ -58,15 +50,6 @@ export class OneSignalPlugin {
     private _notificationOpenedDelegate = function(notificationOpened: OpenedEvent) {};
 
     private _permissionObserverList: ((event:ChangeEvent<PermissionChange>)=>void)[] = [];
-    private _subscriptionObserverList: ((event:ChangeEvent<SubscriptionChange>)=>void)[] = [];
-    private _emailSubscriptionObserverList: ((event:ChangeEvent<EmailSubscriptionChange>)=>void)[] = [];
-    private _smsSubscriptionObserverList: ((event:ChangeEvent<SMSSubscriptionChange>)=>void)[] = [];
-
-    private _processFunctionList<ObserverChangeEvent>(array: ((event:ChangeEvent<ObserverChangeEvent>)=>void)[], param: ChangeEvent<ObserverChangeEvent>): void {
-        for (let i = 0; i < array.length; i++) {
-            array[i](param);
-        }
-    }
 
     /**
      * Initializes the OneSignal SDK. This should be called during startup of the application.
@@ -77,7 +60,7 @@ export class OneSignalPlugin {
         this._appID = appId;
 
         const observerCallback = () => {
-            this.User.pushSubscription.setPropertiesAndObserver();
+            this.User.pushSubscription._setPropertiesAndObserver();
         }
 
         window.cordova.exec(observerCallback, function(){}, "OneSignalPush", "init", [this._appID]);
@@ -141,45 +124,6 @@ export class OneSignalPlugin {
             handler(new DeviceState(json));
         };
         window.cordova.exec(deviceStateCallback, function(){}, "OneSignalPush", "getDeviceState", []);
-    };
-
-    /**
-     * Add a callback that fires when the OneSignal subscription state changes.
-     * @param  {(event:ChangeEvent<SubscriptionChange>)=>void} observer
-     * @returns void
-     */
-    addSubscriptionObserver(observer: (event: ChangeEvent<SubscriptionChange>) => void): void {
-        this._subscriptionObserverList.push(observer);
-        const subscriptionCallBackProcessor = (state: ChangeEvent<SubscriptionChange>) => {
-            this._processFunctionList(this._subscriptionObserverList, state);
-        };
-        window.cordova.exec(subscriptionCallBackProcessor, function(){}, "OneSignalPush", "addSubscriptionObserver", []);
-    };
-
-    /**
-     * Add a callback that fires when the OneSignal email subscription changes.
-     * @param  {(event:ChangeEvent<EmailSubscriptionChange>)=>void} observer
-     * @returns void
-     */
-    addEmailSubscriptionObserver(observer: (event: ChangeEvent<EmailSubscriptionChange>) => void): void {
-        this._emailSubscriptionObserverList.push(observer);
-        const emailSubscriptionCallbackProcessor = (state: ChangeEvent<EmailSubscriptionChange>) => {
-            this._processFunctionList(this._emailSubscriptionObserverList, state);
-        };
-        window.cordova.exec(emailSubscriptionCallbackProcessor, function(){}, "OneSignalPush", "addEmailSubscriptionObserver", []);
-    };
-
-    /**
-     * Add a callback that fires when the OneSignal sms subscription changes.
-     * @param  {(event:ChangeEvent<SMSSubscriptionChange>)=>void} observer
-     * @returns void
-     */
-    addSMSSubscriptionObserver(observer: (event: ChangeEvent<SMSSubscriptionChange>) => void): void {
-        this._smsSubscriptionObserverList.push(observer);
-        const smsSubscriptionCallbackProcessor = (state: ChangeEvent<SMSSubscriptionChange>) => {
-            this._processFunctionList(this._smsSubscriptionObserverList, state);
-        };
-        window.cordova.exec(smsSubscriptionCallbackProcessor, function(){}, "OneSignalPush", "addSMSSubscriptionObserver", []);
     };
 
     /**


### PR DESCRIPTION
# Description
## One Line Summary
Update PushSubscription methods on Android

## Details

### Motivation
Update methods to adhere to User Model conventions.

### Scope
PushSubscription has updated methods to observe and access push subscription behavior/properties. They will be invoked as:
`window.plugins.OneSignal.User.pushSubscription.addObserver(function (state){...});`
`window.plugins.OneSignal.User.pushSubscription.removeObserver();`
`window.plugins.OneSignal.User.pushSubscription.optIn();`
`window.plugins.OneSignal.User.pushSubscription.optOut();`

Separate internal methods were created in order to access pushSubscription properties with the following API:
`let pushId = window.plugins.OneSignal.User.pushSubscription.id;`
`let token = window.plugins.OneSignal.User.pushSubscription.token;`
`let optedIn = window.plugins.OneSignal.User.pushSubscription.optedIn;`

### OPTIONAL - Other
This PR only encompasses changes to Android and some small updates to the main plugin/iOS files. Previous iOS PR here: https://github.com/OneSignal/OneSignal-Cordova-SDK/pull/852

# Testing
## Unit testing
No unit testing was used.

## Manual testing
**RECOMMEND - OPTIONAL -** Explain what scenarios were tested and the environment.
Successfully tested methods on Samsung Galaxy S21 running Android 13 and various emulators running Android 12 and Android 13.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [X] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/859)
<!-- Reviewable:end -->
