### PR TITLE
[Fix] iOS click listener fire from cold start

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -84,7 +84,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" spec="5.0.1" />
+            <pod name="OneSignalXCFramework" spec="5.0.2" />
         </pods>
     </podspec>
 

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -100,7 +100,7 @@ void processNotificationClicked(OSNotificationClickEvent* event) {
 void initOneSignalObject(NSDictionary* launchOptions) {
     OneSignalWrapper.sdkType = @"cordova";
     OneSignalWrapper.sdkVersion = @"050000";
-    [OneSignal setLaunchOptions:launchOptions];
+    [OneSignal initialize:nil withLaunchOptions:launchOptions];
     initialLaunchFired = true;
 }
 


### PR DESCRIPTION
# Description
## One Line Summary
Fix iOS notifications clicked event not firing when clicking a notification to open the app from a cold start.

## Details

### Motivation
Fixes iOS bug where notification click listener is set but not firing when clicking the notification from a cold start.

### Scope
In the iOS bridge, the `initOneSignalObject` has been updated to call `initialize:nil withLaunchOptions:launchOptions` so that the SDK can be initialized in order to get the cold start notification click event. This will result in the iOS SDK reading the appId from cache when nil is passed.

# Testing
## Manual testing
Tested the following scenarios on an iPhone 14 Pro emulator running iOS 16.4:

1. Add click listener on app start. Kill app and and click notification to open from cold start. Alert is shown via visual logging. 
2. Click on notification from cold start, app opens, then add the click listener from a button. Click event for previously-clicked notification successfully fires. 

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [X] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/919)
<!-- Reviewable:end -->
