### PR TITLE
Fix listener behavior on app reloads

### DIFF
--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -239,14 +239,12 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
   private boolean hasAddedNotificationClickListener = false;
 
   public boolean addNotificationClickListener(CallbackContext callbackContext) {
-      if (this.hasAddedNotificationClickListener) {
-        return false;
-      }
-
+    jsNotificationClickedCallback = callbackContext;
+    if (!this.hasAddedNotificationClickListener) {
       OneSignal.getNotifications().addClickListener(this);
-      jsNotificationClickedCallback = callbackContext;
       hasAddedNotificationClickListener = true;
-      return true;
+    }
+    return true;
   }
 
   @Override

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -150,6 +150,8 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
   private static CallbackContext jsNotificationInForegroundCallBack;
   private static CallbackContext jsNotificationClickedCallback;
 
+  private static boolean initDone;
+
   /**
    * N O T I F I C A T I O N    L I F E C Y C L E
    */
@@ -357,6 +359,12 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
    */
 
   public boolean init(CallbackContext callbackContext, JSONArray data) {
+    if (initDone) {
+      Logging.debug("Already initialized the OneSignal Cordova SDK", null);
+      return true;
+    }
+
+    initDone = true;
     OneSignalWrapper.setSdkType("cordova");  
     OneSignalWrapper.setSdkVersion("050211");
     try {
@@ -705,6 +713,12 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
 
   @Override
   public void onDestroy() {
+    if (!initDone) {
+      Logging.debug("OneSignal Cordova SDK not initialized yet. Could not remove listeners.", null);
+      return;
+    }
+
+    hasAddedNotificationClickListener = false;
     OneSignal.getNotifications().removeClickListener(this);
     OneSignal.getNotifications().removeForegroundLifecycleListener(this);
     OneSignal.getInAppMessages().removeClickListener(this);

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -267,9 +267,9 @@ static Class delegateClass = nil;
 }
 
 - (void)addForegroundLifecycleListener:(CDVInvokedUrlCommand*)command {
-    bool first = notificationWillShowInForegoundCallbackId  == nil;
+    bool handlerNotSet = notificationWillShowInForegoundCallbackId  == nil;
     notificationWillShowInForegoundCallbackId = command.callbackId;
-    if (first) {
+    if (handlerNotSet) {
         [OneSignal.Notifications addForegroundLifecycleListener:self];
     }
 }
@@ -281,9 +281,9 @@ static Class delegateClass = nil;
 }
 
 - (void)addNotificationClickListener:(CDVInvokedUrlCommand*)command {
-    bool first = notificationClickedCallbackId  == nil;
+    bool handlerNotSet = notificationClickedCallbackId  == nil;
     notificationClickedCallbackId = command.callbackId;
-    if (first) {
+    if (handlerNotSet) {
         [OneSignal.Notifications addClickListener:self];
     }
 }
@@ -320,24 +320,24 @@ static Class delegateClass = nil;
 }
 
 - (void)addPermissionObserver:(CDVInvokedUrlCommand*)command {
-    bool first = permissionObserverCallbackId == nil;
+    bool handlerNotSet = permissionObserverCallbackId == nil;
     permissionObserverCallbackId = command.callbackId;
-    if (first) {
+    if (handlerNotSet) {
         [OneSignal.Notifications addPermissionObserver:self];
     }
 }
 
 - (void)addPushSubscriptionObserver:(CDVInvokedUrlCommand*)command {
-    bool first = subscriptionObserverCallbackId == nil;
+    bool handlerNotSet = subscriptionObserverCallbackId == nil;
     subscriptionObserverCallbackId = command.callbackId;
-    if (first)
+    if (handlerNotSet)
         [OneSignal.User.pushSubscription addObserver:self];
 }
 
 - (void)addUserStateObserver:(CDVInvokedUrlCommand*)command {
-    bool first = userObserverCallbackId == nil;
+    bool handlerNotSet = userObserverCallbackId == nil;
     userObserverCallbackId = command.callbackId;
-    if (first) {
+    if (handlerNotSet) {
         [OneSignal.User addObserver:self];
     }
 }
@@ -505,9 +505,9 @@ static Class delegateClass = nil;
 }
 
 - (void)setInAppMessageClickHandler:(CDVInvokedUrlCommand*)command {
-    bool first = inAppMessageClickedCallbackId  == nil;
+    bool handlerNotSet = inAppMessageClickedCallbackId  == nil;
     inAppMessageClickedCallbackId = command.callbackId;
-    if (first) {
+    if (handlerNotSet) {
         [OneSignal.InAppMessages addClickListener:self];
     }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Fix notification and IAM listener registration so that they are not duplicated on app reloads.

## Details

### Motivation
- [Android] If the app is reloaded, native listeners will be added multiple times. This scenario can happen even in a non-debug mode. Clean up how the listeners are registered in the initialize method and return early if initialize is called multiple times by the developer. See https://github.com/OneSignal/OneSignal-Cordova-SDK/issues/1015
- [Android] fix notification click listener not fired on reload. Regardless of if the listener has been added already, we need to update the callback and return true. See #1032.


### Scope
- Only add native listeners once when the SDK is in memory

### iOS was not affected by reloads or adding multiple listeners
I saw some odd behavior that reloading the app, or even **manually** adding a native listener multiple times in [OneSignalPush.m](https://github.com/OneSignal/OneSignal-Cordova-SDK/blob/13868a466f2ce0e90056532813c8a7e12adc07d6/src/ios/OneSignalPush.m) did not trigger my final event listener to fire multiple times. I think this may have to do with how the event is emitted by the platform with the same callback ID. I saw that our `successCallback` method was invoked multiple times however [[pluginCommandDelegate sendPluginResult:commandResult callbackId:callbackId]](https://github.com/OneSignal/OneSignal-Cordova-SDK/blob/13868a466f2ce0e90056532813c8a7e12adc07d6/src/ios/OneSignalPush.m#L79) must be only invoking the final listener once.

Thus the problems experienced on Android mentioned above are not reproducible on iOS. Regardless, let's clean up how the listeners are registered in the initialize method and return early if initialize is called multiple times by the developer.

# Testing
Listeners tested:
- Notification click
- Notification foreground display
- IAM click
- IAM display (4 lifecycle events)
- permission observer
- push sub observer
- user state observer

## Manual testing
**Android API 33 emulator**
- reproduced the problems by calling `window.location.reload()` to invoke an app refresh 
- confirmed after PR, all listeners are working as expected

iPhone 13 running iOS 18.4.1
- never able to reproduce the problem, even adding the native listeners manually (see above notes)
- confirmed after PR, all listeners are working as expected

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes
   - [x] Listeners firing

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/1052)
<!-- Reviewable:end -->
