### PR TITLE
Fix unsuccessful `optIn` method call

### DIFF
--- a/www/PushSubscriptionNamespace.ts
+++ b/www/PushSubscriptionNamespace.ts
@@ -101,7 +101,7 @@ export default class PushSubscription {
      * @returns void
      */
     optIn(): void {
-        window.cordova.exec(function(){}, function(){}, "OneSignalPush", "OptInPushSubscription");
+        window.cordova.exec(function(){}, function(){}, "OneSignalPush", "optInPushSubscription");
     }
 
     /**


### PR DESCRIPTION
# Description
## One Line Summary
Fix unsuccessful `optIn` method call

## Details

### Motivation
`optIn` was unsuccessful due to a casing typo while calling method to bridge.

### Scope
Changes affect `pushSubscription` namespace

# Testing
## Manual testing
Manually tested calling this method on both iOS and Android.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/914)
<!-- Reviewable:end -->
