### PR TITLE
Fix: Notification click listener fires on cold start

### DIFF
--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -236,10 +236,17 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
    * N O T I F I C A T I O N    C L I C K    L I S T E N E R
    */
 
+  private boolean hasAddedNotificationClickListener = false;
+
   public boolean addNotificationClickListener(CallbackContext callbackContext) {
-    OneSignal.getNotifications().addClickListener(this);
-    jsNotificationClickedCallback = callbackContext;
-    return true;
+      if (this.hasAddedNotificationClickListener) {
+        return false;
+      }
+
+      OneSignal.getNotifications().addClickListener(this);
+      jsNotificationClickedCallback = callbackContext;
+      hasAddedNotificationClickListener = true;
+      return true;
   }
 
   @Override

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -237,6 +237,7 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
    */
 
   public boolean addNotificationClickListener(CallbackContext callbackContext) {
+    OneSignal.getNotifications().addClickListener(this);
     jsNotificationClickedCallback = callbackContext;
     return true;
   }
@@ -361,7 +362,6 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
       OneSignal.getInAppMessages().addLifecycleListener(this);
       OneSignal.getInAppMessages().addClickListener(this);
       OneSignal.getNotifications().addForegroundLifecycleListener(this);
-      OneSignal.getNotifications().addClickListener(this);
 
       CallbackHelper.callbackSuccessBoolean(callbackContext, true);
       return true;


### PR DESCRIPTION
# Description
## One Line Summary
Ensure notification click listener fires on cold start

## Details
The native notification click listener is currently added on initialization, rather than when the listener method is explicitly called. This could lead to timing issues where the listener is added after the `onClick` event. Moving the listener out of initialization and into the bridge method follows other wrapper implementations.

### Motivation
It was reported that on certain implementations of Ionic and Cordova apps, the notification click listener was not firing on cold start. Making this change fixes that issue and allows the listener to fire when the notification is clicked from cold start, background, and foreground app states.

# Testing
## Manual testing
Tested opening a notification while the app was both backgrounded and from a cold start. App build with Android Studio 2023.2.1 with a fresh install of the OneSignal example app on a Pixel 6 with Android 14.

# Affected code checklist
   - [X] Notifications
      - [ ] Display
      - [ ] Open
      - [X] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/1017)
<!-- Reviewable:end -->
