### PR TITLE
Release 5.2.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.2.9",
+  "version": "5.2.10",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="5.2.9">
+    version="5.2.10">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -37,7 +37,7 @@
   <js-module src="dist/LiveActivitiesNamespace.js" name="LiveActivitiesNamespace" />
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:5.1.26" />
+    <framework src="com.onesignal:OneSignal:5.1.29" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
     <framework src="org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10" />
 
@@ -85,7 +85,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" spec="5.2.9" />
+            <pod name="OneSignalXCFramework" spec="5.2.10" />
         </pods>
     </podspec>
 

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -360,7 +360,7 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
 
   public boolean init(CallbackContext callbackContext, JSONArray data) {
     OneSignalWrapper.setSdkType("cordova");  
-    OneSignalWrapper.setSdkVersion("050209");
+    OneSignalWrapper.setSdkVersion("050210");
     try {
       String appId = data.getString(0);
       OneSignal.initWithContext(this.cordova.getActivity(), appId);

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -107,7 +107,7 @@ void processNotificationClicked(OSNotificationClickEvent* event) {
 
 void initOneSignalObject(NSDictionary* launchOptions) {
     OneSignalWrapper.sdkType = @"cordova";
-    OneSignalWrapper.sdkVersion = @"050209";
+    OneSignalWrapper.sdkVersion = @"050210";
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     initialLaunchFired = true;
 }


### PR DESCRIPTION
### 🐛 Bug Fixes
- when upgrading from v3 to v5 of this SDK, notifications will be received when the app has not been opened yet [Android fix](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2244)

---------

### 🛠️ Native Dependency Updates
**Update Android SDK from 5.1.26 to 5.1.29 | select fixes listed**
- [add Amazon IAP v3.0.5 handle](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2255)
- [fix issue with notification click not foregrounding the app on the first click in certain scenarios](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2259)
- [fix rare 400 issues that happen on new installs](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2059)
- See [release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases) for full details.

**Update iOS SDK from 5.2.9 to 5.2.10**
- [Fix requiring privacy consent blocks confirmed deliveries indefinitely](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1541)
- [Detect for timezone changes and update the user](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1542)
- See [release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases) for full details.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/1044)
<!-- Reviewable:end -->
