### PR TITLE
Release 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.0.0-beta-02",
+  "version": "5.0.0",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="5.0.0-beta-02">
+    version="5.0.0">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -343,7 +343,6 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
 
   public boolean init(CallbackContext callbackContext, JSONArray data) {
     OneSignalWrapper.setSdkType("cordova");  
-    // For 5.0.0-beta, hard code to reflect SDK version
     OneSignalWrapper.setSdkVersion("050000");
     try {
       String appId = data.getString(0);


### PR DESCRIPTION
**⚠️ This is a major release which contains breaking API changes.**

In this major version release for the OneSignal Cordova SDK, we are making a significant shift from a device-centered model to a user-centered model. A user-centered model allows for more powerful omni-channel integrations within the OneSignal platform.

## What's Changed Since beta-02
### API Updates
- `setLaunchURLsInApp` has been removed
- Rename `OneSignal.init` to `OneSignal.initialize`
- Rename `OneSignal.Notifications.permission` to `OneSignal.Notifications.hasPermission()`
- All observers/listeners updated to use `addEventListener` and `removeEventListener`
- Rename and fix event types passed to developers' listeners
- Make `InAppMessageClickResult.urlTarget` a string type and fix iOS so it matches Android
- Add `OneSignal.Notifications.permissionNative()` method
- Add `LogLevel` enum
- Add `OneSignal.Notifications.canRequestPermission()` for Android
- Export all public types
- In native bridges, check for existence of callbacks before firing and prevent adding any listener more than once
- Use promises instead of callbacks for these methods:
```typescript
    await OneSignal.Location.isShared()
    await OneSignal.Notifications.requestPermission(fallbackToSettings?: boolean)
    await OneSignal.Notifications.canRequestPermission()
    await OneSignal.InAppMessages.getPaused() // which is also renamed from `isPaused`
```

### Native Updates
Updated included Android SDK to [5.0.0](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.0.0)
Updated included iOS SDK to [5.0.1](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.0.1)


For information please see the [migration guide](https://github.com/OneSignal/OneSignal-Cordova-SDK/blob/user_model/main/MIGRATION_GUIDE.md).


**Note that Identity Verification has not yet been enabled in this version and will be released in a later version**

**Full Changelog**: https://github.com/OneSignal/OneSignal-Cordova-SDK/compare/5.0.0-beta-02...5.0.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/908)
<!-- Reviewable:end -->
