### PR TITLE
Release 3.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.3.0",
+  "version": "3.3.1",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="3.3.0">
+    version="3.3.1">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -30,7 +30,7 @@
   <js-module src="dist/OSNotification.js" name="OSNotification" />
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:4.8.2" />
+    <framework src="com.onesignal:OneSignal:4.8.5" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
 
     <config-file target="res/xml/config.xml" parent="/*">
@@ -76,7 +76,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" spec="3.12.3" />
+            <pod name="OneSignalXCFramework" spec="3.12.4" />
         </pods>
     </podspec>
 


### PR DESCRIPTION
## Native iOS SDK Update
Bump native iOS SDK version from `3.12.3` to `3.12.4`
- Fix In App Messages occasionally being displayed twice 
- Fix a OneSignal log ignoring the "None" log level

## Native Android SDK Update
Bump native Android SDK version from `4.8.2` to `4.8.5`
- Fix issue which caused groupless notifications to not get cleared if there were at least 4 of them
- Remove OneSignal gradle plugin from build.gradle files 
- Fix an issue with liquid IAMs when a non-existent tag doesn't show the correct default value.
- Speculative Fix for WorkManager not Initialized Crash

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/874)
<!-- Reviewable:end -->
