### PR TITLE
[User Model] Create LiveActivities Namespace

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -35,6 +35,7 @@
   <js-module src="dist/SessionNamespace.js" name="SessionNamespace" />
   <js-module src="dist/LocationNamespace.js" name="LocationNamespace" />
   <js-module src="dist/NotificationsNamespace.js" name="NotificationsNamespace" />
+  <js-module src="dist/LiveActivitiesNamespace.js" name="LiveActivitiesNamespace" />
 
   <platform name="android">
     <framework src="com.onesignal:OneSignal:5.0.0-beta2" />

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -542,7 +542,7 @@ static Class delegateClass = nil;
     NSString *activityId = command.arguments[0];
     NSString *token = command.arguments[1];
     
-    [OneSignal enterLiveActivity:activityId withToken:token withSuccess:^(NSDictionary* results){
+    [OneSignal.LiveActivities enter:activityId withToken:token withSuccess:^(NSDictionary* results){
         successCallback(enterLiveActivityCallbackId, results);
     } withFailure:^(NSError *error) {
         failureCallback(enterLiveActivityCallbackId, error.userInfo);
@@ -554,7 +554,7 @@ static Class delegateClass = nil;
 
     NSString *activityId = command.arguments[0];
 
-    [OneSignal exitLiveActivity:activityId withSuccess:^(NSDictionary* results){
+    [OneSignal.LiveActivities exit:activityId withSuccess:^(NSDictionary* results){
         successCallback(exitLiveActivityCallbackId, results);
     } withFailure:^(NSError *error) {
         failureCallback(exitLiveActivityCallbackId, error.userInfo);

--- a/www/LiveActivitiesNamespace.ts
+++ b/www/LiveActivitiesNamespace.ts
@@ -1,0 +1,43 @@
+// Suppress TS warnings about window.cordova
+declare let window: any; // turn off type checking
+
+export default class LiveActivities {
+    /**
+     * Enter a live activity
+     * @param  {string} activityId
+     * @param  {string} token
+     * @param  {Function} onSuccess
+     * @param  {Function} onFailure
+     * @returns void
+     */
+    enter(activityId: string, token: string, onSuccess?: Function, onFailure?: Function): void {
+        if (onSuccess == null) {
+            onSuccess = function() {};
+        }
+    
+        if (onFailure == null) {
+            onFailure = function() {};
+        }
+
+        window.cordova.exec(onSuccess, onFailure, "OneSignalPush", "enterLiveActivity", [activityId, token]);
+    };
+
+    /**
+     * Exit a live activity
+     * @param  {string} activityId
+     * @param  {Function} onSuccess
+     * @param  {Function} onFailure
+     * @returns void
+     */
+     exit(activityId: string, onSuccess?: Function, onFailure?: Function): void {
+        if (onSuccess == null) {
+            onSuccess = function() {};
+        }
+
+        if (onFailure == null) {
+            onFailure = function() {};
+        }
+
+        window.cordova.exec(onSuccess, onFailure, "OneSignalPush", "exitLiveActivity", [activityId]);
+    };
+}

--- a/www/index.ts
+++ b/www/index.ts
@@ -31,6 +31,7 @@ import Session from "./SessionNamespace";
 import Location from "./LocationNamespace";
 import InAppMessages from "./InAppMessagesNamespace";
 import Notifications from "./NotificationsNamespace";
+import LiveActivities from "./LiveActivitiesNamespace";
 
 // Suppress TS warnings about window.cordova
 declare let window: any; // turn off type checking
@@ -42,6 +43,7 @@ export class OneSignalPlugin {
     Location: Location = new Location();
     InAppMessages: InAppMessages = new InAppMessages();
     Notifications: Notifications = new Notifications();
+    LiveActivities: LiveActivities = new LiveActivities();
 
     private _appID = "";
 
@@ -123,49 +125,6 @@ export class OneSignalPlugin {
      */
     getPrivacyConsent(handler: (value: boolean) => void): void {
         window.cordova.exec(handler, function () { }, "OneSignalPush", "getPrivacyConsent", []);
-    };
-
-    /**
-     * Live Activities
-     */
-
-    /**
-     * Enter a live activity
-     * @param  {string} activityId
-     * @param  {string} token
-     * @param  {Function} onSuccess
-     * @param  {Function} onFailure
-     * @returns void
-     */
-    enterLiveActivity(activityId: string, token: string, onSuccess?: Function, onFailure?: Function): void {
-        if (onSuccess == null) {
-            onSuccess = function() {};
-        }
-    
-        if (onFailure == null) {
-            onFailure = function() {};
-        }
-
-        window.cordova.exec(onSuccess, onFailure, "OneSignalPush", "enterLiveActivity", [activityId, token]);
-    };
-
-    /**
-     * Exit a live activity
-     * @param  {string} activityId
-     * @param  {Function} onSuccess
-     * @param  {Function} onFailure
-     * @returns void
-     */
-     exitLiveActivity(activityId: string, onSuccess?: Function, onFailure?: Function): void {
-        if (onSuccess == null) {
-            onSuccess = function() {};
-        }
-
-        if (onFailure == null) {
-            onFailure = function() {};
-        }
-
-        window.cordova.exec(onSuccess, onFailure, "OneSignalPush", "exitLiveActivity", [activityId]);
     };
 }
 


### PR DESCRIPTION
# Description
## One Line Summary
Create Live Activities namespace

## Details

### Motivation
Live Activities was determined to have its own namespace as part of Beta 2 release.

### Scope
Live Activities for iOS can now be invoked with:
`window.plugins.OneSignal.LiveActivities.enter("ACTIVITY_ID", "TOKEN");`
`window.plugins.OneSignal.LiveActivities.exit("ACTIVITY_ID", "TOKEN");`


### OPTIONAL - Other
This only impacts iOS platform.

# Testing
## Unit testing


## Manual testing
Manual Testing was used to successfully receive a 200 response back in the SDK when entering and exiting a mock Live Activity on iPad running iOS 15.2.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [X] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/881)
<!-- Reviewable:end -->
