### PR TITLE
Release 5.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.0.2",
+  "version": "5.0.3",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="5.0.2">
+    version="5.0.3">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -37,7 +37,7 @@
   <js-module src="dist/LiveActivitiesNamespace.js" name="LiveActivitiesNamespace" />
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:5.0.3" />
+    <framework src="com.onesignal:OneSignal:5.0.4" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
     <framework src="org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10" />
 
@@ -84,7 +84,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" spec="5.0.2" />
+            <pod name="OneSignalXCFramework" spec="5.0.4" />
         </pods>
     </podspec>
 

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -343,7 +343,7 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
 
   public boolean init(CallbackContext callbackContext, JSONArray data) {
     OneSignalWrapper.setSdkType("cordova");  
-    OneSignalWrapper.setSdkVersion("050002");
+    OneSignalWrapper.setSdkVersion("050003");
     try {
       String appId = data.getString(0);
       OneSignal.initWithContext(this.cordova.getActivity(), appId);

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -99,7 +99,7 @@ void processNotificationClicked(OSNotificationClickEvent* event) {
 
 void initOneSignalObject(NSDictionary* launchOptions) {
     OneSignalWrapper.sdkType = @"cordova";
-    OneSignalWrapper.sdkVersion = @"050002";
+    OneSignalWrapper.sdkVersion = @"050003";
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     initialLaunchFired = true;
 }


### PR DESCRIPTION
## What's Changed
* Remove modifying manifest placeholders in https://github.com/OneSignal/OneSignal-Cordova-SDK/pull/937
* V5 resolve request permission in https://github.com/OneSignal/OneSignal-Cordova-SDK/pull/936

## Native SDK Updates
### Update Android SDK to [5.0.4](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.0.4)
- Update PropertiesModel's deserialization of tags to not use Model.initializeFromJson in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1884
- Retrieve current ADM PurchasingListener assuming it returns a nullable. in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1888
- Fix: Add synchronized blocks to prevent ConcurrentModificationException  in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1876
- Update work-runtime dependency version in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1890
- General protection against exceptions that occur on a thread. in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1887
### Update iOS SDK to [5.0.4](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.0.4)
- Fix badge clearing when calling clearAll in https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1335
- Fix crash with direct influence but nil direct id https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1327
- Fix forwarding notification opens from non onesignal notifs https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1326

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/939)
<!-- Reviewable:end -->
