### PR TITLE
[Bug] Ignore Live Activities code for Mac Catalyst

### DIFF
--- a/example/IonicCapOneSignal/ios/App/ExampleWidget/ExampleWidgetBundle.swift
+++ b/example/IonicCapOneSignal/ios/App/ExampleWidget/ExampleWidgetBundle.swift
@@ -8,10 +8,11 @@
 
 import WidgetKit
 import SwiftUI
-
+#if !targetEnvironment(macCatalyst)
 @main
 struct ExampleWidgetBundle: WidgetBundle {
     var body: some Widget {
         ExampleWidgetLiveActivity()
     }
 }
+#endif

--- a/example/IonicCapOneSignal/ios/App/ExampleWidget/ExampleWidgetLiveActivity.swift
+++ b/example/IonicCapOneSignal/ios/App/ExampleWidget/ExampleWidgetLiveActivity.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2024 The Chromium Authors. All rights reserved.
 //
 
+#if !targetEnvironment(macCatalyst)
 import ActivityKit
 import WidgetKit
 import SwiftUI
@@ -64,3 +65,4 @@ struct ExampleWidgetLiveActivity: Widget {
         }
     }
 }
+#endif

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -636,6 +636,7 @@ static Class delegateClass = nil;
 }
 
 - (void)setPushToStartToken:(CDVInvokedUrlCommand *)command {
+    #if !TARGET_OS_MACCATALYST
     NSString *activityType = command.arguments[0];
     NSString *token = command.arguments[1];
     NSError* err=nil;
@@ -648,9 +649,11 @@ static Class delegateClass = nil;
     } else {
         [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"cannot setPushToStartToken on iOS < 17.2"]];
     }
+    #endif
 }
 
 - (void)removePushToStartToken:(CDVInvokedUrlCommand *)command {
+    #if !TARGET_OS_MACCATALYST
     NSString *activityType = command.arguments[0];
     NSError* err=nil;
 
@@ -662,9 +665,11 @@ static Class delegateClass = nil;
     } else {
         [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"cannot removePushToStartToken on iOS < 17.2"]];
     }
+    #endif
 }
 
 - (void)setupDefaultLiveActivity:(CDVInvokedUrlCommand *)command {
+    #if !TARGET_OS_MACCATALYST
     NSDictionary *options = command.arguments[0];
     LiveActivitySetupOptions *laOptions = nil;
 
@@ -679,9 +684,11 @@ static Class delegateClass = nil;
     } else {
         [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"cannot setupDefault on iOS < 16.1"]];
     }
+    #endif
 }
 
 - (void)startDefaultLiveActivity:(CDVInvokedUrlCommand *)command {
+    #if !TARGET_OS_MACCATALYST
     NSString *activityId = command.arguments[0];
     NSDictionary *attributes = command.arguments[1];
     NSDictionary *content = command.arguments[2];
@@ -691,5 +698,6 @@ static Class delegateClass = nil;
     } else {
         [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"cannot startDefault on iOS < 16.1"]];
     }
+    #endif
 }
 @end


### PR DESCRIPTION
# Description
## One Line Summary
Fix Mac Catalyst builds by ignoring offending Live Activities code.

## Details
* We fixed Mac Catalyst Live Activities build issues in native SDK https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1446
* However, this wrapper SDK has code that reference `OneSignalLiveActivitiesManagerImpl` directly which is in a module not available to Mac Catalyst due to ActivityKit dependency
* Therefore, it caused build failures for Mac Catalyst.
* Live Activities does not work for Mac anyway, so just ignore these methods.

### Motivation
Fix builds, address followup report here https://github.com/OneSignal/OneSignal-iOS-SDK/issues/1445.

### Scope
- No op Live Activities for Mac Catalyst

# Testing
## Unit testing
None

## Manual testing
Tested on my Mac Catalyst - builds, Live Activities is no-op
Tested on iPhone - builds, Live Activities setup is done

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/1005)
<!-- Reviewable:end -->
