### PR TITLE
Fix notification foreground listener preventing notification display

### DIFF
--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -198,7 +198,6 @@ static Class delegateClass = nil;
 }
 
 -(void)proceedWithWillDisplay:(CDVInvokedUrlCommand *)command {
-    notificationWillShowInForegoundCallbackId = command.callbackId;
     NSString *notificationId = command.arguments[0];
     OSNotificationWillDisplayEvent *event = self.notificationWillDisplayCache[notificationId];
     if (!event) {


### PR DESCRIPTION
# Description
## One Line Summary
This PR fixes a bug that prevented notifications after the first one from displaying when the foreground listener is set.

## Details
* The `notificationWillShowInForegoundCallbackId` is set over the bridge when the developer calls to add their notification foreground listener.
* It is used to link back to their listeners and fire them.
* This callback ID was being overwritten once the first foreground notification is processed.
* This led subsequent foreground notifications to be stuck and never display.

### Motivation
Fixes https://github.com/OneSignal/OneSignal-Cordova-SDK/issues/943

### Scope
We were overwriting this `notificationWillShowInForegoundCallbackId`. It is set when app developers call the add listener method to add their listener, so it can hook back to their listener.

# Testing

## Manual testing
**iPhone 13 on iOS 17.2**

✅ All foreground notifications display if I did not call `preventDefault()`
✅ If multiple listeners are added, they are all triggered
✅ Listener calls `preventDefault()` and then `display()` 5 seconds later will display the notification after 5 seconds
✅ Listener calls `preventDefault()` and notification never displays

# Affected code checklist
   - [ ] Notifications
      - [x] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/963)
<!-- Reviewable:end -->
