### PR TITLE
Release 5.2.0

### DIFF
--- a/example/IonicCapOneSignal/android/app/capacitor.build.gradle
+++ b/example/IonicCapOneSignal/android/app/capacitor.build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation project(':capacitor-haptics')
     implementation project(':capacitor-keyboard')
     implementation project(':capacitor-status-bar')
-    implementation "com.onesignal:OneSignal:5.1.10"
+    implementation "com.onesignal:OneSignal:5.1.13"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10"
 }
 apply from: "../../../../build-extras-onesignal.gradle"

--- a/example/IonicCapOneSignal/package-lock.json
+++ b/example/IonicCapOneSignal/package-lock.json
@@ -48,7 +48,7 @@
     },
     "../..": {
       "name": "onesignal-cordova-plugin",
-      "version": "5.1.4",
+      "version": "5.2.0",
       "engines": [
         {
           "name": "cordova-android",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.1.4",
+  "version": "5.2.0",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="5.1.4">
+    version="5.2.0">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -352,7 +352,7 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
 
   public boolean init(CallbackContext callbackContext, JSONArray data) {
     OneSignalWrapper.setSdkType("cordova");  
-    OneSignalWrapper.setSdkVersion("050104");
+    OneSignalWrapper.setSdkVersion("050200");
     try {
       String appId = data.getString(0);
       OneSignal.initWithContext(this.cordova.getActivity(), appId);

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -107,7 +107,7 @@ void processNotificationClicked(OSNotificationClickEvent* event) {
 
 void initOneSignalObject(NSDictionary* launchOptions) {
     OneSignalWrapper.sdkType = @"cordova";
-    OneSignalWrapper.sdkVersion = @"050104";
+    OneSignalWrapper.sdkVersion = @"050200";
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     initialLaunchFired = true;
 }


### PR DESCRIPTION
_No native changes in this release_

What's New
--------
### 🎉 Push to Start Live Activities
Starting with iOS 17.2, Live Activities can now be started via push notification ([Apple's documentation](https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications#Start-new-Live-Activities-with-ActivityKit-push-notifications)). This change enhances the OneSignal SDK to provide application's access to the full suite of Live Activity functionality.

To use Push To Start Live Activities, see documentation on [How to start a Live Activity with a remote push notification](https://documentation.onesignal.com/docs/push-to-start-live-activities).

**Default Live Activity**
The concept of a "Default" Live Activity has been established in the SDK, which eliminates the need for a customer app to define and manage their own `ActivityAttributes`. The primary use case of the "Default" Live Activity is to facilitate easier cross-platform adoption.

- A new function `OneSignal.LiveActivities.setupDefault()` which tells the OneSignal SDK to manage the LiveActivity lifecycle for the `DefaultLiveActivityAttributes` type. When calling this method, a customer can use both `push-to-start` and `push-to-update` notifications to start/update/end their Default Live Activity.
- A new function `OneSignal.LiveActivities.startDefault(activityId, activityAttributes, initialContentState)` which allows a customer app to start a live activity based on the `DefaultLiveActivityAttributes` type "in app".

**Four New APIs for Live Activities**
```typescript
OneSignal.LiveActivities.setupDefault()
OneSignal.LiveActivities.startDefault(activityId, activityAttributes, initialContentState)
OneSignal.LiveActivities.setPushToStartToken(activityType: string, token: string)
OneSignal.LiveActivities.removePushToStartToken(activityType: string)
```

Please see the PR description for more details.
- Push to start live activities added to the SDK #997 

### ✨ Ionic Capacitor Example App
A new Ionic Capacitor app using the React framework has been added to this repository.

Adding an integrated example app with User Model methods and an automatic linked dependency to the SDK will allow for easy testing of our Cordova SDK as well as method implementation examples.

A new directory, /examples has been added to the Cordova SDK.

From this directory, the example app can be opened by running:

```
ionic capacitor run android

ionic capacitor run ios
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/1001)
<!-- Reviewable:end -->
