### PR TITLE
Release 5.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.1.2",
+  "version": "5.1.3",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="5.1.2">
+    version="5.1.3">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -37,7 +37,7 @@
   <js-module src="dist/LiveActivitiesNamespace.js" name="LiveActivitiesNamespace" />
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:5.1.9" />
+    <framework src="com.onesignal:OneSignal:5.1.10" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
     <framework src="org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10" />
 
@@ -85,7 +85,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" spec="5.1.5" />
+            <pod name="OneSignalXCFramework" spec="5.1.6" />
         </pods>
     </podspec>
 

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -348,7 +348,7 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
 
   public boolean init(CallbackContext callbackContext, JSONArray data) {
     OneSignalWrapper.setSdkType("cordova");  
-    OneSignalWrapper.setSdkVersion("050102");
+    OneSignalWrapper.setSdkVersion("050103");
     try {
       String appId = data.getString(0);
       OneSignal.initWithContext(this.cordova.getActivity(), appId);

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -106,7 +106,7 @@ void processNotificationClicked(OSNotificationClickEvent* event) {
 
 void initOneSignalObject(NSDictionary* launchOptions) {
     OneSignalWrapper.sdkType = @"cordova";
-    OneSignalWrapper.sdkVersion = @"050102";
+    OneSignalWrapper.sdkVersion = @"050103";
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     initialLaunchFired = true;
 }


### PR DESCRIPTION
## 🔧 Native SDK Dependency Updates Only

**Update Android SDK from `5.1.9` to `5.1.10`**
- [5.1.10 release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.10)
- 🛠️ Added additional Network call optimizations
- 🐛 Handle incorrect 404 responses; add a delay after creates and retries on 404 of new ids [#2095](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2059)

**Update iOS SDK from `5.1.5` to `5.1.6`**
- [5.1.6 Release Notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.1.6)
- 🐛 Bug Fixes
  - Fix crashes when encoding user models [#1412]([OneSignal/OneSignal-iOS-SDK#1412](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1412))
  - Some pending properties can be sent to new user, when users change quickly after the last updates are made ([#1418](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1418))
  - Fix crash in OneSignalAttachmentHandler trimURLSpacing method ([#1411](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1411))
  - Fix crash when handling a dialog result when stack traces point to delayResult ([#1417](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1417))
  - [Bug] Remove IAM window when an in app message is inactive ([#1413](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1413))

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/991)
<!-- Reviewable:end -->
