### PR TITLE
Add public `getTags` method

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -221,6 +221,7 @@ The User name space is accessible via `OneSignal.User` and provides access to us
 | `OneSignal.User.addTags({"KEY_01": "VALUE_01", "KEY_02": "VALUE_02"});`                          | *Add multiple tags for the current user.  Tags are key:value pairs used as building blocks for targeting specific users and/or personalizing messages. If the tag key already exists, it will be replaced with the value provided here.* |
 | `OneSignal.User.removeTag("KEY");`                                                                   | *Remove the data tag with the provided key from the current user.*                                                                                                                                                                       |
 | `OneSignal.User.removeTags(["KEY_01", "KEY_02"]);`                                                 | *Remove multiple tags with the provided keys from the current user.*                                                                                                                                                             |
+| `OneSignal.User.getTags();`                                                   | *Returns the local tags for the current user.*                                                                                                                                                                                        |
 
 
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -37,7 +37,7 @@
   <js-module src="dist/LiveActivitiesNamespace.js" name="LiveActivitiesNamespace" />
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:5.0.4" />
+    <framework src="com.onesignal:OneSignal:5.0.5" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
     <framework src="org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10" />
 
@@ -84,7 +84,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" spec="5.0.4" />
+            <pod name="OneSignalXCFramework" spec="5.0.5" />
         </pods>
     </podspec>
 

--- a/src/android/com/onesignal/cordova/OneSignalController.java
+++ b/src/android/com/onesignal/cordova/OneSignalController.java
@@ -192,6 +192,18 @@ public class OneSignalController {
     }
   }
 
+  public static boolean getTags(CallbackContext callbackContext) {
+    try {
+        Map<String, String> tagsMap = OneSignal.getUser().getTags();
+        JSONObject tagsJson = new JSONObject(tagsMap);
+        CallbackHelper.callbackSuccess(callbackContext, tagsJson);
+    } catch (Throwable t) {
+        t.printStackTrace();
+        return false;
+    }
+    return true;
+  }
+
   /**
    * Notifications
    */

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -94,6 +94,7 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
 
   private static final String REMOVE_TAGS = "removeTags";
   private static final String ADD_TAGS = "addTags";
+  private static final String GET_TAGS = "getTags";
 
   private static final String REGISTER_FOR_PROVISIONAL_AUTHORIZATION = "registerForProvisionalAuthorization";
   private static final String REQUEST_PERMISSION = "requestPermission";
@@ -465,6 +466,10 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
 
       case REMOVE_TAGS:
         result = OneSignalController.removeTags(data);
+        break;
+
+      case GET_TAGS:
+        result = OneSignalController.getTags(callbackContext);
         break;
 
       case REGISTER_FOR_PROVISIONAL_AUTHORIZATION:

--- a/src/ios/OneSignalPush.h
+++ b/src/ios/OneSignalPush.h
@@ -51,6 +51,7 @@
 
 - (void)addTags:(CDVInvokedUrlCommand* _Nonnull)command;
 - (void)removeTags:(CDVInvokedUrlCommand* _Nonnull)command;
+- (void)getTags:(CDVInvokedUrlCommand* _Nonnull)command;
 
 // Push Subscription
 - (void)addPushSubscriptionObserver:(CDVInvokedUrlCommand* _Nonnull)command;

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -333,6 +333,11 @@ static Class delegateClass = nil;
     [OneSignal.User removeTags:command.arguments];
 }
 
+- (void)getTags:(CDVInvokedUrlCommand*)command {
+    NSDictionary<NSString *, NSString *> *tags = [OneSignal.User getTags];
+    successCallback(command.callbackId, tags);
+}
+
 - (void)requestPermission:(CDVInvokedUrlCommand*)command {
     requestPermissionCallbackId = command.callbackId;
     [OneSignal.Notifications requestPermission:^(BOOL accepted) {

--- a/www/UserNamespace.ts
+++ b/www/UserNamespace.ts
@@ -143,4 +143,13 @@ export default class User {
     removeTags(keys: string[]): void {
         window.cordova.exec(function(){}, function(){}, "OneSignalPush", "removeTags", keys);
     };
+
+    /** Returns the local tags for the current user.
+     * @returns Promise<{ [key: string]: string }>
+     */
+    getTags(): Promise<{ [key: string]: string }> {
+        return new Promise<{ [key: string]: string; }>((resolve, reject) => {
+            window.cordova.exec(resolve, reject, "OneSignalPush", "getTags", []);
+        });
+    };
 }


### PR DESCRIPTION
# Description
## One Line Summary
Add public `OneSignal.User.getTags()` method to return local tags for the current user.

## Details
Add `getTags` public method that will return local tags for the current user on both Android and iOS.

### Motivation
We removed the `getTags` method in v5 of the SDKs to discourage use of OneSignal tags as a data store. We have heard feedback from app developers that they have a need for this method still, so we are adding back an implementation to return the local tags.

### Scope
Keep note it returns the local tags and not via a server fetch so any tags added mid-session through the REST API will not be reflected.

# Testing
## Unit testing
None

## Manual testing
Successfully call new method getTags on iPhone 15 emulator running iOS 17.0.1 and Pixel 7 running Android 14.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item