### PR TITLE
Release 5.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.1.3",
+  "version": "5.1.4",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="5.1.3">
+    version="5.1.4">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -37,7 +37,7 @@
   <js-module src="dist/LiveActivitiesNamespace.js" name="LiveActivitiesNamespace" />
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:5.1.10" />
+    <framework src="com.onesignal:OneSignal:5.1.13" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
     <framework src="org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10" />
 
@@ -85,7 +85,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" spec="5.1.6" />
+            <pod name="OneSignalXCFramework" spec="5.2.0" />
         </pods>
     </podspec>
 

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -348,7 +348,7 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
 
   public boolean init(CallbackContext callbackContext, JSONArray data) {
     OneSignalWrapper.setSdkType("cordova");  
-    OneSignalWrapper.setSdkVersion("050103");
+    OneSignalWrapper.setSdkVersion("050104");
     try {
       String appId = data.getString(0);
       OneSignal.initWithContext(this.cordova.getActivity(), appId);

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -106,7 +106,7 @@ void processNotificationClicked(OSNotificationClickEvent* event) {
 
 void initOneSignalObject(NSDictionary* launchOptions) {
     OneSignalWrapper.sdkType = @"cordova";
-    OneSignalWrapper.sdkVersion = @"050103";
+    OneSignalWrapper.sdkVersion = @"050104";
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     initialLaunchFired = true;
 }


### PR DESCRIPTION
🔧 Native SDK Dependency Updates Only
--------
### Update Android SDK from `5.1.10` to `5.1.13`
- For full changes, [see the native release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases)
**🐛 Bug Fixes**
- [Fix] grouping skipping opRepoPostCreateDelay, causing operations being applied out of order when multiple login operations are pending. (fixes issue since 5.1.10) ([2087](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2087))
- [Fix]: Cancelling permission request dialog does not fire continuation ([2085](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2085))
- [Fix] RecoverFromDroppedLoginBug not running in very rare cases ([2084](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2084))
- Fix the ANR issue caused by prolonged loading of OperationRepo and potentially by extended holding of the model lock during disk I/O read operations. ([2068](ttps://github.com/OneSignal/OneSignal-Android-SDK/pull/2068))
**🔧 Maintenance**
- Add HTTP header `OneSignal-Install-Id` that allows the OneSignal's backend know where traffic is coming from ([2072](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2072))

### Update iOS SDK from `5.1.6` to `5.2.0`
- [5.2.0 Release Notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.0)
- ✨ Privacy Manifest Improvements
- 🐛 [Bug] Fix rare scenario of dropping data when multiple logins are called ([1427](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1427))

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/994)
<!-- Reviewable:end -->
