### PR TITLE
Release 5.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.1.1",
+  "version": "5.1.2",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="5.1.1">
+    version="5.1.2">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -37,7 +37,7 @@
   <js-module src="dist/LiveActivitiesNamespace.js" name="LiveActivitiesNamespace" />
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:5.1.8" />
+    <framework src="com.onesignal:OneSignal:5.1.9" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
     <framework src="org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10" />
 
@@ -85,7 +85,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" spec="5.1.4" />
+            <pod name="OneSignalXCFramework" spec="5.1.5" />
         </pods>
     </podspec>
 

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -348,7 +348,7 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
 
   public boolean init(CallbackContext callbackContext, JSONArray data) {
     OneSignalWrapper.setSdkType("cordova");  
-    OneSignalWrapper.setSdkVersion("050101");
+    OneSignalWrapper.setSdkVersion("050102");
     try {
       String appId = data.getString(0);
       OneSignal.initWithContext(this.cordova.getActivity(), appId);

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -106,7 +106,7 @@ void processNotificationClicked(OSNotificationClickEvent* event) {
 
 void initOneSignalObject(NSDictionary* launchOptions) {
     OneSignalWrapper.sdkType = @"cordova";
-    OneSignalWrapper.sdkVersion = @"050101";
+    OneSignalWrapper.sdkVersion = @"050102";
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     initialLaunchFired = true;
 }


### PR DESCRIPTION
## 🔧 Native SDK Dependency Updates Only

**Update Android SDK from `5.1.8` to `5.1.9`**
- [5.1.9 release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.9)
- Added Network call optimizations
- Fix for WorkManager not initialized crash
- Added `AndroidManifest` options to override In-App Messages **gray overlay** and **dropshadow** 
```
<meta-data android:name="com.onesignal.inAppMessageHideGrayOverlay" android:value="true"/>
<meta-data android:name="com.onesignal.inAppMessageHideDropShadow" android:value="true"/>
```

**Update iOS SDK from `5.1.4` to `5.1.5`**
- [5.1.5 Release Notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.1.5)
- ✨ In-App Message Enhancements:
  - The **status bar** will be hidden on full-bleed In-App Messages
  - Add back the **dropshadow** on In-App Messages and include a `plist` option to disable it
  - Add `plist` option to override and hide the **gray overlay** to In-App Messages
```
OneSignal_in_app_message_hide_gray_overlay
OneSignal_in_app_message_hide_drop_shadow
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/989)
<!-- Reviewable:end -->
