### PR TITLE
Release 5.2.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.2.12",
+  "version": "5.2.13",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="5.2.12">
+    version="5.2.13">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -85,7 +85,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" spec="5.2.11" />
+            <pod name="OneSignalXCFramework" spec="5.2.10" />
         </pods>
     </podspec>
 

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -364,7 +364,7 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
 
     initDone = true;
     OneSignalWrapper.setSdkType("cordova");  
-    OneSignalWrapper.setSdkVersion("050212");
+    OneSignalWrapper.setSdkVersion("050213");
     try {
       String appId = data.getString(0);
       OneSignal.initWithContext(this.cordova.getActivity(), appId);

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -107,7 +107,7 @@ void processNotificationClicked(OSNotificationClickEvent* event) {
 
 void initOneSignalObject(NSDictionary* launchOptions) {
     OneSignalWrapper.sdkType = @"cordova";
-    OneSignalWrapper.sdkVersion = @"050212";
+    OneSignalWrapper.sdkVersion = @"050213";
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
 }
 


### PR DESCRIPTION
Channels: Current

### 🐛 Bug Fixes
- Fix listener behavior on app reloads (#1052)

### ✨ Improvements
- Add cordova types package (#1047)
---------

### 🛠️ Native Dependency Updates
**Update Android SDK from 5.1.29 to 5.1.33 | select fixes listed**
- [Fix] very rare bug where app doesn't opening from notification tap when it cold starts the app, affects Samsung and Redmi (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2289)
- IAM not showing fixes: (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2287) and (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2284)
- Fix: ANR fixes (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2281)
- See [release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases) for full details.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/1056)
<!-- Reviewable:end -->
