### PR TITLE
Release 5.2.9

### DIFF
--- a/example/IonicCapOneSignal/android/app/capacitor.build.gradle
+++ b/example/IonicCapOneSignal/android/app/capacitor.build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation project(':capacitor-haptics')
     implementation project(':capacitor-keyboard')
     implementation project(':capacitor-status-bar')
-    implementation "com.onesignal:OneSignal:5.1.25"
+    implementation "com.onesignal:OneSignal:5.1.26"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10"
 }
 apply from: "../../../../build-extras-onesignal.gradle"

--- a/example/IonicCapOneSignal/ios/App/Podfile.lock
+++ b/example/IonicCapOneSignal/ios/App/Podfile.lock
@@ -12,10 +12,10 @@ PODS:
     - Capacitor
   - CordovaPluginsStatic (6.0.0):
     - CapacitorCordova
-    - OneSignalXCFramework (= 5.2.8)
-  - OneSignalXCFramework (5.2.8):
-    - OneSignalXCFramework/OneSignalComplete (= 5.2.8)
-  - OneSignalXCFramework/OneSignal (5.2.8):
+    - OneSignalXCFramework (= 5.2.9)
+  - OneSignalXCFramework (5.2.9):
+    - OneSignalXCFramework/OneSignalComplete (= 5.2.9)
+  - OneSignalXCFramework/OneSignal (5.2.9):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalExtension
     - OneSignalXCFramework/OneSignalLiveActivities
@@ -23,38 +23,38 @@ PODS:
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalComplete (5.2.8):
+  - OneSignalXCFramework/OneSignalComplete (5.2.9):
     - OneSignalXCFramework/OneSignal
     - OneSignalXCFramework/OneSignalInAppMessages
     - OneSignalXCFramework/OneSignalLocation
-  - OneSignalXCFramework/OneSignalCore (5.2.8)
-  - OneSignalXCFramework/OneSignalExtension (5.2.8):
+  - OneSignalXCFramework/OneSignalCore (5.2.9)
+  - OneSignalXCFramework/OneSignalExtension (5.2.9):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOutcomes
-  - OneSignalXCFramework/OneSignalInAppMessages (5.2.8):
+  - OneSignalXCFramework/OneSignalInAppMessages (5.2.9):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalLiveActivities (5.2.8):
+  - OneSignalXCFramework/OneSignalLiveActivities (5.2.9):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalLocation (5.2.8):
+  - OneSignalXCFramework/OneSignalLocation (5.2.9):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalNotifications (5.2.8):
+  - OneSignalXCFramework/OneSignalNotifications (5.2.9):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalExtension
     - OneSignalXCFramework/OneSignalOutcomes
-  - OneSignalXCFramework/OneSignalOSCore (5.2.8):
+  - OneSignalXCFramework/OneSignalOSCore (5.2.9):
     - OneSignalXCFramework/OneSignalCore
-  - OneSignalXCFramework/OneSignalOutcomes (5.2.8):
+  - OneSignalXCFramework/OneSignalOutcomes (5.2.9):
     - OneSignalXCFramework/OneSignalCore
-  - OneSignalXCFramework/OneSignalUser (5.2.8):
+  - OneSignalXCFramework/OneSignalUser (5.2.9):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
@@ -97,8 +97,8 @@ SPEC CHECKSUMS:
   CapacitorHaptics: 9ebc9363f0e9b8eb4295088a0b474530acf1859b
   CapacitorKeyboard: deacbd09d8d1029c3681197fb05d206b721d5f73
   CapacitorStatusBar: 2e4369f99166125435641b1908d05f561eaba6f6
-  CordovaPluginsStatic: 7a2084b3aa930386f423ea1d0fe3ae03b4382c55
-  OneSignalXCFramework: 4215fb8deb8a669504d39c02dffaf2ec8ebe10ae
+  CordovaPluginsStatic: 74720072a4a4ab131d56823ddd85736b6bc9f92b
+  OneSignalXCFramework: f5b2a3c4f130e4c910ead7bb25bed7455e976fbf
 
 PODFILE CHECKSUM: 178e2a2e451311a871c2b4db713ac4b63d0ebeeb
 

--- a/example/IonicCapOneSignal/package-lock.json
+++ b/example/IonicCapOneSignal/package-lock.json
@@ -48,7 +48,7 @@
     },
     "../..": {
       "name": "onesignal-cordova-plugin",
-      "version": "5.2.8",
+      "version": "5.2.9",
       "engines": [
         {
           "name": "cordova-android",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.2.8",
+  "version": "5.2.9",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="5.2.8">
+    version="5.2.9">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -37,7 +37,7 @@
   <js-module src="dist/LiveActivitiesNamespace.js" name="LiveActivitiesNamespace" />
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:5.1.25" />
+    <framework src="com.onesignal:OneSignal:5.1.26" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
     <framework src="org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10" />
 
@@ -85,7 +85,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" spec="5.2.8" />
+            <pod name="OneSignalXCFramework" spec="5.2.9" />
         </pods>
     </podspec>
 

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -360,7 +360,7 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
 
   public boolean init(CallbackContext callbackContext, JSONArray data) {
     OneSignalWrapper.setSdkType("cordova");  
-    OneSignalWrapper.setSdkVersion("050208");
+    OneSignalWrapper.setSdkVersion("050209");
     try {
       String appId = data.getString(0);
       OneSignal.initWithContext(this.cordova.getActivity(), appId);

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -107,7 +107,7 @@ void processNotificationClicked(OSNotificationClickEvent* event) {
 
 void initOneSignalObject(NSDictionary* launchOptions) {
     OneSignalWrapper.sdkType = @"cordova";
-    OneSignalWrapper.sdkVersion = @"050208";
+    OneSignalWrapper.sdkVersion = @"050209";
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     initialLaunchFired = true;
 }


### PR DESCRIPTION
🔧 Native SDK Dependency Updates Only
--------
### Update Android SDK from 5.1.25 to 5.1.26 | [release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.26)
🐛 Bug Fixes
- [Fix] ANR caused by operationRepo.enqueue while loading is in progress [#2233](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2233)
- [Fix] Check subscription Id before executing delete and update subscription operations [#2223](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2223)

### Update iOS SDK from 5.2.8 to 5.2.9 | [release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.9)
🐛 Bug Fixes
- [Fix] Use new OneSignalClientError type for callbacks which fixes crash report of NSInvalidArgumentException [#1528](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1528)
- [Fix] Don't evaluate in app messages when paused which fixes issues with duration-since-last In-App Messages when pausing and unpausing [#1524](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1524)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/1037)
<!-- Reviewable:end -->
