### PR TITLE
Release 5.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.1.0",
+  "version": "5.1.1",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="5.1.0">
+    version="5.1.1">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -37,7 +37,7 @@
   <js-module src="dist/LiveActivitiesNamespace.js" name="LiveActivitiesNamespace" />
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:5.1.6" />
+    <framework src="com.onesignal:OneSignal:5.1.8" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
     <framework src="org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10" />
 
@@ -85,7 +85,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" spec="5.1.3" />
+            <pod name="OneSignalXCFramework" spec="5.1.4" />
         </pods>
     </podspec>
 

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -348,7 +348,7 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
 
   public boolean init(CallbackContext callbackContext, JSONArray data) {
     OneSignalWrapper.setSdkType("cordova");  
-    OneSignalWrapper.setSdkVersion("050100");
+    OneSignalWrapper.setSdkVersion("050101");
     try {
       String appId = data.getString(0);
       OneSignal.initWithContext(this.cordova.getActivity(), appId);

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -106,7 +106,7 @@ void processNotificationClicked(OSNotificationClickEvent* event) {
 
 void initOneSignalObject(NSDictionary* launchOptions) {
     OneSignalWrapper.sdkType = @"cordova";
-    OneSignalWrapper.sdkVersion = @"050100";
+    OneSignalWrapper.sdkVersion = @"050101";
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     initialLaunchFired = true;
 }


### PR DESCRIPTION
## 🔧 Native SDK Dependency Updates Only

**Update Android SDK from `5.1.6` to `5.1.8`**
- Fix crash with EventProducer's fire events in https://github.com/OneSignal/OneSignal-Android-SDK/pull/2034
- Battery improvements
    - Possibly resolves issues of "Egregious levels of battery drain"
    - Prevent OperationRepo from continuously pulling when empty (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2033)
    - Add backoff to OperationRepo when retrying network calls (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2017)
    - Limit refresh User and GET IAMs to foreground (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2036)
- Fixes network call batching not waiting the full 5 seconds in most cases to reduce the total number of REST API calls to OneSignal. 
- Issue with external_id being skipped and updates stop if something updates the User (such as addTag) shortly before login is called https://github.com/OneSignal/OneSignal-Android-SDK/pull/2046
- For full changes, [see the native release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases)

**Update iOS SDK from `5.1.3` to `5.1.4`**
- [5.1.4 Release Notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.1.4)
- The XCFrameworks in this release is signed to help keep your apps secure
- Fix rare scenario where login requests are stuck and prevent the SDK from making updates (https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1398)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/986)
<!-- Reviewable:end -->
