### PR TITLE
Release 5.2.4

### DIFF
--- a/example/IonicCapOneSignal/android/app/capacitor.build.gradle
+++ b/example/IonicCapOneSignal/android/app/capacitor.build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation project(':capacitor-haptics')
     implementation project(':capacitor-keyboard')
     implementation project(':capacitor-status-bar')
-    implementation "com.onesignal:OneSignal:5.1.17"
+    implementation "com.onesignal:OneSignal:5.1.20"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10"
 }
 apply from: "../../../../build-extras-onesignal.gradle"

--- a/example/IonicCapOneSignal/ios/App/Podfile.lock
+++ b/example/IonicCapOneSignal/ios/App/Podfile.lock
@@ -12,10 +12,10 @@ PODS:
     - Capacitor
   - CordovaPluginsStatic (6.0.0):
     - CapacitorCordova
-    - OneSignalXCFramework (= 5.2.2)
-  - OneSignalXCFramework (5.2.2):
-    - OneSignalXCFramework/OneSignalComplete (= 5.2.2)
-  - OneSignalXCFramework/OneSignal (5.2.2):
+    - OneSignalXCFramework (= 5.2.3)
+  - OneSignalXCFramework (5.2.3):
+    - OneSignalXCFramework/OneSignalComplete (= 5.2.3)
+  - OneSignalXCFramework/OneSignal (5.2.3):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalExtension
     - OneSignalXCFramework/OneSignalLiveActivities
@@ -23,38 +23,38 @@ PODS:
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalComplete (5.2.2):
+  - OneSignalXCFramework/OneSignalComplete (5.2.3):
     - OneSignalXCFramework/OneSignal
     - OneSignalXCFramework/OneSignalInAppMessages
     - OneSignalXCFramework/OneSignalLocation
-  - OneSignalXCFramework/OneSignalCore (5.2.2)
-  - OneSignalXCFramework/OneSignalExtension (5.2.2):
+  - OneSignalXCFramework/OneSignalCore (5.2.3)
+  - OneSignalXCFramework/OneSignalExtension (5.2.3):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOutcomes
-  - OneSignalXCFramework/OneSignalInAppMessages (5.2.2):
+  - OneSignalXCFramework/OneSignalInAppMessages (5.2.3):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalLiveActivities (5.2.2):
+  - OneSignalXCFramework/OneSignalLiveActivities (5.2.3):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalLocation (5.2.2):
+  - OneSignalXCFramework/OneSignalLocation (5.2.3):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalNotifications (5.2.2):
+  - OneSignalXCFramework/OneSignalNotifications (5.2.3):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalExtension
     - OneSignalXCFramework/OneSignalOutcomes
-  - OneSignalXCFramework/OneSignalOSCore (5.2.2):
+  - OneSignalXCFramework/OneSignalOSCore (5.2.3):
     - OneSignalXCFramework/OneSignalCore
-  - OneSignalXCFramework/OneSignalOutcomes (5.2.2):
+  - OneSignalXCFramework/OneSignalOutcomes (5.2.3):
     - OneSignalXCFramework/OneSignalCore
-  - OneSignalXCFramework/OneSignalUser (5.2.2):
+  - OneSignalXCFramework/OneSignalUser (5.2.3):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
@@ -97,9 +97,9 @@ SPEC CHECKSUMS:
   CapacitorHaptics: 9ebc9363f0e9b8eb4295088a0b474530acf1859b
   CapacitorKeyboard: deacbd09d8d1029c3681197fb05d206b721d5f73
   CapacitorStatusBar: 2e4369f99166125435641b1908d05f561eaba6f6
-  CordovaPluginsStatic: 0f3d1400283dc86a8fd20f5c8ef7bf7bee9909df
-  OneSignalXCFramework: f06edd9b146c7ac5935136a117ce2a5fdd6420f6
+  CordovaPluginsStatic: 48e6caafc14371ce07e4142d7ebe613c219b855b
+  OneSignalXCFramework: 356e59953e157f6e45a7fdfc863073b3168b2d01
 
 PODFILE CHECKSUM: 178e2a2e451311a871c2b4db713ac4b63d0ebeeb
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.15.2

--- a/example/IonicCapOneSignal/package-lock.json
+++ b/example/IonicCapOneSignal/package-lock.json
@@ -48,7 +48,7 @@
     },
     "../..": {
       "name": "onesignal-cordova-plugin",
-      "version": "5.2.3",
+      "version": "5.2.4",
       "engines": [
         {
           "name": "cordova-android",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.2.3",
+  "version": "5.2.4",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="5.2.3">
+    version="5.2.4">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -37,7 +37,7 @@
   <js-module src="dist/LiveActivitiesNamespace.js" name="LiveActivitiesNamespace" />
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:5.1.17" />
+    <framework src="com.onesignal:OneSignal:5.1.20" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
     <framework src="org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10" />
 
@@ -85,7 +85,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" spec="5.2.2" />
+            <pod name="OneSignalXCFramework" spec="5.2.3" />
         </pods>
     </podspec>
 

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -352,7 +352,7 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
 
   public boolean init(CallbackContext callbackContext, JSONArray data) {
     OneSignalWrapper.setSdkType("cordova");  
-    OneSignalWrapper.setSdkVersion("050203");
+    OneSignalWrapper.setSdkVersion("050204");
     try {
       String appId = data.getString(0);
       OneSignal.initWithContext(this.cordova.getActivity(), appId);

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -107,7 +107,7 @@ void processNotificationClicked(OSNotificationClickEvent* event) {
 
 void initOneSignalObject(NSDictionary* launchOptions) {
     OneSignalWrapper.sdkType = @"cordova";
-    OneSignalWrapper.sdkVersion = @"050203";
+    OneSignalWrapper.sdkVersion = @"050204";
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     initialLaunchFired = true;
 }


### PR DESCRIPTION
🔧 Native SDK Dependency Updates Only
--------

### Update Android SDK from 5.1.17 to 5.1.20 [release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.20)

🐛 Bug Fixes
* IAM with dynamic trigger showing forever (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2137)
* Allow preventDefault to be fired up to two times (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2138)
* Recover null onesignal ID crashes for Operations (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2157)
*Prevent retrying IAM display if 410 is received from backend (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2158)


✨ Improvements
- Optimized the initialization process by moving some service initialization to a background thread (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2151)
- Add option to default to HMS over FCM (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2163)
- Remove fallback code for FCM pre-21.0.0 (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2148)
- Clean up Android Support Library references, drop dependency on androidx.legacy, & Android 4.4 and older code (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2147)

### Update iOS SDK from 5.2.2 to 5.2.3 [release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.3)

🐛 Bug Fixes
- The user executor needs to uncache first which fixes some cached requests being dropped for past users (https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1465)

✨ Improvements
- Omit misleading fatal-level log for cross-platform SDKs (https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1468)

🛠️ Maintenance
- [For our server] Use only OneSignal ID for requests (https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1464)