### PR TITLE
Release 5.2.3

### DIFF
--- a/example/IonicCapOneSignal/android/app/capacitor.build.gradle
+++ b/example/IonicCapOneSignal/android/app/capacitor.build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation project(':capacitor-haptics')
     implementation project(':capacitor-keyboard')
     implementation project(':capacitor-status-bar')
-    implementation "com.onesignal:OneSignal:5.1.16"
+    implementation "com.onesignal:OneSignal:5.1.17"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10"
 }
 apply from: "../../../../build-extras-onesignal.gradle"

--- a/example/IonicCapOneSignal/package-lock.json
+++ b/example/IonicCapOneSignal/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "IonicCapOneSignal",
       "version": "0.0.1",
       "dependencies": {
         "@capacitor/android": "6.0.0",
@@ -47,7 +48,7 @@
     },
     "../..": {
       "name": "onesignal-cordova-plugin",
-      "version": "5.2.2",
+      "version": "5.2.3",
       "engines": [
         {
           "name": "cordova-android",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.2.2",
+  "version": "5.2.3",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="5.2.2">
+    version="5.2.3">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -37,7 +37,7 @@
   <js-module src="dist/LiveActivitiesNamespace.js" name="LiveActivitiesNamespace" />
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:5.1.16" />
+    <framework src="com.onesignal:OneSignal:5.1.17" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
     <framework src="org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10" />
 

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -352,7 +352,7 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
 
   public boolean init(CallbackContext callbackContext, JSONArray data) {
     OneSignalWrapper.setSdkType("cordova");  
-    OneSignalWrapper.setSdkVersion("050202");
+    OneSignalWrapper.setSdkVersion("050203");
     try {
       String appId = data.getString(0);
       OneSignal.initWithContext(this.cordova.getActivity(), appId);

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -107,7 +107,7 @@ void processNotificationClicked(OSNotificationClickEvent* event) {
 
 void initOneSignalObject(NSDictionary* launchOptions) {
     OneSignalWrapper.sdkType = @"cordova";
-    OneSignalWrapper.sdkVersion = @"050202";
+    OneSignalWrapper.sdkVersion = @"050203";
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     initialLaunchFired = true;
 }


### PR DESCRIPTION
### 🐛 Bug Fixes
- Fix Mac Catalyst build errors in [#1005](https://github.com/OneSignal/OneSignal-Cordova-SDK/pull/1005)

### 🔧 Update Android SDK from `5.1.15` to `5.1.17` [release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases)
- Fix "could not be instantiated" exception when; some modules are omitted AND android.enableR8.fullMode is enabled. [PR](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2136)

### 🔧 Update iOS SDK from `5.2.1` to `5.2.2` [release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.2)
- Prevent In-App Message request crashes by making null values safe [PR](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1457)
- Add Dispatch Queues to all executors to prevent concurrency crashes [PR](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1454)
- Fix clearing notifications incorrectly such as when pulling down the notification center [PR](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1451)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/1008)
<!-- Reviewable:end -->
