### PR TITLE
[Android] Add data/background message support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.3.1",
+  "version": "3.3.1-patched",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="3.3.1">
+    version="3.3.1-patched">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -46,6 +46,7 @@
     <source-file src="src/android/com/onesignal/cordova/OneSignalObserverController.java" target-dir="src/com/onesignal/cordova/" />
     <source-file src="src/android/com/onesignal/cordova/OneSignalOutcomeController.java" target-dir="src/com/onesignal/cordova/" />
     <source-file src="src/android/com/onesignal/cordova/OneSignalInAppMessagingController.java" target-dir="src/com/onesignal/cordova/" />
+    <source-file src="src/android/com/onesignal/OneSignalRemoteNotificationHandlerSetter.java" target-dir="src/com/onesignal/cordova/" />
     <source-file src="src/android/com/onesignal/cordova/CallbackHelper.java" target-dir="src/com/onesignal/cordova/" />
   </platform>
 

--- a/src/android/com/onesignal/OneSignalRemoteNotificationHandlerSetter.java
+++ b/src/android/com/onesignal/OneSignalRemoteNotificationHandlerSetter.java
@@ -1,0 +1,7 @@
+package com.onesignal;
+
+public class OneSignalRemoteNotificationHandlerSetter {
+    public static void setRemoteNotificationHandler(OneSignal.OSRemoteNotificationReceivedHandler handler) {
+        OneSignal.setRemoteNotificationReceivedHandler(handler);
+    }
+}


### PR DESCRIPTION
# Description
## One Line Summary
[Android] Add data/background message support

## Details

### Motivation

Since onesignal-cordova-plugin@3 we have no possibility to send data message without showing popup like a:
```
{
  "app_id": "xxxx",
  "include_player_ids": ["yyyy"],
  "data": {
     "action": "visit_refresh"
  },
  "content_available": true
}
```
To process data message with content_available=true on Android I propose to add OSRemoteNotificationReceivedHandler 
according to https://documentation.onesignal.com/docs/data-notifications#android-data-notification-setup 
https://documentation.onesignal.com/docs/service-extensions#android-notification-service-extension

And notify about data/background message via setNotificationWillShowInForegroundHandler. So client API is not changed.

### Scope
Android

### OPTIONAL - Other

# Testing
## Unit testing

## Manual testing
I have subscribe on setNotificationWillShowInForegroundHandler() in application:
```
            OneSignal.setNotificationWillShowInForegroundHandler((notificationReceivedEvent)=>{
              const notification = notificationReceivedEvent.getNotification();
              this.logger.log(`PushService: notificationWillShowInForeground: notification=${JSON.stringify(notification)}`);
              // Silence notification by calling complete() with no argument
              notificationReceivedEvent.complete(notification);
            })
```

Run one on android emulator for Android 7 to Android 12.

Send to application data message:
```
{
  "app_id": "xxxx",
  "include_player_ids": ["yyyy"],
  "data": {
     "action": "visit_refresh"
  },
  "content_available": true
}
```
And I see in a log the following:
```
PushService: notificationWillShowInForeground: notification={"notificationId":"b62ab6da-7b24-46b2-8635-550b8d3cdbbe","additionalData":{"action":"visit_refresh"},"rawPayload":{"google.delivered_priority":"normal","google.sent_time":1680680487811,"google.ttl":259200,"google.original_priority":"normal","custom":"{\"a\":{\"action\":\"visit_refresh\"},\"i\":\"b62ab6da-7b24-46b2-8635-550b8d3cdbbe\"}","from":"267986468402","google.message_id":"0:1680680487816734%24bd0d61f9fd7ecd","google.c.sender.id":"267986468402"},"priority":0,"fromProjectNumber":"267986468402","lockScreenVisibility":1,"androidNotificationId":326831907}
```
We get data message notification as expected.


# Affected code checklist
   - [X] Notifications
      - [ ] Display
      - [ ] Open
      - [X] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.