### PR TITLE
Release 5.2.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.2.14",
+  "version": "5.2.15",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="5.2.14">
+    version="5.2.15">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -37,7 +37,7 @@
   <js-module src="dist/LiveActivitiesNamespace.js" name="LiveActivitiesNamespace" />
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:5.1.34" />
+    <framework src="com.onesignal:OneSignal:5.1.35" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
     <framework src="org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10" />
 
@@ -85,7 +85,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" spec="5.2.13" />
+            <pod name="OneSignalXCFramework" spec="5.2.14" />
         </pods>
     </podspec>
 

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -364,7 +364,7 @@ public class OneSignalPush extends CordovaPlugin implements INotificationLifecyc
 
     initDone = true;
     OneSignalWrapper.setSdkType("cordova");  
-    OneSignalWrapper.setSdkVersion("050214");
+    OneSignalWrapper.setSdkVersion("050215");
     try {
       String appId = data.getString(0);
       OneSignal.initWithContext(this.cordova.getActivity(), appId);

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -107,7 +107,7 @@ void processNotificationClicked(OSNotificationClickEvent* event) {
 
 void initOneSignalObject(NSDictionary* launchOptions) {
     OneSignalWrapper.sdkType = @"cordova";
-    OneSignalWrapper.sdkVersion = @"050214";
+    OneSignalWrapper.sdkVersion = @"050215";
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
 }
 


### PR DESCRIPTION
Channels: Current

### 🛠️ Native Dependency Updates Only
**Update Android SDK from 5.1.34 to 5.1.35**
- https://github.com/OneSignal/OneSignal-Android-SDK/pull/2333
- https://github.com/OneSignal/OneSignal-Android-SDK/pull/2330
- https://github.com/OneSignal/OneSignal-Android-SDK/pull/2328
- https://github.com/OneSignal/OneSignal-Android-SDK/pull/2329
- https://github.com/OneSignal/OneSignal-Android-SDK/pull/2327
- https://github.com/OneSignal/OneSignal-Android-SDK/pull/2332
- See [release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases) for full details.

**Update iOS SDK from 5.2.13 to 5.2.14**
- https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1573
- See [release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases) for full details.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/1068)
<!-- Reviewable:end -->
