### PR TITLE
Release 5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.0.6",
+  "version": "5.1.0",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="5.0.6">
+    version="5.1.0">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -37,7 +37,7 @@
   <js-module src="dist/LiveActivitiesNamespace.js" name="LiveActivitiesNamespace" />
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:5.1.4" />
+    <framework src="com.onesignal:OneSignal:5.1.6" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
     <framework src="org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10" />
 
@@ -85,7 +85,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" spec="5.1.0" />
+            <pod name="OneSignalXCFramework" spec="5.1.1" />
         </pods>
     </podspec>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -85,7 +85,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" spec="5.1.1" />
+            <pod name="OneSignalXCFramework" spec="5.1.3" />
         </pods>
     </podspec>
 

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -348,7 +348,7 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
 
   public boolean init(CallbackContext callbackContext, JSONArray data) {
     OneSignalWrapper.setSdkType("cordova");  
-    OneSignalWrapper.setSdkVersion("050006");
+    OneSignalWrapper.setSdkVersion("050100");
     try {
       String appId = data.getString(0);
       OneSignal.initWithContext(this.cordova.getActivity(), appId);

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -106,7 +106,7 @@ void processNotificationClicked(OSNotificationClickEvent* event) {
 
 void initOneSignalObject(NSDictionary* launchOptions) {
     OneSignalWrapper.sdkType = @"cordova";
-    OneSignalWrapper.sdkVersion = @"050006";
+    OneSignalWrapper.sdkVersion = @"050100";
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     initialLaunchFired = true;
 }


### PR DESCRIPTION
## What's Changed
**🎉  New Methods 🎉** 
* Add getter for `onesignalId` and `externalId` and a UserState Observer to be notified of changes in [#959]
    * See the [User Namespace API Reference](https://github.com/OneSignal/OneSignal-Cordova-SDK/blob/main/MIGRATION_GUIDE.md#user-namespace) in the Migration Guide for usage
* Add asynchronous getter methods for Notifications `permission` and Push Subscription `token`, `id`,`optedIn` in [#977]
    * ⚠️ Previous methods `Notifications.hasPermission`, `User.pushSubscription.id`, `User.pushSubscription.token`, and `User.pushSubscription.optedIn` are now deprecated but non-breaking. ⚠️ 
    * See the [Push Subscription Namespace API Reference](https://github.com/OneSignal/OneSignal-Cordova-SDK/blob/main/MIGRATION_GUIDE.md#push-subscription-namespace) and [Notifications Namespace API Reference](https://github.com/OneSignal/OneSignal-Cordova-SDK/blob/main/MIGRATION_GUIDE.md#notifications-namespace) in the Migration Guide for usage of new methods `getPermissionAsync`, `getIdAsync`, `getTokenAsync`, and `getOptedInAsync`. 

### Native Changes
* Bump Android Native Version to [5.1.6](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.6)
* Bump iOS Native Version to [5.1.3](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.1.1)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/980)
<!-- Reviewable:end -->
