### PR TITLE
[User Model] Notifications namespace and implementations for iOS & Android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -34,6 +34,7 @@
   <js-module src="dist/InAppMessagesNamespace.js" name="InAppMessagesNamespace" />
   <js-module src="dist/SessionNamespace.js" name="SessionNamespace" />
   <js-module src="dist/LocationNamespace.js" name="LocationNamespace" />
+  <js-module src="dist/NotificationsNamespace.js" name="NotificationsNamespace" />
 
   <platform name="android">
     <framework src="com.onesignal:OneSignal:5.0.0-beta1" />

--- a/src/android/com/onesignal/cordova/OneSignalController.java
+++ b/src/android/com/onesignal/cordova/OneSignalController.java
@@ -1,8 +1,6 @@
 package com.onesignal.cordova;
 
-import com.onesignal.OSDeviceState;
 import com.onesignal.OneSignal;
-import com.onesignal.OneSignal.PostNotificationResponseHandler;
 import com.onesignal.Continue;
 
 import org.apache.cordova.CallbackContext;
@@ -17,27 +15,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class OneSignalController {
-
-  /**
-   * Subscriptions
-   */
-  public static boolean getDeviceState(CallbackContext callbackContext) {
-    OSDeviceState deviceState = OneSignal.getDeviceState();
-    if (deviceState != null)
-      CallbackHelper.callbackSuccess(callbackContext, deviceState.toJSONObject());
-    return true;
-  }
-
-  public static boolean disablePush(JSONArray data) {
-    try {
-      OneSignal.disablePush(data.getBoolean(0));
-      return true;
-    }
-    catch (Throwable t) {
-      t.printStackTrace();
-      return false;
-    }
-  }
 
   /**
    * Misc
@@ -207,34 +184,10 @@ public class OneSignalController {
   /**
    * Notifications
    */
-  public static boolean postNotification(CallbackContext callbackContext, JSONArray data) {
+
+  public static boolean clearAllNotifications() {
     try {
-      JSONObject jo = data.getJSONObject(0);
-      final CallbackContext jsPostNotificationCallBack = callbackContext;
-      OneSignal.postNotification(jo,
-              new PostNotificationResponseHandler() {
-                @Override
-                public void onSuccess(JSONObject response) {
-                  CallbackHelper.callbackSuccess(jsPostNotificationCallBack, response);
-                }
-
-                @Override
-                public void onFailure(JSONObject response) {
-                  CallbackHelper.callbackError(jsPostNotificationCallBack, response);
-                }
-              });
-
-      return true;
-    }
-    catch (Throwable t) {
-      t.printStackTrace();
-      return false;
-    }
-  }
-
-  public static boolean clearOneSignalNotifications() {
-    try {
-      OneSignal.clearOneSignalNotifications();
+      OneSignal.getNotifications().clearAllNotifications();
       return true;
     }
     catch(Throwable t) {
@@ -245,7 +198,7 @@ public class OneSignalController {
 
   public static boolean removeNotification(JSONArray data) {
     try {
-      OneSignal.removeNotification(data.getInt(0));
+      OneSignal.getNotifications().removeNotification(data.getInt(0));
       return true;
     } catch (Throwable t) {
       t.printStackTrace();
@@ -255,7 +208,7 @@ public class OneSignalController {
 
   public static boolean removeGroupedNotifications(JSONArray data) {
     try {
-      OneSignal.removeGroupedNotifications(data.getString(0));
+      OneSignal.getNotifications().removeGroupedNotifications(data.getString(0));
       return true;
     } catch (Throwable t) {
       t.printStackTrace();
@@ -268,7 +221,7 @@ public class OneSignalController {
     return true;
   }
 
-  public static boolean promptForPushNotificationsWithUserResponse(CallbackContext callbackContext, JSONArray data) {
+  public static boolean requestPermission(CallbackContext callbackContext, JSONArray data) {
     final CallbackContext jsPromptForPushNotificationsCallback = callbackContext;
     boolean fallbackToSettings = false;
     try {
@@ -277,28 +230,38 @@ public class OneSignalController {
       e.printStackTrace();
     }
 
-    OneSignal.promptForPushNotifications(fallbackToSettings, new OneSignal.PromptForPushNotificationPermissionResponseHandler() {
-      @Override
-      public void response(boolean accepted) {
-        CallbackHelper.callbackSuccessBoolean(callbackContext, accepted);
+    OneSignal.getNotifications().requestPermission(fallbackToSettings, Continue.with(r -> {
+      if (r.isSuccess()) {
+        if (r.getData()) {
+          Boolean didPermit = r.getData();
+          CallbackHelper.callbackSuccessBoolean(callbackContext, didPermit);
+        }
       }
-    });
+    }));
     return true;
+  }
+
+  public static boolean getPermission(CallbackContext callbackContext) {
+    boolean granted = OneSignal.getNotifications().getPermission();
+    try {
+      JSONObject permissionObj = new JSONObject ();
+      permissionObj.put("value", granted);
+
+      CallbackHelper.callbackSuccess(callbackContext, permissionObj);
+    } catch (JSONException e){
+      e.printStackTrace();
+    }
+    return true;
+  }
+
+  public static boolean canRequestPermission() {
+      // doesn't apply to Android 5.0.0-beta1?
+      return true;
   }
 
   public static boolean setLaunchURLsInApp() {
     // doesn't apply to Android
     return true;
-  }
-
-  public static boolean unsubscribeWhenNotificationsAreDisabled(JSONArray data) {
-    try {
-      OneSignal.unsubscribeWhenNotificationsAreDisabled(data.getBoolean(0));
-      return true;
-    } catch (JSONException e) {
-      e.printStackTrace();
-    }
-    return false;
   }
 
   /**

--- a/src/android/com/onesignal/cordova/OneSignalObserverController.java
+++ b/src/android/com/onesignal/cordova/OneSignalObserverController.java
@@ -11,16 +11,13 @@ import com.onesignal.OneSignal;
 import com.onesignal.user.subscriptions.IPushSubscription;
 import com.onesignal.user.subscriptions.ISubscription;
 import com.onesignal.user.subscriptions.ISubscriptionChangedHandler;
-
-
-import com.onesignal.OSPermissionObserver;
-import com.onesignal.OSPermissionStateChanges;
+import com.onesignal.notifications.IPermissionChangedHandler;
 
 public class OneSignalObserverController {
   private static CallbackContext jsPermissionObserverCallBack;
   private static CallbackContext jsSubscriptionObserverCallBack;
 
-  private static OSPermissionObserver permissionObserver;
+  private static IPermissionChangedHandler permissionObserver;
 
   private static ISubscriptionChangedHandler handler;
 
@@ -36,31 +33,20 @@ public class OneSignalObserverController {
 
   public static boolean addPermissionObserver(CallbackContext callbackContext) {
     jsPermissionObserverCallBack = callbackContext;
-    if (permissionObserver == null) {
-      permissionObserver = new OSPermissionObserver() {
-        @Override
-        public void onOSPermissionChanged(OSPermissionStateChanges stateChanges) {
-          JSONObject fromJSON = stateChanges.getFrom().toJSONObject();
-          JSONObject toJSON = stateChanges.getTo().toJSONObject();
-          JSONObject modifiedObj = new JSONObject();
+    permissionObserver = new IPermissionChangedHandler() {
+      @Override
+      public void onPermissionChanged(boolean permission) {
+        JSONObject permissionObj = new JSONObject();
 
-          try {
-            // convert areNotificationsEnabled to status of type PermissionStatus
-            fromJSON.put("status", fromJSON.getBoolean("areNotificationsEnabled") ? 2 : 1);
-            fromJSON.remove("areNotificationsEnabled");
-            toJSON.put("status", toJSON.getBoolean("areNotificationsEnabled") ? 2 : 1);
-            toJSON.remove("areNotificationsEnabled");
-
-            modifiedObj.put("from", fromJSON);
-            modifiedObj.put("to", toJSON);
-          } catch (JSONException e) {
-            e.printStackTrace();
-          }
-          callbackSuccess(jsPermissionObserverCallBack, modifiedObj);
+        try {
+          System.out.println(permissionObj);
+        } catch (JSONException e) {
+          e.printStackTrace();
         }
-      };
-      OneSignal.addPermissionObserver(permissionObserver);
-    }
+        callbackSuccess(jsPermissionObserverCallBack, permissionObj);
+      }
+    };
+    OneSignal.getNotifications().addPermissionChangedHandler(permissionObserver);
     return true;
   }
 

--- a/src/android/com/onesignal/cordova/OneSignalObserverController.java
+++ b/src/android/com/onesignal/cordova/OneSignalObserverController.java
@@ -37,9 +37,8 @@ public class OneSignalObserverController {
       @Override
       public void onPermissionChanged(boolean permission) {
         JSONObject permissionObj = new JSONObject();
-
         try {
-          System.out.println(permissionObj);
+          permissionObj.put("value", permission);
         } catch (JSONException e) {
           e.printStackTrace();
         }

--- a/src/android/com/onesignal/cordova/OneSignalObserverController.java
+++ b/src/android/com/onesignal/cordova/OneSignalObserverController.java
@@ -37,17 +37,11 @@ public class OneSignalObserverController {
       permissionObserver = new IPermissionChangedHandler() {
         @Override
         public void onPermissionChanged(boolean permission) {
-          JSONObject permissionObj = new JSONObject();
-          try {
-            permissionObj.put("value", permission);
-          } catch (JSONException e) {
-            e.printStackTrace();
-          }
-          callbackSuccess(jsPermissionObserverCallBack, permissionObj);
+          CallbackHelper.callbackSuccessBoolean(jsPermissionObserverCallBack, permission);
         }
-      OneSignal.getNotifications().addPermissionChangedHandler(permissionObserver);
       };
-    }
+      OneSignal.getNotifications().addPermissionChangedHandler(permissionObserver);
+    };  
     return true;
   }
 

--- a/src/android/com/onesignal/cordova/OneSignalObserverController.java
+++ b/src/android/com/onesignal/cordova/OneSignalObserverController.java
@@ -33,19 +33,21 @@ public class OneSignalObserverController {
 
   public static boolean addPermissionObserver(CallbackContext callbackContext) {
     jsPermissionObserverCallBack = callbackContext;
-    permissionObserver = new IPermissionChangedHandler() {
-      @Override
-      public void onPermissionChanged(boolean permission) {
-        JSONObject permissionObj = new JSONObject();
-        try {
-          permissionObj.put("value", permission);
-        } catch (JSONException e) {
-          e.printStackTrace();
+    if (permissionObserver == null) {
+      permissionObserver = new IPermissionChangedHandler() {
+        @Override
+        public void onPermissionChanged(boolean permission) {
+          JSONObject permissionObj = new JSONObject();
+          try {
+            permissionObj.put("value", permission);
+          } catch (JSONException e) {
+            e.printStackTrace();
+          }
+          callbackSuccess(jsPermissionObserverCallBack, permissionObj);
         }
-        callbackSuccess(jsPermissionObserverCallBack, permissionObj);
-      }
-    };
-    OneSignal.getNotifications().addPermissionChangedHandler(permissionObserver);
+      OneSignal.getNotifications().addPermissionChangedHandler(permissionObserver);
+      };
+    }
     return true;
   }
 

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -509,8 +509,7 @@ public class OneSignalPush extends CordovaPlugin {
         foregroundData.put("sound", notification.getSound());
         foregroundData.put("title", notification.getTitle());
         foregroundData.put("launchURL", notification.getLaunchURL());
-        // Can't seem to access this?
-        // foregroundData.put("rawPayload", notification.getrawPayload());
+        foregroundData.put("rawPayload", notification.getrawPayload());
         foregroundData.put("actionButtons", notification.getActionButtons());
         foregroundData.put("additionalData", notification.getAdditionalData());
         foregroundData.put("notificationId", notification.getNotificationId());

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -34,6 +34,7 @@ import com.onesignal.inAppMessages.IInAppMessageClickHandler;
 import com.onesignal.inAppMessages.IInAppMessageClickResult;
 import com.onesignal.inAppMessages.IInAppMessageLifecycleHandler;
 import com.onesignal.OneSignal;
+import com.onesignal.debug.internal.logging.Logging;
 import com.onesignal.common.OneSignalWrapper;
 
 import com.onesignal.notifications.INotification;
@@ -224,7 +225,7 @@ public class OneSignalPush extends CordovaPlugin {
       CallbackHelper.callbackSuccessBoolean(callbackContext, true);
       return true;
     } catch (JSONException e) {
-      Log.e(TAG, "execute: Got JSON Exception " + e.getMessage());
+      Logging.error(TAG + "execute: Got JSON Exception " + e.getMessage(), null);
       return false;
     }
   }
@@ -453,7 +454,7 @@ public class OneSignalPush extends CordovaPlugin {
         break;
 
       default:
-        Log.e(TAG, "Invalid action : " + action);
+        Logging.error(TAG + "Invalid action : " + action, null);
         CallbackHelper.callbackError(callbackContext, "Invalid action : " + action);
     }
 
@@ -468,6 +469,7 @@ public class OneSignalPush extends CordovaPlugin {
       INotificationReceivedEvent notificationReceivedEvent = notificationReceivedEventCache.get(notificationId);
 
       if (notificationReceivedEvent == null) {
+        Logging.error("Could not find notification completion block with id: " + notificationId, null); //crashes without 2nd parameter
         return false;
       }
 

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -494,8 +494,6 @@ public class OneSignalPush extends CordovaPlugin {
     @Override
     public void notificationWillShowInForeground(INotificationReceivedEvent notificationReceivedEvent) {
       try {
-        System.out.println(notificationReceivedEvent.getNotification());
-
         INotification notification = notificationReceivedEvent.getNotification();
         notificationReceivedEventCache.put(notification.getNotificationId(), notificationReceivedEvent);
 

--- a/src/ios/OneSignalPush.h
+++ b/src/ios/OneSignalPush.h
@@ -39,11 +39,6 @@
 - (void)completeNotification:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)init:(CDVInvokedUrlCommand* _Nonnull)command;
 
-- (void)addPermissionObserver:(CDVInvokedUrlCommand* _Nonnull)command;
-- (void)addSubscriptionObserver:(CDVInvokedUrlCommand* _Nonnull)command;
-- (void)addEmailSubscriptionObserver:(CDVInvokedUrlCommand* _Nonnull)command;
-- (void)addSMSSubscriptionObserver:(CDVInvokedUrlCommand* _Nonnull)command;
-
 - (void)setLogLevel:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)setAlertLevel:(CDVInvokedUrlCommand* _Nonnull)command;
 

--- a/src/ios/OneSignalPush.h
+++ b/src/ios/OneSignalPush.h
@@ -39,8 +39,6 @@
 - (void)completeNotification:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)init:(CDVInvokedUrlCommand* _Nonnull)command;
 
-- (void)getDeviceState:(CDVInvokedUrlCommand* _Nonnull)command;
-
 - (void)addPermissionObserver:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)addSubscriptionObserver:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)addEmailSubscriptionObserver:(CDVInvokedUrlCommand* _Nonnull)command;
@@ -64,17 +62,16 @@
 - (void)optIn:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)optOut:(CDVInvokedUrlCommand* _Nonnull)command;
 
-- (void)promptForPushNotificationsWithUserResponse:(CDVInvokedUrlCommand* _Nonnull)command;
+// Notifications
+- (void)addPermissionObserver:(CDVInvokedUrlCommand* _Nonnull)command;
+- (void)requestPermission:(CDVInvokedUrlCommand* _Nonnull)command;
+- (void)getPermission:(CDVInvokedUrlCommand* _Nonnull)command;
+- (void)canRequestPermission:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)registerForProvisionalAuthorization:(CDVInvokedUrlCommand* _Nonnull)command;
-- (void)disablePush:(CDVInvokedUrlCommand* _Nonnull)command;
-- (void)postNotification:(CDVInvokedUrlCommand* _Nonnull)command;
-
-// Start Android Only
-- (void)clearOneSignalNotifications:(CDVInvokedUrlCommand* _Nonnull)command;
-- (void)unsubscribeWhenNotificationsAreDisabled:(CDVInvokedUrlCommand* _Nonnull)command;
+- (void)clearAllNotifications:(CDVInvokedUrlCommand* _Nonnull)command;
+// Android Only - Notifications
 - (void)removeNotification:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)removeGroupedNotifications:(CDVInvokedUrlCommand* _Nonnull)command;
-// End Android Only
 
 - (void)getPrivacyConsent:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)getRequiresPrivacyConsent:(CDVInvokedUrlCommand* _Nonnull)command;

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -161,8 +161,8 @@ static Class delegateClass = nil;
 
 @implementation OneSignalPush
 
-- (void)onOSPermissionChanged:(OSPermissionStateChanges*)stateChanges {
-    successCallback(permissionObserverCallbackId, [stateChanges toDictionary]);
+- (void)onOSPermissionChanged:(OSPermissionState*)state {
+    successCallbackBoolean(permissionObserverCallbackId, state.permission);
 }
 
 - (void)onOSSubscriptionChanged:(OSSubscriptionStateChanges*)stateChanges {
@@ -200,6 +200,7 @@ static Class delegateClass = nil;
     OSNotificationDisplayResponse completion = self.notificationCompletionCache[notificationId];
 
     if (!completion) {
+        [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"OneSignal (objc): could not find notification completion block with id: %@", notificationId]];
         return;
     }
 
@@ -332,8 +333,7 @@ static Class delegateClass = nil;
 - (void)registerForProvisionalAuthorization:(CDVInvokedUrlCommand *)command {
     registerForProvisionalAuthorizationCallbackId = command.callbackId;
     [OneSignal.Notifications registerForProvisionalAuthorization:^(BOOL accepted) {
-        // TODO: Update the response in 5.0.0 GA release to just boolean
-        successCallback(registerForProvisionalAuthorizationCallbackId, @{@"accepted": (accepted ? @"true" : @"false")});
+        successCallbackBoolean(registerForProvisionalAuthorizationCallbackId, accepted);
     }];
 }
 

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -34,10 +34,9 @@
 NSString* notificationWillShowInForegoundCallbackId;
 NSString* notificationOpenedCallbackId;
 NSString* getIdsCallbackId;
-NSString* postNotificationCallbackId;
 NSString* permissionObserverCallbackId;
 NSString* subscriptionObserverCallbackId;
-NSString* promptForPushNotificationsWithUserResponseCallbackId;
+NSString* requestPermissionCallbackId;
 NSString* registerForProvisionalAuthorizationCallbackId;
 NSString* enterLiveActivityCallbackId;
 NSString* exitLiveActivityCallbackId;
@@ -178,7 +177,7 @@ static Class delegateClass = nil;
 - (void)setNotificationWillShowInForegroundHandler:(CDVInvokedUrlCommand*)command {
     notificationWillShowInForegoundCallbackId = command.callbackId;
 
-    [OneSignal setNotificationWillShowInForegroundHandler:^(OSNotification *notification, OSNotificationDisplayResponse completion) {
+    [OneSignal.Notifications setNotificationWillShowInForegroundHandler:^(OSNotification *notification, OSNotificationDisplayResponse completion) {
         self.receivedNotificationCache[notification.notificationId] = notification;
         self.notificationCompletionCache[notification.notificationId] = completion;
         processNotificationWillShowInForeground(notification);
@@ -188,7 +187,7 @@ static Class delegateClass = nil;
 - (void)setNotificationOpenedHandler:(CDVInvokedUrlCommand*)command {
     notificationOpenedCallbackId = command.callbackId;
 
-    [OneSignal setNotificationOpenedHandler:^(OSNotificationOpenedResult * _Nonnull result) {
+    [OneSignal.Notifications setNotificationOpenedHandler:^(OSNotificationOpenedResult * _Nonnull result) {
         actionNotification = result;
         if (pluginCommandDelegate)
             processNotificationOpened(actionNotification);
@@ -201,7 +200,6 @@ static Class delegateClass = nil;
     OSNotificationDisplayResponse completion = self.notificationCompletionCache[notificationId];
 
     if (!completion) {
-        [OneSignal onesignalLog:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"OneSignal (objc): could not find notification completion block with id: %@", notificationId]];
         return;
     }
 
@@ -229,10 +227,6 @@ static Class delegateClass = nil;
         processNotificationOpened(actionNotification);
 }
 
-- (void)getDeviceState:(CDVInvokedUrlCommand*)command {
-    successCallback(command.callbackId, [[OneSignal getDeviceState] jsonRepresentation]);
-}
-
 - (void)setLanguage:(CDVInvokedUrlCommand*)command {
     [OneSignal.User setLanguage:command.arguments[0]];
 }
@@ -240,8 +234,9 @@ static Class delegateClass = nil;
 - (void)addPermissionObserver:(CDVInvokedUrlCommand*)command {
     bool first = permissionObserverCallbackId  == nil;
     permissionObserverCallbackId = command.callbackId;
-    if (first)
-        [OneSignal addPermissionObserver:self];
+    if (first) {
+        [OneSignal.Notifications addPermissionObserver:self];
+    }
 }
 
 - (void)addPushSubscriptionObserver:(CDVInvokedUrlCommand*)command {
@@ -315,46 +310,42 @@ static Class delegateClass = nil;
     [OneSignal.User removeTags:command.arguments];
 }
 
-- (void)promptForPushNotificationsWithUserResponse:(CDVInvokedUrlCommand*)command {
-   promptForPushNotificationsWithUserResponseCallbackId = command.callbackId;
-    [OneSignal promptForPushNotificationsWithUserResponse:^(BOOL accepted) {
-        successCallbackBoolean(promptForPushNotificationsWithUserResponseCallbackId, accepted);
+- (void)requestPermission:(CDVInvokedUrlCommand*)command {
+    requestPermissionCallbackId = command.callbackId;
+    [OneSignal.Notifications requestPermission:^(BOOL accepted) {
+        successCallbackBoolean(requestPermissionCallbackId, accepted);
     } fallbackToSettings:[command.arguments[0] boolValue]];
+}
+
+- (void)getPermission:(CDVInvokedUrlCommand*)command {
+    bool isPermitted = [OneSignal.Notifications permission];
+    NSDictionary *result = @{
+            @"value" : @(isPermitted)
+    };
+    successCallback(command.callbackId, result);
+}
+
+- (void)canRequestPermission:(CDVInvokedUrlCommand*)command {
+    bool canRequest = [OneSignal.Notifications canRequestPermission];
+    NSDictionary *result = @{
+            @"value" : @(canRequest)
+    };
+    successCallback(command.callbackId, result);
 }
 
 - (void)registerForProvisionalAuthorization:(CDVInvokedUrlCommand *)command {
     registerForProvisionalAuthorizationCallbackId = command.callbackId;
-    [OneSignal registerForProvisionalAuthorization:^(BOOL accepted) {
-        // TODO: Update the response in next major release to just boolean
+    [OneSignal.Notifications registerForProvisionalAuthorization:^(BOOL accepted) {
+        // TODO: Update the response in 5.0.0 GA release to just boolean
         successCallback(registerForProvisionalAuthorizationCallbackId, @{@"accepted": (accepted ? @"true" : @"false")});
     }];
 }
 
-- (void)disablePush:(CDVInvokedUrlCommand*)command {
-    [OneSignal disablePush:[command.arguments[0] boolValue]];
-}
-
-- (void)postNotification:(CDVInvokedUrlCommand*)command {
-    postNotificationCallbackId = command.callbackId;
-
-    [OneSignal postNotification:command.arguments[0]
-        onSuccess:^(NSDictionary* results) {
-            successCallback(postNotificationCallbackId, results);
-        }
-        onFailure:^(NSError* error) {
-            if (error.userInfo && error.userInfo[@"returned"])
-                failureCallback(postNotificationCallbackId, error.userInfo[@"returned"]);
-            else
-                failureCallback(postNotificationCallbackId, @{@"error": @"HTTP no response error"});
-
-    }];
+- (void)clearAllNotifications:(CDVInvokedUrlCommand*)command {
+    [OneSignal.Notifications clearAll];
 }
 
 // Start Android only
-- (void)clearOneSignalNotifications:(CDVInvokedUrlCommand*)command {}
-
-- (void)unsubscribeWhenNotificationsAreDisabled:(CDVInvokedUrlCommand *)command {}
-
 - (void)removeNotification:(CDVInvokedUrlCommand *)command {}
 
 - (void)removeGroupedNotifications:(CDVInvokedUrlCommand *)command {}

--- a/www/NotificationsNamespace.ts
+++ b/www/NotificationsNamespace.ts
@@ -1,0 +1,185 @@
+import { OpenedEvent } from "./models/NotificationOpened";
+import NotificationReceivedEvent from "./NotificationReceivedEvent";
+import OSNotification from './OSNotification';
+
+// Suppress TS warnings about window.cordova
+declare let window: any; // turn off type checking
+
+export default class Notifications {
+    private _permissionObserverList: ((event:boolean)=>void)[] = [];
+    private _notificationOpenedDelegate = function(notificationOpened: OpenedEvent) {};
+    private _notificationWillShowInForegroundDelegate = function(notificationReceived: NotificationReceivedEvent) {};
+
+    private _processFunctionList(array: ((event:boolean)=>void)[], param: boolean): void {
+        for (let i = 0; i < array.length; i++) {
+            array[i](param);
+        }
+    }
+
+    private _permission?: boolean;
+
+    /**
+     * Sets initial permission value and adds observer for changes
+     */
+    _setPropertyAndObserver():void {
+        const getPermissionCallback = (obj: {value: boolean}) => {
+            this._permission = obj.value;
+        };
+        window.cordova.exec(getPermissionCallback, function(){}, "OneSignalPush", "getPermission");
+
+        this.addPermissionObserver(result => {
+            this._permission = result;
+        });
+    }
+
+    get permission(): boolean {
+        return this._permission || false;
+    }  
+
+    /**
+     * Add a callback that fires when the native push permission changes.
+     * @param  {(event:ChangeEvent<PermissionChange>)=>void} observer
+     * @returns void
+     */
+    addPermissionObserver(observer: (event: boolean) => void): void {
+        this._permissionObserverList.push(observer);
+        const permissionCallBackProcessor = (state: boolean) => {
+            this._processFunctionList(this._permissionObserverList, state);
+        };
+
+        window.cordova.exec(permissionCallBackProcessor, function(){}, "OneSignalPush", "addPermissionObserver", []);
+    };
+
+    /**
+     * Remove a push permission observer that has been previously added.
+     * @param  {(event:ChangeEvent<PermissionChange>)=>void} observer
+     * @returns void
+     */
+    removePermissionObserver(observer: (event: boolean) => void): void {
+        let index = this._permissionObserverList.indexOf(observer);
+        if (index !== -1) {
+            this._permissionObserverList.splice(index, 1);
+        }
+    };
+
+    /**
+     * Prompt the user for permission to receive push notifications. This will display the native system prompt to request push notification permission.
+     * Use the fallbackToSettings parameter to prompt to open the settings app if a user has already declined push permissions.
+     *
+     * Call with requestPermission(fallbackToSettings?, handler?)
+     *
+     * @param  {boolean} fallbackToSettings
+     * @param  {(response:boolean)=>void} handler
+     * @returns void
+     */
+    requestPermission(fallbackToSettingsOrHandler?: boolean | ((response: boolean) => void), handler?: (response: boolean) => void): void {
+        var fallbackToSettings = false;
+
+        if (typeof fallbackToSettingsOrHandler === "function") {
+            // Method was called like promptForPushNotificationsWithUserResponse(handler: function)
+            handler = fallbackToSettingsOrHandler;
+        }
+        else if (typeof fallbackToSettingsOrHandler === "boolean") {
+            // Method was called like promptForPushNotificationsWithUserResponse(fallbackToSettings: boolean, handler?: function)
+            fallbackToSettings = fallbackToSettingsOrHandler;
+        }
+        // Else method was called like promptForPushNotificationsWithUserResponse(), no need to modify
+
+        const internalCallback = (response: boolean) => {
+            if (handler) {
+                handler(response);
+            }
+        };
+        window.cordova.exec(internalCallback, function(){}, "OneSignalPush", "requestPermission", [fallbackToSettings]);
+    };
+
+    /**
+     * @param {(value: boolean) => void} handler
+     * @returns void
+     */
+    canRequestPermission(handler: (value: boolean) => void): void {
+        const canRequestPermissionCallback = (obj: {value: boolean}) => {
+            handler(obj.value);
+        };
+
+        window.cordova.exec(canRequestPermissionCallback, function(){}, "OneSignalPush", "canRequestPermission", []);
+    }
+
+    /**
+     * iOS Only
+     */
+
+    /**
+     * Instead of having to prompt the user for permission to send them push notifications, your app can request provisional authorization.
+     *
+     * For more information: https://documentation.onesignal.com/docs/ios-customizations#provisional-push-notifications
+     *
+     * @param  {(response:{accepted:boolean})=>void} handler
+     * @returns void
+     */
+    registerForProvisionalAuthorization(handler?: (response: { accepted: boolean }) => void): void {
+        // TODO: Update the response in GA release to just boolean
+        window.cordova.exec(handler, function(){}, "OneSignalPush", "registerForProvisionalAuthorization", []);
+    };
+
+    /**
+     * Sets a handler that will run whenever a notification is opened by the user.
+     * @param  {(openedEvent:OpenedEvent) => void} handler
+     * @returns void
+     */
+    setNotificationOpenedHandler(handler: (openedEvent: OpenedEvent) => void): void {
+        this._notificationOpenedDelegate = handler;
+
+        const notificationOpenedHandler = (json: OpenedEvent) => {
+            this._notificationOpenedDelegate(json);
+        };
+
+        window.cordova.exec(notificationOpenedHandler, function(){}, "OneSignalPush", "setNotificationOpenedHandler", []);
+    };
+
+    /**
+     * Sets the handler to run before displaying a notification while the app is in focus. Use this handler to read notification data and change it or decide if the notification should show or not.
+     * Note: this runs after the Notification Service Extension which can be used to modify the notification before showing it.
+     * @param  {(event:NotificationReceivedEvent)=>void} handler
+     * @returns void
+     */
+    setNotificationWillShowInForegroundHandler(handler: (event: NotificationReceivedEvent) => void): void {
+        this._notificationWillShowInForegroundDelegate = handler;
+
+        const foregroundParsingHandler = (notificationReceived: OSNotification) => {
+            this._notificationWillShowInForegroundDelegate(new NotificationReceivedEvent(notificationReceived));
+        };
+
+        window.cordova.exec(foregroundParsingHandler, function(){}, "OneSignalPush", "setNotificationWillShowInForegroundHandler", []);
+    };
+
+    /**
+     * Removes all OneSignal notifications.
+     * @returns void
+     */
+    clearAll(): void {
+        window.cordova.exec(function(){}, function(){}, "OneSignalPush", "clearAllNotifications", []);
+    };
+
+    /**
+     * Android Only 
+     */
+    
+    /**
+     * Cancels a single OneSignal notification based on its Android notification integer ID. Use instead of Android's [android.app.NotificationManager.cancel], otherwise the notification will be restored when your app is restarted.
+     * @param  {number} id - notification id to cancel
+     * @returns void
+     */
+    removeNotification(id: number): void {
+        window.cordova.exec(function(){}, function(){}, "OneSignalPush", "removeNotification", [id]);
+    };
+
+    /**
+     * Cancels a group of OneSignal notifications with the provided group key. Grouping notifications is a OneSignal concept, there is no [android.app.NotificationManager] equivalent.
+     * @param  {string} id - notification group id to cancel
+     * @returns void
+     */
+    removeGroupedNotifications(id: string): void {
+        window.cordova.exec(function(){}, function(){}, "OneSignalPush", "removeGroupedNotifications", [id]);
+    };
+}

--- a/www/NotificationsNamespace.ts
+++ b/www/NotificationsNamespace.ts
@@ -94,6 +94,7 @@ export default class Notifications {
     };
 
     /**
+     * Whether attempting to request notification permission will show a prompt. Returns true if the device has not been prompted for push notification permission already.
      * @param {(value: boolean) => void} handler
      * @returns void
      */
@@ -114,11 +115,10 @@ export default class Notifications {
      *
      * For more information: https://documentation.onesignal.com/docs/ios-customizations#provisional-push-notifications
      *
-     * @param  {(response:{accepted:boolean})=>void} handler
+     * @param  {(response: boolean)=>void} handler
      * @returns void
      */
-    registerForProvisionalAuthorization(handler?: (response: { accepted: boolean }) => void): void {
-        // TODO: Update the response in GA release to just boolean
+    registerForProvisionalAuthorization(handler?: (response: boolean) => void): void {
         window.cordova.exec(handler, function(){}, "OneSignalPush", "registerForProvisionalAuthorization", []);
     };
 

--- a/www/NotificationsNamespace.ts
+++ b/www/NotificationsNamespace.ts
@@ -38,7 +38,7 @@ export default class Notifications {
 
     /**
      * Add a callback that fires when the native push permission changes.
-     * @param  {(event:ChangeEvent<PermissionChange>)=>void} observer
+     * @param  {(event: boolean) => void} observer
      * @returns void
      */
     addPermissionObserver(observer: (event: boolean) => void): void {
@@ -52,7 +52,7 @@ export default class Notifications {
 
     /**
      * Remove a push permission observer that has been previously added.
-     * @param  {(event:ChangeEvent<PermissionChange>)=>void} observer
+     * @param  {(observer: (event: boolean) => void)} observer
      * @returns void
      */
     removePermissionObserver(observer: (event: boolean) => void): void {

--- a/www/OSNotification.ts
+++ b/www/OSNotification.ts
@@ -3,7 +3,7 @@ export default class OSNotification {
     sound               ?: string;
     title               ?: string;
     launchURL           ?: string;
-    rawPayload          : object;
+    rawPayload          : string;
     actionButtons       ?: object[];
     additionalData      : object;
     notificationId      : string;


### PR DESCRIPTION
# Description
## One Line Summary
Create Notifications namespace and implementations for iOS & Android.

## Details

### Motivation
Create Notifications namespace to decouple from OneSignal class to adhere to User Model conventions.

### Scope
Updates included for both iOS and Android.

Methods will be invoked as:
`window.plugins.OneSignal.Notifications.setNotificationOpenedHandler(function(opened) {...});`
`window.plugins.OneSignal.Notifications.setNotificationWillShowInForegroundHandler(function(willShow) {...});`
`window.plugins.OneSignal.Notifications.addPermissionObserver();`
`window.plugins.OneSignal.Notifications.removePermissionObserver();`
`window.plugins.OneSignal.Notifications.requestPermission();`
`window.plugins.OneSignal.Notifications.clearAll();`

iOS Only:
`window.plugins.OneSignal.Notifications.registerForProvisionalAuthorization();`
`window.plugins.OneSignal.Notifications.canRequestPermission(function (canRequest) {...});`

Android Only:
`window.plugins.OneSignal.Notifications.removeNotification("ID");`
`window.plugins.OneSignal.Notifications.removeGroupedNotifications("ID");`

Internal methods `_setPropertyAndObserver()` and `getPermission()` were created to allow developers to access permission status with:
`let permission = window.plugins.OneSignal.Notifications.permission`

### OPTIONAL - Other
**OPTIONAL -** Feel free to add any other sections or sub-sections that can explain your PR better.

# Testing
## Unit testing
No unit testing was used.

## Manual testing
**RECOMMEND - OPTIONAL -** Explain what scenarios were tested and the environment.
Tested methods on Samsung Galaxy S21 running Android 13 and 6th Gen iPad running iOS 15.2.

# Affected code checklist
   - [X] Notifications
      - [X] Display
      - [X] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [X] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/863)
<!-- Reviewable:end -->
