### PR TITLE
Fix: Update iOS addTags method to convert tag values to string

### DIFF
--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -326,7 +326,15 @@ static Class delegateClass = nil;
 }
 
 - (void)addTags:(CDVInvokedUrlCommand*)command {
-    [OneSignal.User addTags:command.arguments[0]];
+    NSDictionary *tags = command.arguments[0];
+    NSMutableDictionary *convertedTags = [NSMutableDictionary dictionary];
+
+    for (id key in tags) {
+        id value = tags[key];
+        convertedTags[key] = [value isKindOfClass:[NSString class]] ? value : [NSString stringWithFormat:@"%@", value];
+    }
+
+    [OneSignal.User addTags:convertedTags];
 }
 
 - (void)removeTags:(CDVInvokedUrlCommand*)command {

--- a/www/UserNamespace.ts
+++ b/www/UserNamespace.ts
@@ -107,7 +107,7 @@ export default class User {
      */
 
     /**
-     * Add a tag for the current user. Tags are key:value pairs used as building blocks for targeting specific users and/or personalizing messages. If the tag key already exists, it will be replaced with the value provided here.
+     * Add a tag for the current user. Tags are key:value string pairs used as building blocks for targeting specific users and/or personalizing messages. If the tag key already exists, it will be replaced with the value provided here.
      * @param  {string} key
      * @param  {string} value
      * @returns void
@@ -118,7 +118,7 @@ export default class User {
     };
 
     /**
-     * Add multiple tags for the current user. Tags are key:value pairs used as building blocks for targeting specific users and/or personalizing messages. If the tag key already exists, it will be replaced with the value provided here.
+     * Add multiple tags for the current user. Tags are key:value string pairs used as building blocks for targeting specific users and/or personalizing messages. If the tag key already exists, it will be replaced with the value provided here.
      * @param  {object} tags
      * @returns void
      */


### PR DESCRIPTION
# Description
## One Line Summary
Update iOS addTags method to convert tag values to string

## Details

### Motivation
I discovered that the method signature for `addTags` does not specify key:value type string in the params. This allows the potential for non-string values to be accepted into the method. Android already [accounts for this](https://github.com/OneSignal/OneSignal-Cordova-SDK/blob/3e991934b7216d22fbb1fb0b6998e197ea79a240/src/android/com/onesignal/cordova/OneSignalController.java#L163) by converting all values into strings. iOS should be updated to do the same to prevent any potential crashes when a non-string parameter is passed into the Cordova method.

### Scope
Only the addTags method on iOS is impacted.

# Testing
## Unit testing
None

## Manual testing
Tested on iPhone 15 Emulator running 17.0.1.

Sent tags with mixed value types:
`OneSignal.User.addTags({"KEY_01": 1, "KEY_02": "VALUE_02"});`

App no longer crashes.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.