### PR TITLE
fix: prevent duplicate native handler registrations

### DIFF
--- a/www/InAppMessagesNamespace.test.ts
+++ b/www/InAppMessagesNamespace.test.ts
@@ -89,6 +89,79 @@ describe('InAppMessages', () => {
 
       expect(window.cordova.exec).not.toHaveBeenCalled();
     });
+
+    test('should only register native handler once for multiple listeners of same event type', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+      const handler3 = vi.fn();
+
+      // Add first listener - should register native handler
+      inAppMessages.addEventListener('click', handler1);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Add second listener - should NOT register native handler again
+      inAppMessages.addEventListener('click', handler2);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Add third listener - should still be only one registration
+      inAppMessages.addEventListener('click', handler3);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Trigger the event with click data
+      const clickData = {
+        message: { messageId: 'test' },
+        result: { closingMessage: true, actionId: 'test' },
+      };
+      mockExec.mock.calls[0][0](clickData);
+
+      // All handlers should execute exactly once
+      expect(handler1).toHaveBeenCalledTimes(1);
+      expect(handler1).toHaveBeenCalledWith(clickData);
+      expect(handler2).toHaveBeenCalledTimes(1);
+      expect(handler2).toHaveBeenCalledWith(clickData);
+      expect(handler3).toHaveBeenCalledTimes(1);
+      expect(handler3).toHaveBeenCalledWith(clickData);
+    });
+
+    test('should only register native handler once for willDisplay event', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+
+      inAppMessages.addEventListener('willDisplay', handler1);
+      inAppMessages.addEventListener('willDisplay', handler2);
+
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+    });
+
+    test('should only register native handler once for didDisplay event', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+
+      inAppMessages.addEventListener('didDisplay', handler1);
+      inAppMessages.addEventListener('didDisplay', handler2);
+
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+    });
+
+    test('should only register native handler once for willDismiss event', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+
+      inAppMessages.addEventListener('willDismiss', handler1);
+      inAppMessages.addEventListener('willDismiss', handler2);
+
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+    });
+
+    test('should only register native handler once for didDismiss event', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+
+      inAppMessages.addEventListener('didDismiss', handler1);
+      inAppMessages.addEventListener('didDismiss', handler2);
+
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('removeEventListener', () => {

--- a/www/InAppMessagesNamespace.test.ts
+++ b/www/InAppMessagesNamespace.test.ts
@@ -73,6 +73,79 @@ describe('InAppMessages', () => {
 
       expect(window.cordova.exec).not.toHaveBeenCalled();
     });
+
+    test('should only register native handler once for multiple listeners of same event type', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+      const handler3 = vi.fn();
+
+      // Add first listener - should register native handler
+      inAppMessages.addEventListener('click', handler1);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Add second listener - should NOT register native handler again
+      inAppMessages.addEventListener('click', handler2);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Add third listener - should still be only one registration
+      inAppMessages.addEventListener('click', handler3);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Trigger the event with click data
+      const clickData = {
+        message: { messageId: 'test' },
+        result: { closingMessage: true, actionId: 'test' },
+      };
+      mockExec.mock.calls[0][0](clickData);
+
+      // All handlers should execute exactly once
+      expect(handler1).toHaveBeenCalledTimes(1);
+      expect(handler1).toHaveBeenCalledWith(clickData);
+      expect(handler2).toHaveBeenCalledTimes(1);
+      expect(handler2).toHaveBeenCalledWith(clickData);
+      expect(handler3).toHaveBeenCalledTimes(1);
+      expect(handler3).toHaveBeenCalledWith(clickData);
+    });
+
+    test('should only register native handler once for willDisplay event', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+
+      inAppMessages.addEventListener('willDisplay', handler1);
+      inAppMessages.addEventListener('willDisplay', handler2);
+
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+    });
+
+    test('should only register native handler once for didDisplay event', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+
+      inAppMessages.addEventListener('didDisplay', handler1);
+      inAppMessages.addEventListener('didDisplay', handler2);
+
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+    });
+
+    test('should only register native handler once for willDismiss event', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+
+      inAppMessages.addEventListener('willDismiss', handler1);
+      inAppMessages.addEventListener('willDismiss', handler2);
+
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+    });
+
+    test('should only register native handler once for didDismiss event', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+
+      inAppMessages.addEventListener('didDismiss', handler1);
+      inAppMessages.addEventListener('didDismiss', handler2);
+
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('removeEventListener', () => {

--- a/www/InAppMessagesNamespace.ts
+++ b/www/InAppMessagesNamespace.ts
@@ -26,6 +26,13 @@ export default class InAppMessages {
     event: InAppMessageDidDismissEvent,
   ) => void)[] = [];
 
+  // Track whether native handlers have been registered to avoid duplicate registrations
+  private _clickHandlerRegistered = false;
+  private _willDisplayHandlerRegistered = false;
+  private _didDisplayHandlerRegistered = false;
+  private _willDismissHandlerRegistered = false;
+  private _didDismissHandlerRegistered = false;
+
   private _processFunctionList<T>(
     array: ((event: T) => void)[],
     param: T,
@@ -49,86 +56,111 @@ export default class InAppMessages {
       this._inAppMessageClickListeners.push(
         listener as (event: InAppMessageClickEvent) => void,
       );
-      const inAppMessageClickListener = (json: InAppMessageClickEvent) => {
-        this._processFunctionList(this._inAppMessageClickListeners, json);
-      };
-      window.cordova.exec(
-        inAppMessageClickListener,
-        noop,
-        'OneSignalPush',
-        'setInAppMessageClickHandler',
-        [],
-      );
+
+      // Only register the native handler once
+      if (!this._clickHandlerRegistered) {
+        this._clickHandlerRegistered = true;
+        const inAppMessageClickListener = (json: InAppMessageClickEvent) => {
+          this._processFunctionList(this._inAppMessageClickListeners, json);
+        };
+        window.cordova.exec(
+          inAppMessageClickListener,
+          noop,
+          'OneSignalPush',
+          'setInAppMessageClickHandler',
+          [],
+        );
+      }
     } else if (event === 'willDisplay') {
       this._willDisplayInAppMessageListeners.push(
         listener as (event: InAppMessageWillDisplayEvent) => void,
       );
-      const willDisplayCallBackProcessor = (
-        event: InAppMessageWillDisplayEvent,
-      ) => {
-        this._processFunctionList(
-          this._willDisplayInAppMessageListeners,
-          event,
+
+      // Only register the native handler once
+      if (!this._willDisplayHandlerRegistered) {
+        this._willDisplayHandlerRegistered = true;
+        const willDisplayCallBackProcessor = (
+          event: InAppMessageWillDisplayEvent,
+        ) => {
+          this._processFunctionList(
+            this._willDisplayInAppMessageListeners,
+            event,
+          );
+        };
+        window.cordova.exec(
+          willDisplayCallBackProcessor,
+          noop,
+          'OneSignalPush',
+          'setOnWillDisplayInAppMessageHandler',
+          [],
         );
-      };
-      window.cordova.exec(
-        willDisplayCallBackProcessor,
-        noop,
-        'OneSignalPush',
-        'setOnWillDisplayInAppMessageHandler',
-        [],
-      );
+      }
     } else if (event === 'didDisplay') {
       this._didDisplayInAppMessageListeners.push(
         listener as (event: InAppMessageDidDisplayEvent) => void,
       );
-      const didDisplayCallBackProcessor = (
-        event: InAppMessageDidDisplayEvent,
-      ) => {
-        this._processFunctionList(this._didDisplayInAppMessageListeners, event);
-      };
-      window.cordova.exec(
-        didDisplayCallBackProcessor,
-        noop,
-        'OneSignalPush',
-        'setOnDidDisplayInAppMessageHandler',
-        [],
-      );
+
+      // Only register the native handler once
+      if (!this._didDisplayHandlerRegistered) {
+        this._didDisplayHandlerRegistered = true;
+        const didDisplayCallBackProcessor = (
+          event: InAppMessageDidDisplayEvent,
+        ) => {
+          this._processFunctionList(this._didDisplayInAppMessageListeners, event);
+        };
+        window.cordova.exec(
+          didDisplayCallBackProcessor,
+          noop,
+          'OneSignalPush',
+          'setOnDidDisplayInAppMessageHandler',
+          [],
+        );
+      }
     } else if (event === 'willDismiss') {
       this._willDismissInAppMessageListeners.push(
         listener as (event: InAppMessageWillDismissEvent) => void,
       );
-      const willDismissInAppMessageProcessor = (
-        event: InAppMessageWillDismissEvent,
-      ) => {
-        this._processFunctionList(
-          this._willDismissInAppMessageListeners,
-          event,
+
+      // Only register the native handler once
+      if (!this._willDismissHandlerRegistered) {
+        this._willDismissHandlerRegistered = true;
+        const willDismissInAppMessageProcessor = (
+          event: InAppMessageWillDismissEvent,
+        ) => {
+          this._processFunctionList(
+            this._willDismissInAppMessageListeners,
+            event,
+          );
+        };
+        window.cordova.exec(
+          willDismissInAppMessageProcessor,
+          noop,
+          'OneSignalPush',
+          'setOnWillDismissInAppMessageHandler',
+          [],
         );
-      };
-      window.cordova.exec(
-        willDismissInAppMessageProcessor,
-        noop,
-        'OneSignalPush',
-        'setOnWillDismissInAppMessageHandler',
-        [],
-      );
+      }
     } else if (event === 'didDismiss') {
       this._didDismissInAppMessageListeners.push(
         listener as (event: InAppMessageDidDismissEvent) => void,
       );
-      const didDismissInAppMessageCallBackProcessor = (
-        event: InAppMessageDidDismissEvent,
-      ) => {
-        this._processFunctionList(this._didDismissInAppMessageListeners, event);
-      };
-      window.cordova.exec(
-        didDismissInAppMessageCallBackProcessor,
-        noop,
-        'OneSignalPush',
-        'setOnDidDismissInAppMessageHandler',
-        [],
-      );
+
+      // Only register the native handler once
+      if (!this._didDismissHandlerRegistered) {
+        this._didDismissHandlerRegistered = true;
+        const didDismissInAppMessageCallBackProcessor = (
+          event: InAppMessageDidDismissEvent,
+        ) => {
+          this._processFunctionList(this._didDismissInAppMessageListeners, event);
+        };
+        window.cordova.exec(
+          didDismissInAppMessageCallBackProcessor,
+          noop,
+          'OneSignalPush',
+          'setOnDidDismissInAppMessageHandler',
+          [],
+        );
+      }
     }
   }
 

--- a/www/InAppMessagesNamespace.ts
+++ b/www/InAppMessagesNamespace.ts
@@ -106,7 +106,10 @@ export default class InAppMessages {
         const didDisplayCallBackProcessor = (
           event: InAppMessageDidDisplayEvent,
         ) => {
-          this._processFunctionList(this._didDisplayInAppMessageListeners, event);
+          this._processFunctionList(
+            this._didDisplayInAppMessageListeners,
+            event,
+          );
         };
         window.cordova.exec(
           didDisplayCallBackProcessor,
@@ -151,7 +154,10 @@ export default class InAppMessages {
         const didDismissInAppMessageCallBackProcessor = (
           event: InAppMessageDidDismissEvent,
         ) => {
-          this._processFunctionList(this._didDismissInAppMessageListeners, event);
+          this._processFunctionList(
+            this._didDismissInAppMessageListeners,
+            event,
+          );
         };
         window.cordova.exec(
           didDismissInAppMessageCallBackProcessor,

--- a/www/InAppMessagesNamespace.ts
+++ b/www/InAppMessagesNamespace.ts
@@ -10,21 +10,11 @@ import type {
 } from './types/InAppMessage';
 
 export default class InAppMessages {
-  private _inAppMessageClickListeners: ((
-    action: InAppMessageClickEvent,
-  ) => void)[] = [];
-  private _willDisplayInAppMessageListeners: ((
-    event: InAppMessageWillDisplayEvent,
-  ) => void)[] = [];
-  private _didDisplayInAppMessageListeners: ((
-    event: InAppMessageDidDisplayEvent,
-  ) => void)[] = [];
-  private _willDismissInAppMessageListeners: ((
-    event: InAppMessageWillDismissEvent,
-  ) => void)[] = [];
-  private _didDismissInAppMessageListeners: ((
-    event: InAppMessageDidDismissEvent,
-  ) => void)[] = [];
+  private _inAppMessageClickListeners: ((action: InAppMessageClickEvent) => void)[] = [];
+  private _willDisplayInAppMessageListeners: ((event: InAppMessageWillDisplayEvent) => void)[] = [];
+  private _didDisplayInAppMessageListeners: ((event: InAppMessageDidDisplayEvent) => void)[] = [];
+  private _willDismissInAppMessageListeners: ((event: InAppMessageWillDismissEvent) => void)[] = [];
+  private _didDismissInAppMessageListeners: ((event: InAppMessageDidDismissEvent) => void)[] = [];
 
   // Track whether native handlers have been registered to avoid duplicate registrations
   private _clickHandlerRegistered = false;
@@ -33,10 +23,7 @@ export default class InAppMessages {
   private _willDismissHandlerRegistered = false;
   private _didDismissHandlerRegistered = false;
 
-  private _processFunctionList<T>(
-    array: ((event: T) => void)[],
-    param: T,
-  ): void {
+  private _processFunctionList<T>(array: ((event: T) => void)[], param: T): void {
     for (let i = 0; i < array.length; i++) {
       array[i](param);
     }
@@ -53,9 +40,7 @@ export default class InAppMessages {
     listener: (event: InAppMessageEventTypeMap[K]) => void,
   ): void {
     if (event === 'click') {
-      this._inAppMessageClickListeners.push(
-        listener as (event: InAppMessageClickEvent) => void,
-      );
+      this._inAppMessageClickListeners.push(listener as (event: InAppMessageClickEvent) => void);
 
       // Only register the native handler once
       if (!this._clickHandlerRegistered) {
@@ -79,13 +64,8 @@ export default class InAppMessages {
       // Only register the native handler once
       if (!this._willDisplayHandlerRegistered) {
         this._willDisplayHandlerRegistered = true;
-        const willDisplayCallBackProcessor = (
-          event: InAppMessageWillDisplayEvent,
-        ) => {
-          this._processFunctionList(
-            this._willDisplayInAppMessageListeners,
-            event,
-          );
+        const willDisplayCallBackProcessor = (event: InAppMessageWillDisplayEvent) => {
+          this._processFunctionList(this._willDisplayInAppMessageListeners, event);
         };
         window.cordova.exec(
           willDisplayCallBackProcessor,
@@ -103,9 +83,7 @@ export default class InAppMessages {
       // Only register the native handler once
       if (!this._didDisplayHandlerRegistered) {
         this._didDisplayHandlerRegistered = true;
-        const didDisplayCallBackProcessor = (
-          event: InAppMessageDidDisplayEvent,
-        ) => {
+        const didDisplayCallBackProcessor = (event: InAppMessageDidDisplayEvent) => {
           this._processFunctionList(this._didDisplayInAppMessageListeners, event);
         };
         window.cordova.exec(
@@ -124,13 +102,8 @@ export default class InAppMessages {
       // Only register the native handler once
       if (!this._willDismissHandlerRegistered) {
         this._willDismissHandlerRegistered = true;
-        const willDismissInAppMessageProcessor = (
-          event: InAppMessageWillDismissEvent,
-        ) => {
-          this._processFunctionList(
-            this._willDismissInAppMessageListeners,
-            event,
-          );
+        const willDismissInAppMessageProcessor = (event: InAppMessageWillDismissEvent) => {
+          this._processFunctionList(this._willDismissInAppMessageListeners, event);
         };
         window.cordova.exec(
           willDismissInAppMessageProcessor,
@@ -148,9 +121,7 @@ export default class InAppMessages {
       // Only register the native handler once
       if (!this._didDismissHandlerRegistered) {
         this._didDismissHandlerRegistered = true;
-        const didDismissInAppMessageCallBackProcessor = (
-          event: InAppMessageDidDismissEvent,
-        ) => {
+        const didDismissInAppMessageCallBackProcessor = (event: InAppMessageDidDismissEvent) => {
           this._processFunctionList(this._didDismissInAppMessageListeners, event);
         };
         window.cordova.exec(
@@ -231,9 +202,7 @@ export default class InAppMessages {
    */
   removeTriggers(keys: string[]): void {
     if (!Array.isArray(keys)) {
-      console.error(
-        'OneSignal: removeTriggers: argument must be of type Array',
-      );
+      console.error('OneSignal: removeTriggers: argument must be of type Array');
     }
 
     window.cordova.exec(noop, noop, 'OneSignalPush', 'removeTriggers', [keys]);

--- a/www/InAppMessagesNamespace.ts
+++ b/www/InAppMessagesNamespace.ts
@@ -15,13 +15,11 @@ export default class InAppMessages {
   private _didDisplayInAppMessageListeners: ((event: InAppMessageDidDisplayEvent) => void)[] = [];
   private _willDismissInAppMessageListeners: ((event: InAppMessageWillDismissEvent) => void)[] = [];
   private _didDismissInAppMessageListeners: ((event: InAppMessageDidDismissEvent) => void)[] = [];
-
-  // Track whether native handlers have been registered to avoid duplicate registrations
-  private _clickHandlerRegistered = false;
-  private _willDisplayHandlerRegistered = false;
-  private _didDisplayHandlerRegistered = false;
-  private _willDismissHandlerRegistered = false;
-  private _didDismissHandlerRegistered = false;
+  private _hasRegisteredClickListener = false;
+  private _hasRegisteredWillDisplayListener = false;
+  private _hasRegisteredDidDisplayListener = false;
+  private _hasRegisteredWillDismissListener = false;
+  private _hasRegisteredDidDismissListener = false;
 
   private _processFunctionList<T>(array: ((event: T) => void)[], param: T): void {
     for (let i = 0; i < array.length; i++) {
@@ -31,9 +29,8 @@ export default class InAppMessages {
 
   /**
    * Add event listeners for In-App Message click and/or lifecycle events.
-   * @param event
-   * @param listener
-   * @returns
+   * Each native bridge channel is registered once per namespace instance;
+   * subsequent subscribers append to the local list to avoid orphaned handlers.
    */
   addEventListener<K extends InAppMessageEventName>(
     event: K,
@@ -41,10 +38,8 @@ export default class InAppMessages {
   ): void {
     if (event === 'click') {
       this._inAppMessageClickListeners.push(listener as (event: InAppMessageClickEvent) => void);
-
-      // Only register the native handler once
-      if (!this._clickHandlerRegistered) {
-        this._clickHandlerRegistered = true;
+      if (!this._hasRegisteredClickListener) {
+        this._hasRegisteredClickListener = true;
         const inAppMessageClickListener = (json: InAppMessageClickEvent) => {
           this._processFunctionList(this._inAppMessageClickListeners, json);
         };
@@ -60,10 +55,8 @@ export default class InAppMessages {
       this._willDisplayInAppMessageListeners.push(
         listener as (event: InAppMessageWillDisplayEvent) => void,
       );
-
-      // Only register the native handler once
-      if (!this._willDisplayHandlerRegistered) {
-        this._willDisplayHandlerRegistered = true;
+      if (!this._hasRegisteredWillDisplayListener) {
+        this._hasRegisteredWillDisplayListener = true;
         const willDisplayCallBackProcessor = (event: InAppMessageWillDisplayEvent) => {
           this._processFunctionList(this._willDisplayInAppMessageListeners, event);
         };
@@ -79,10 +72,8 @@ export default class InAppMessages {
       this._didDisplayInAppMessageListeners.push(
         listener as (event: InAppMessageDidDisplayEvent) => void,
       );
-
-      // Only register the native handler once
-      if (!this._didDisplayHandlerRegistered) {
-        this._didDisplayHandlerRegistered = true;
+      if (!this._hasRegisteredDidDisplayListener) {
+        this._hasRegisteredDidDisplayListener = true;
         const didDisplayCallBackProcessor = (event: InAppMessageDidDisplayEvent) => {
           this._processFunctionList(this._didDisplayInAppMessageListeners, event);
         };
@@ -98,10 +89,8 @@ export default class InAppMessages {
       this._willDismissInAppMessageListeners.push(
         listener as (event: InAppMessageWillDismissEvent) => void,
       );
-
-      // Only register the native handler once
-      if (!this._willDismissHandlerRegistered) {
-        this._willDismissHandlerRegistered = true;
+      if (!this._hasRegisteredWillDismissListener) {
+        this._hasRegisteredWillDismissListener = true;
         const willDismissInAppMessageProcessor = (event: InAppMessageWillDismissEvent) => {
           this._processFunctionList(this._willDismissInAppMessageListeners, event);
         };
@@ -117,10 +106,8 @@ export default class InAppMessages {
       this._didDismissInAppMessageListeners.push(
         listener as (event: InAppMessageDidDismissEvent) => void,
       );
-
-      // Only register the native handler once
-      if (!this._didDismissHandlerRegistered) {
-        this._didDismissHandlerRegistered = true;
+      if (!this._hasRegisteredDidDismissListener) {
+        this._hasRegisteredDidDismissListener = true;
         const didDismissInAppMessageCallBackProcessor = (event: InAppMessageDidDismissEvent) => {
           this._processFunctionList(this._didDismissInAppMessageListeners, event);
         };

--- a/www/InAppMessagesNamespace.ts
+++ b/www/InAppMessagesNamespace.ts
@@ -10,13 +10,33 @@ import type {
 } from './types/InAppMessage';
 
 export default class InAppMessages {
-  private _inAppMessageClickListeners: ((action: InAppMessageClickEvent) => void)[] = [];
-  private _willDisplayInAppMessageListeners: ((event: InAppMessageWillDisplayEvent) => void)[] = [];
-  private _didDisplayInAppMessageListeners: ((event: InAppMessageDidDisplayEvent) => void)[] = [];
-  private _willDismissInAppMessageListeners: ((event: InAppMessageWillDismissEvent) => void)[] = [];
-  private _didDismissInAppMessageListeners: ((event: InAppMessageDidDismissEvent) => void)[] = [];
+  private _inAppMessageClickListeners: ((
+    action: InAppMessageClickEvent,
+  ) => void)[] = [];
+  private _willDisplayInAppMessageListeners: ((
+    event: InAppMessageWillDisplayEvent,
+  ) => void)[] = [];
+  private _didDisplayInAppMessageListeners: ((
+    event: InAppMessageDidDisplayEvent,
+  ) => void)[] = [];
+  private _willDismissInAppMessageListeners: ((
+    event: InAppMessageWillDismissEvent,
+  ) => void)[] = [];
+  private _didDismissInAppMessageListeners: ((
+    event: InAppMessageDidDismissEvent,
+  ) => void)[] = [];
 
-  private _processFunctionList<T>(array: ((event: T) => void)[], param: T): void {
+  // Track whether native handlers have been registered to avoid duplicate registrations
+  private _clickHandlerRegistered = false;
+  private _willDisplayHandlerRegistered = false;
+  private _didDisplayHandlerRegistered = false;
+  private _willDismissHandlerRegistered = false;
+  private _didDismissHandlerRegistered = false;
+
+  private _processFunctionList<T>(
+    array: ((event: T) => void)[],
+    param: T,
+  ): void {
     for (let i = 0; i < array.length; i++) {
       array[i](param);
     }
@@ -33,73 +53,114 @@ export default class InAppMessages {
     listener: (event: InAppMessageEventTypeMap[K]) => void,
   ): void {
     if (event === 'click') {
-      this._inAppMessageClickListeners.push(listener as (event: InAppMessageClickEvent) => void);
-      const inAppMessageClickListener = (json: InAppMessageClickEvent) => {
-        this._processFunctionList(this._inAppMessageClickListeners, json);
-      };
-      window.cordova.exec(
-        inAppMessageClickListener,
-        noop,
-        'OneSignalPush',
-        'setInAppMessageClickHandler',
-        [],
+      this._inAppMessageClickListeners.push(
+        listener as (event: InAppMessageClickEvent) => void,
       );
+
+      // Only register the native handler once
+      if (!this._clickHandlerRegistered) {
+        this._clickHandlerRegistered = true;
+        const inAppMessageClickListener = (json: InAppMessageClickEvent) => {
+          this._processFunctionList(this._inAppMessageClickListeners, json);
+        };
+        window.cordova.exec(
+          inAppMessageClickListener,
+          noop,
+          'OneSignalPush',
+          'setInAppMessageClickHandler',
+          [],
+        );
+      }
     } else if (event === 'willDisplay') {
       this._willDisplayInAppMessageListeners.push(
         listener as (event: InAppMessageWillDisplayEvent) => void,
       );
-      const willDisplayCallBackProcessor = (event: InAppMessageWillDisplayEvent) => {
-        this._processFunctionList(this._willDisplayInAppMessageListeners, event);
-      };
-      window.cordova.exec(
-        willDisplayCallBackProcessor,
-        noop,
-        'OneSignalPush',
-        'setOnWillDisplayInAppMessageHandler',
-        [],
-      );
+
+      // Only register the native handler once
+      if (!this._willDisplayHandlerRegistered) {
+        this._willDisplayHandlerRegistered = true;
+        const willDisplayCallBackProcessor = (
+          event: InAppMessageWillDisplayEvent,
+        ) => {
+          this._processFunctionList(
+            this._willDisplayInAppMessageListeners,
+            event,
+          );
+        };
+        window.cordova.exec(
+          willDisplayCallBackProcessor,
+          noop,
+          'OneSignalPush',
+          'setOnWillDisplayInAppMessageHandler',
+          [],
+        );
+      }
     } else if (event === 'didDisplay') {
       this._didDisplayInAppMessageListeners.push(
         listener as (event: InAppMessageDidDisplayEvent) => void,
       );
-      const didDisplayCallBackProcessor = (event: InAppMessageDidDisplayEvent) => {
-        this._processFunctionList(this._didDisplayInAppMessageListeners, event);
-      };
-      window.cordova.exec(
-        didDisplayCallBackProcessor,
-        noop,
-        'OneSignalPush',
-        'setOnDidDisplayInAppMessageHandler',
-        [],
-      );
+
+      // Only register the native handler once
+      if (!this._didDisplayHandlerRegistered) {
+        this._didDisplayHandlerRegistered = true;
+        const didDisplayCallBackProcessor = (
+          event: InAppMessageDidDisplayEvent,
+        ) => {
+          this._processFunctionList(this._didDisplayInAppMessageListeners, event);
+        };
+        window.cordova.exec(
+          didDisplayCallBackProcessor,
+          noop,
+          'OneSignalPush',
+          'setOnDidDisplayInAppMessageHandler',
+          [],
+        );
+      }
     } else if (event === 'willDismiss') {
       this._willDismissInAppMessageListeners.push(
         listener as (event: InAppMessageWillDismissEvent) => void,
       );
-      const willDismissInAppMessageProcessor = (event: InAppMessageWillDismissEvent) => {
-        this._processFunctionList(this._willDismissInAppMessageListeners, event);
-      };
-      window.cordova.exec(
-        willDismissInAppMessageProcessor,
-        noop,
-        'OneSignalPush',
-        'setOnWillDismissInAppMessageHandler',
-        [],
-      );
+
+      // Only register the native handler once
+      if (!this._willDismissHandlerRegistered) {
+        this._willDismissHandlerRegistered = true;
+        const willDismissInAppMessageProcessor = (
+          event: InAppMessageWillDismissEvent,
+        ) => {
+          this._processFunctionList(
+            this._willDismissInAppMessageListeners,
+            event,
+          );
+        };
+        window.cordova.exec(
+          willDismissInAppMessageProcessor,
+          noop,
+          'OneSignalPush',
+          'setOnWillDismissInAppMessageHandler',
+          [],
+        );
+      }
     } else if (event === 'didDismiss') {
       this._didDismissInAppMessageListeners.push(
         listener as (event: InAppMessageDidDismissEvent) => void,
       );
-      const didDismissInAppMessageCallBackProcessor = (event: InAppMessageDidDismissEvent) => {
-        this._processFunctionList(this._didDismissInAppMessageListeners, event);
-      };
-      window.cordova.exec(
-        didDismissInAppMessageCallBackProcessor,
-        noop,
-        'OneSignalPush',
-        'setOnDidDismissInAppMessageHandler',
-        [],
-      );
+
+      // Only register the native handler once
+      if (!this._didDismissHandlerRegistered) {
+        this._didDismissHandlerRegistered = true;
+        const didDismissInAppMessageCallBackProcessor = (
+          event: InAppMessageDidDismissEvent,
+        ) => {
+          this._processFunctionList(this._didDismissInAppMessageListeners, event);
+        };
+        window.cordova.exec(
+          didDismissInAppMessageCallBackProcessor,
+          noop,
+          'OneSignalPush',
+          'setOnDidDismissInAppMessageHandler',
+          [],
+        );
+      }
     }
   }
 
@@ -170,7 +231,9 @@ export default class InAppMessages {
    */
   removeTriggers(keys: string[]): void {
     if (!Array.isArray(keys)) {
-      console.error('OneSignal: removeTriggers: argument must be of type Array');
+      console.error(
+        'OneSignal: removeTriggers: argument must be of type Array',
+      );
     }
 
     window.cordova.exec(noop, noop, 'OneSignalPush', 'removeTriggers', [keys]);

--- a/www/NotificationsNamespace.test.ts
+++ b/www/NotificationsNamespace.test.ts
@@ -243,13 +243,15 @@ describe('Notifications', () => {
         [],
       );
 
-      mockExec.mockClear();
+      // Capture the callback before adding second listener
+      const foregroundCallback = mockExec.mock.calls[0][0];
+
       const mockListener2 = vi.fn();
       notifications.addEventListener('foregroundWillDisplay', mockListener2);
 
       // can call display event listeners
       const notificationData = mockNotification();
-      mockExec.mock.calls[0][0](notificationData);
+      foregroundCallback(notificationData);
 
       const displayEvent = new NotificationWillDisplayEvent(notificationData);
       expect(mockListener).toHaveBeenCalledWith(displayEvent);
@@ -291,6 +293,56 @@ describe('Notifications', () => {
       notifications.addEventListener('unknown', mockListener);
 
       expect(window.cordova.exec).not.toHaveBeenCalled();
+    });
+
+    test('should only register native handler once for multiple click listeners', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+      const handler3 = vi.fn();
+
+      // Add first listener - should register native handler
+      notifications.addEventListener('click', handler1);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Add second listener - should NOT register native handler again
+      notifications.addEventListener('click', handler2);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Add third listener - should still be only one registration
+      notifications.addEventListener('click', handler3);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Trigger the event
+      const clickData = mockNotificationClickEvent();
+      mockExec.mock.calls[0][0](clickData);
+
+      // All handlers should execute exactly once
+      expect(handler1).toHaveBeenCalledTimes(1);
+      expect(handler1).toHaveBeenCalledWith(clickData);
+      expect(handler2).toHaveBeenCalledTimes(1);
+      expect(handler2).toHaveBeenCalledWith(clickData);
+      expect(handler3).toHaveBeenCalledTimes(1);
+      expect(handler3).toHaveBeenCalledWith(clickData);
+    });
+
+    test('should only register native handler once for multiple foregroundWillDisplay listeners', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+
+      notifications.addEventListener('foregroundWillDisplay', handler1);
+      notifications.addEventListener('foregroundWillDisplay', handler2);
+
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+    });
+
+    test('should only register native handler once for multiple permissionChange listeners', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+
+      notifications.addEventListener('permissionChange', handler1);
+      notifications.addEventListener('permissionChange', handler2);
+
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/www/NotificationsNamespace.test.ts
+++ b/www/NotificationsNamespace.test.ts
@@ -241,13 +241,15 @@ describe('Notifications', () => {
         [],
       );
 
-      mockExec.mockClear();
+      // Capture the callback before adding second listener
+      const foregroundCallback = mockExec.mock.calls[0][0];
+
       const mockListener2 = vi.fn();
       notifications.addEventListener('foregroundWillDisplay', mockListener2);
 
       // can call display event listeners
       const notificationData = mockNotification();
-      mockExec.mock.calls[0][0](notificationData);
+      foregroundCallback(notificationData);
 
       const displayEvent = new NotificationWillDisplayEvent(notificationData);
       expect(mockListener).toHaveBeenCalledWith(displayEvent);
@@ -289,6 +291,56 @@ describe('Notifications', () => {
       notifications.addEventListener('unknown', mockListener);
 
       expect(window.cordova.exec).not.toHaveBeenCalled();
+    });
+
+    test('should only register native handler once for multiple click listeners', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+      const handler3 = vi.fn();
+
+      // Add first listener - should register native handler
+      notifications.addEventListener('click', handler1);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Add second listener - should NOT register native handler again
+      notifications.addEventListener('click', handler2);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Add third listener - should still be only one registration
+      notifications.addEventListener('click', handler3);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Trigger the event
+      const clickData = mockNotificationClickEvent();
+      mockExec.mock.calls[0][0](clickData);
+
+      // All handlers should execute exactly once
+      expect(handler1).toHaveBeenCalledTimes(1);
+      expect(handler1).toHaveBeenCalledWith(clickData);
+      expect(handler2).toHaveBeenCalledTimes(1);
+      expect(handler2).toHaveBeenCalledWith(clickData);
+      expect(handler3).toHaveBeenCalledTimes(1);
+      expect(handler3).toHaveBeenCalledWith(clickData);
+    });
+
+    test('should only register native handler once for multiple foregroundWillDisplay listeners', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+
+      notifications.addEventListener('foregroundWillDisplay', handler1);
+      notifications.addEventListener('foregroundWillDisplay', handler2);
+
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+    });
+
+    test('should only register native handler once for multiple permissionChange listeners', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+
+      notifications.addEventListener('permissionChange', handler1);
+      notifications.addEventListener('permissionChange', handler2);
+
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/www/NotificationsNamespace.ts
+++ b/www/NotificationsNamespace.ts
@@ -19,11 +19,9 @@ export default class Notifications {
   private _permissionObserverList: ((event: boolean) => void)[] = [];
   private _notificationClickedListeners: ((event: NotificationClickEvent) => void)[] = [];
   private _notificationWillDisplayListeners: ((event: NotificationWillDisplayEvent) => void)[] = [];
-
-  // Track whether native handlers have been registered to avoid duplicate registrations
-  private _clickHandlerRegistered = false;
-  private _foregroundWillDisplayHandlerRegistered = false;
-  private _permissionChangeHandlerRegistered = false;
+  private _hasRegisteredClickListener = false;
+  private _hasRegisteredForegroundWillDisplayListener = false;
+  private _hasRegisteredPermissionListener = false;
 
   private _processFunctionList<T>(array: ((event: T) => void)[], param: T): void {
     for (let i = 0; i < array.length; i++) {
@@ -126,9 +124,8 @@ export default class Notifications {
 
   /**
    * Add listeners for notification events.
-   * @param event
-   * @param listener
-   * @returns
+   * Each native bridge channel is registered once per namespace instance;
+   * subsequent subscribers append to the local list to avoid orphaned handlers.
    */
   addEventListener<K extends NotificationEventName>(
     event: K,
@@ -136,10 +133,8 @@ export default class Notifications {
   ): void {
     if (event === 'click') {
       this._notificationClickedListeners.push(listener as (event: NotificationClickEvent) => void);
-
-      // Only register the native handler once
-      if (!this._clickHandlerRegistered) {
-        this._clickHandlerRegistered = true;
+      if (!this._hasRegisteredClickListener) {
+        this._hasRegisteredClickListener = true;
         const clickParsingHandler = (json: NotificationClickEvent) => {
           this._processFunctionList(this._notificationClickedListeners, json);
         };
@@ -155,10 +150,8 @@ export default class Notifications {
       this._notificationWillDisplayListeners.push(
         listener as (event: NotificationWillDisplayEvent) => void,
       );
-
-      // Only register the native handler once
-      if (!this._foregroundWillDisplayHandlerRegistered) {
-        this._foregroundWillDisplayHandlerRegistered = true;
+      if (!this._hasRegisteredForegroundWillDisplayListener) {
+        this._hasRegisteredForegroundWillDisplayListener = true;
         const foregroundParsingHandler = (notification: OSNotification) => {
           this._notificationWillDisplayListeners.forEach((listener) => {
             listener(new NotificationWillDisplayEvent(notification));
@@ -177,10 +170,8 @@ export default class Notifications {
       }
     } else if (event === 'permissionChange') {
       this._permissionObserverList.push(listener as (event: boolean) => void);
-
-      // Only register the native handler once
-      if (!this._permissionChangeHandlerRegistered) {
-        this._permissionChangeHandlerRegistered = true;
+      if (!this._hasRegisteredPermissionListener) {
+        this._hasRegisteredPermissionListener = true;
         const permissionCallBackProcessor = (state: boolean) => {
           this._processFunctionList(this._permissionObserverList, state);
         };

--- a/www/NotificationsNamespace.ts
+++ b/www/NotificationsNamespace.ts
@@ -17,22 +17,15 @@ export enum OSNotificationPermission {
 
 export default class Notifications {
   private _permissionObserverList: ((event: boolean) => void)[] = [];
-  private _notificationClickedListeners: ((
-    event: NotificationClickEvent,
-  ) => void)[] = [];
-  private _notificationWillDisplayListeners: ((
-    event: NotificationWillDisplayEvent,
-  ) => void)[] = [];
+  private _notificationClickedListeners: ((event: NotificationClickEvent) => void)[] = [];
+  private _notificationWillDisplayListeners: ((event: NotificationWillDisplayEvent) => void)[] = [];
 
   // Track whether native handlers have been registered to avoid duplicate registrations
   private _clickHandlerRegistered = false;
   private _foregroundWillDisplayHandlerRegistered = false;
   private _permissionChangeHandlerRegistered = false;
 
-  private _processFunctionList<T>(
-    array: ((event: T) => void)[],
-    param: T,
-  ): void {
+  private _processFunctionList<T>(array: ((event: T) => void)[], param: T): void {
     for (let i = 0; i < array.length; i++) {
       array[i](param);
     }
@@ -48,12 +41,7 @@ export default class Notifications {
     const getPermissionCallback = (granted: boolean) => {
       this._permission = granted;
     };
-    window.cordova.exec(
-      getPermissionCallback,
-      noop,
-      'OneSignalPush',
-      'getPermissionInternal',
-    );
+    window.cordova.exec(getPermissionCallback, noop, 'OneSignalPush', 'getPermissionInternal');
 
     this.addEventListener('permissionChange', (result) => {
       this._permission = result;
@@ -73,12 +61,7 @@ export default class Notifications {
    */
   getPermissionAsync(): Promise<boolean> {
     return new Promise<boolean>((resolve, reject) => {
-      window.cordova.exec(
-        resolve,
-        reject,
-        'OneSignalPush',
-        'getPermissionInternal',
-      );
+      window.cordova.exec(resolve, reject, 'OneSignalPush', 'getPermissionInternal');
     });
   }
 
@@ -95,13 +78,7 @@ export default class Notifications {
    * */
   permissionNative(): Promise<OSNotificationPermission> {
     return new Promise<OSNotificationPermission>((resolve, reject) => {
-      window.cordova.exec(
-        resolve,
-        reject,
-        'OneSignalPush',
-        'permissionNative',
-        [],
-      );
+      window.cordova.exec(resolve, reject, 'OneSignalPush', 'permissionNative', []);
     });
   }
 
@@ -117,13 +94,7 @@ export default class Notifications {
     let fallback = fallbackToSettings ?? false;
 
     return new Promise<boolean>((resolve, reject) => {
-      window.cordova.exec(
-        resolve,
-        reject,
-        'OneSignalPush',
-        'requestPermission',
-        [fallback],
-      );
+      window.cordova.exec(resolve, reject, 'OneSignalPush', 'requestPermission', [fallback]);
     });
   }
 
@@ -133,13 +104,7 @@ export default class Notifications {
    */
   canRequestPermission(): Promise<boolean> {
     return new Promise<boolean>((resolve, reject) => {
-      window.cordova.exec(
-        resolve,
-        reject,
-        'OneSignalPush',
-        'canRequestPermission',
-        [],
-      );
+      window.cordova.exec(resolve, reject, 'OneSignalPush', 'canRequestPermission', []);
     });
   }
 
@@ -155,16 +120,8 @@ export default class Notifications {
    * @param  {(response: boolean)=>void} handler
    * @returns void
    */
-  registerForProvisionalAuthorization(
-    handler: (response: boolean) => void = noop,
-  ): void {
-    window.cordova.exec(
-      handler,
-      noop,
-      'OneSignalPush',
-      'registerForProvisionalAuthorization',
-      [],
-    );
+  registerForProvisionalAuthorization(handler: (response: boolean) => void = noop): void {
+    window.cordova.exec(handler, noop, 'OneSignalPush', 'registerForProvisionalAuthorization', []);
   }
 
   /**
@@ -178,9 +135,7 @@ export default class Notifications {
     listener: (event: NotificationEventTypeMap[K]) => void,
   ): void {
     if (event === 'click') {
-      this._notificationClickedListeners.push(
-        listener as (event: NotificationClickEvent) => void,
-      );
+      this._notificationClickedListeners.push(listener as (event: NotificationClickEvent) => void);
 
       // Only register the native handler once
       if (!this._clickHandlerRegistered) {
@@ -208,13 +163,9 @@ export default class Notifications {
           this._notificationWillDisplayListeners.forEach((listener) => {
             listener(new NotificationWillDisplayEvent(notification));
           });
-          window.cordova.exec(
-            noop,
-            noop,
-            'OneSignalPush',
-            'proceedWithWillDisplay',
-            [notification.notificationId],
-          );
+          window.cordova.exec(noop, noop, 'OneSignalPush', 'proceedWithWillDisplay', [
+            notification.notificationId,
+          ]);
         };
         window.cordova.exec(
           foregroundParsingHandler,
@@ -265,10 +216,7 @@ export default class Notifications {
         listener as (event: NotificationWillDisplayEvent) => void,
       );
     } else if (event === 'permissionChange') {
-      removeListener(
-        this._permissionObserverList,
-        listener as (event: boolean) => void,
-      );
+      removeListener(this._permissionObserverList, listener as (event: boolean) => void);
     }
   }
 
@@ -277,13 +225,7 @@ export default class Notifications {
    * @returns void
    */
   clearAll(): void {
-    window.cordova.exec(
-      noop,
-      noop,
-      'OneSignalPush',
-      'clearAllNotifications',
-      [],
-    );
+    window.cordova.exec(noop, noop, 'OneSignalPush', 'clearAllNotifications', []);
   }
 
   /**
@@ -297,9 +239,7 @@ export default class Notifications {
    * @returns void
    */
   removeNotification(id: number): void {
-    window.cordova.exec(noop, noop, 'OneSignalPush', 'removeNotification', [
-      id,
-    ]);
+    window.cordova.exec(noop, noop, 'OneSignalPush', 'removeNotification', [id]);
   }
 
   /**
@@ -309,12 +249,6 @@ export default class Notifications {
    * @returns void
    */
   removeGroupedNotifications(id: string): void {
-    window.cordova.exec(
-      noop,
-      noop,
-      'OneSignalPush',
-      'removeGroupedNotifications',
-      [id],
-    );
+    window.cordova.exec(noop, noop, 'OneSignalPush', 'removeGroupedNotifications', [id]);
   }
 }

--- a/www/NotificationsNamespace.ts
+++ b/www/NotificationsNamespace.ts
@@ -17,10 +17,22 @@ export enum OSNotificationPermission {
 
 export default class Notifications {
   private _permissionObserverList: ((event: boolean) => void)[] = [];
-  private _notificationClickedListeners: ((event: NotificationClickEvent) => void)[] = [];
-  private _notificationWillDisplayListeners: ((event: NotificationWillDisplayEvent) => void)[] = [];
+  private _notificationClickedListeners: ((
+    event: NotificationClickEvent,
+  ) => void)[] = [];
+  private _notificationWillDisplayListeners: ((
+    event: NotificationWillDisplayEvent,
+  ) => void)[] = [];
 
-  private _processFunctionList<T>(array: ((event: T) => void)[], param: T): void {
+  // Track whether native handlers have been registered to avoid duplicate registrations
+  private _clickHandlerRegistered = false;
+  private _foregroundWillDisplayHandlerRegistered = false;
+  private _permissionChangeHandlerRegistered = false;
+
+  private _processFunctionList<T>(
+    array: ((event: T) => void)[],
+    param: T,
+  ): void {
     for (let i = 0; i < array.length; i++) {
       array[i](param);
     }
@@ -36,7 +48,12 @@ export default class Notifications {
     const getPermissionCallback = (granted: boolean) => {
       this._permission = granted;
     };
-    window.cordova.exec(getPermissionCallback, noop, 'OneSignalPush', 'getPermissionInternal');
+    window.cordova.exec(
+      getPermissionCallback,
+      noop,
+      'OneSignalPush',
+      'getPermissionInternal',
+    );
 
     this.addEventListener('permissionChange', (result) => {
       this._permission = result;
@@ -56,7 +73,12 @@ export default class Notifications {
    */
   getPermissionAsync(): Promise<boolean> {
     return new Promise<boolean>((resolve, reject) => {
-      window.cordova.exec(resolve, reject, 'OneSignalPush', 'getPermissionInternal');
+      window.cordova.exec(
+        resolve,
+        reject,
+        'OneSignalPush',
+        'getPermissionInternal',
+      );
     });
   }
 
@@ -73,7 +95,13 @@ export default class Notifications {
    * */
   permissionNative(): Promise<OSNotificationPermission> {
     return new Promise<OSNotificationPermission>((resolve, reject) => {
-      window.cordova.exec(resolve, reject, 'OneSignalPush', 'permissionNative', []);
+      window.cordova.exec(
+        resolve,
+        reject,
+        'OneSignalPush',
+        'permissionNative',
+        [],
+      );
     });
   }
 
@@ -89,7 +117,13 @@ export default class Notifications {
     let fallback = fallbackToSettings ?? false;
 
     return new Promise<boolean>((resolve, reject) => {
-      window.cordova.exec(resolve, reject, 'OneSignalPush', 'requestPermission', [fallback]);
+      window.cordova.exec(
+        resolve,
+        reject,
+        'OneSignalPush',
+        'requestPermission',
+        [fallback],
+      );
     });
   }
 
@@ -99,7 +133,13 @@ export default class Notifications {
    */
   canRequestPermission(): Promise<boolean> {
     return new Promise<boolean>((resolve, reject) => {
-      window.cordova.exec(resolve, reject, 'OneSignalPush', 'canRequestPermission', []);
+      window.cordova.exec(
+        resolve,
+        reject,
+        'OneSignalPush',
+        'canRequestPermission',
+        [],
+      );
     });
   }
 
@@ -115,8 +155,16 @@ export default class Notifications {
    * @param  {(response: boolean)=>void} handler
    * @returns void
    */
-  registerForProvisionalAuthorization(handler: (response: boolean) => void = noop): void {
-    window.cordova.exec(handler, noop, 'OneSignalPush', 'registerForProvisionalAuthorization', []);
+  registerForProvisionalAuthorization(
+    handler: (response: boolean) => void = noop,
+  ): void {
+    window.cordova.exec(
+      handler,
+      noop,
+      'OneSignalPush',
+      'registerForProvisionalAuthorization',
+      [],
+    );
   }
 
   /**
@@ -130,48 +178,69 @@ export default class Notifications {
     listener: (event: NotificationEventTypeMap[K]) => void,
   ): void {
     if (event === 'click') {
-      this._notificationClickedListeners.push(listener as (event: NotificationClickEvent) => void);
-      const clickParsingHandler = (json: NotificationClickEvent) => {
-        this._processFunctionList(this._notificationClickedListeners, json);
-      };
-      window.cordova.exec(
-        clickParsingHandler,
-        noop,
-        'OneSignalPush',
-        'addNotificationClickListener',
-        [],
+      this._notificationClickedListeners.push(
+        listener as (event: NotificationClickEvent) => void,
       );
+
+      // Only register the native handler once
+      if (!this._clickHandlerRegistered) {
+        this._clickHandlerRegistered = true;
+        const clickParsingHandler = (json: NotificationClickEvent) => {
+          this._processFunctionList(this._notificationClickedListeners, json);
+        };
+        window.cordova.exec(
+          clickParsingHandler,
+          noop,
+          'OneSignalPush',
+          'addNotificationClickListener',
+          [],
+        );
+      }
     } else if (event === 'foregroundWillDisplay') {
       this._notificationWillDisplayListeners.push(
         listener as (event: NotificationWillDisplayEvent) => void,
       );
-      const foregroundParsingHandler = (notification: OSNotification) => {
-        this._notificationWillDisplayListeners.forEach((listener) => {
-          listener(new NotificationWillDisplayEvent(notification));
-        });
-        window.cordova.exec(noop, noop, 'OneSignalPush', 'proceedWithWillDisplay', [
-          notification.notificationId,
-        ]);
-      };
-      window.cordova.exec(
-        foregroundParsingHandler,
-        noop,
-        'OneSignalPush',
-        'addForegroundLifecycleListener',
-        [],
-      );
+
+      // Only register the native handler once
+      if (!this._foregroundWillDisplayHandlerRegistered) {
+        this._foregroundWillDisplayHandlerRegistered = true;
+        const foregroundParsingHandler = (notification: OSNotification) => {
+          this._notificationWillDisplayListeners.forEach((listener) => {
+            listener(new NotificationWillDisplayEvent(notification));
+          });
+          window.cordova.exec(
+            noop,
+            noop,
+            'OneSignalPush',
+            'proceedWithWillDisplay',
+            [notification.notificationId],
+          );
+        };
+        window.cordova.exec(
+          foregroundParsingHandler,
+          noop,
+          'OneSignalPush',
+          'addForegroundLifecycleListener',
+          [],
+        );
+      }
     } else if (event === 'permissionChange') {
       this._permissionObserverList.push(listener as (event: boolean) => void);
-      const permissionCallBackProcessor = (state: boolean) => {
-        this._processFunctionList(this._permissionObserverList, state);
-      };
-      window.cordova.exec(
-        permissionCallBackProcessor,
-        noop,
-        'OneSignalPush',
-        'addPermissionObserver',
-        [],
-      );
+
+      // Only register the native handler once
+      if (!this._permissionChangeHandlerRegistered) {
+        this._permissionChangeHandlerRegistered = true;
+        const permissionCallBackProcessor = (state: boolean) => {
+          this._processFunctionList(this._permissionObserverList, state);
+        };
+        window.cordova.exec(
+          permissionCallBackProcessor,
+          noop,
+          'OneSignalPush',
+          'addPermissionObserver',
+          [],
+        );
+      }
     }
   }
 
@@ -196,7 +265,10 @@ export default class Notifications {
         listener as (event: NotificationWillDisplayEvent) => void,
       );
     } else if (event === 'permissionChange') {
-      removeListener(this._permissionObserverList, listener as (event: boolean) => void);
+      removeListener(
+        this._permissionObserverList,
+        listener as (event: boolean) => void,
+      );
     }
   }
 
@@ -205,7 +277,13 @@ export default class Notifications {
    * @returns void
    */
   clearAll(): void {
-    window.cordova.exec(noop, noop, 'OneSignalPush', 'clearAllNotifications', []);
+    window.cordova.exec(
+      noop,
+      noop,
+      'OneSignalPush',
+      'clearAllNotifications',
+      [],
+    );
   }
 
   /**
@@ -219,7 +297,9 @@ export default class Notifications {
    * @returns void
    */
   removeNotification(id: number): void {
-    window.cordova.exec(noop, noop, 'OneSignalPush', 'removeNotification', [id]);
+    window.cordova.exec(noop, noop, 'OneSignalPush', 'removeNotification', [
+      id,
+    ]);
   }
 
   /**
@@ -229,6 +309,12 @@ export default class Notifications {
    * @returns void
    */
   removeGroupedNotifications(id: string): void {
-    window.cordova.exec(noop, noop, 'OneSignalPush', 'removeGroupedNotifications', [id]);
+    window.cordova.exec(
+      noop,
+      noop,
+      'OneSignalPush',
+      'removeGroupedNotifications',
+      [id],
+    );
   }
 }

--- a/www/PushSubscriptionNamespace.test.ts
+++ b/www/PushSubscriptionNamespace.test.ts
@@ -245,6 +245,35 @@ describe('PushSubscription', () => {
       expect(mockListener).toHaveBeenCalledWith(SUB_CHANGED_STATE);
       expect(mockListener2).toHaveBeenCalledWith(SUB_CHANGED_STATE);
     });
+
+    test('should only register native handler once for multiple listeners', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+      const handler3 = vi.fn();
+
+      // Add first listener - should register native handler
+      pushSubscription.addEventListener('change', handler1);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Add second listener - should NOT register native handler again
+      pushSubscription.addEventListener('change', handler2);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Add third listener - should still be only one registration
+      pushSubscription.addEventListener('change', handler3);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Trigger the event
+      mockExec.mock.calls[0][0](SUB_CHANGED_STATE);
+
+      // All handlers should execute exactly once
+      expect(handler1).toHaveBeenCalledTimes(1);
+      expect(handler1).toHaveBeenCalledWith(SUB_CHANGED_STATE);
+      expect(handler2).toHaveBeenCalledTimes(1);
+      expect(handler2).toHaveBeenCalledWith(SUB_CHANGED_STATE);
+      expect(handler3).toHaveBeenCalledTimes(1);
+      expect(handler3).toHaveBeenCalledWith(SUB_CHANGED_STATE);
+    });
   });
 
   describe('removeEventListener', () => {

--- a/www/PushSubscriptionNamespace.test.ts
+++ b/www/PushSubscriptionNamespace.test.ts
@@ -232,6 +232,35 @@ describe('PushSubscription', () => {
       expect(mockListener).toHaveBeenCalledWith(SUB_CHANGED_STATE);
       expect(mockListener2).toHaveBeenCalledWith(SUB_CHANGED_STATE);
     });
+
+    test('should only register native handler once for multiple listeners', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+      const handler3 = vi.fn();
+
+      // Add first listener - should register native handler
+      pushSubscription.addEventListener('change', handler1);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Add second listener - should NOT register native handler again
+      pushSubscription.addEventListener('change', handler2);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Add third listener - should still be only one registration
+      pushSubscription.addEventListener('change', handler3);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Trigger the event
+      mockExec.mock.calls[0][0](SUB_CHANGED_STATE);
+
+      // All handlers should execute exactly once
+      expect(handler1).toHaveBeenCalledTimes(1);
+      expect(handler1).toHaveBeenCalledWith(SUB_CHANGED_STATE);
+      expect(handler2).toHaveBeenCalledTimes(1);
+      expect(handler2).toHaveBeenCalledWith(SUB_CHANGED_STATE);
+      expect(handler3).toHaveBeenCalledTimes(1);
+      expect(handler3).toHaveBeenCalledWith(SUB_CHANGED_STATE);
+    });
   });
 
   describe('removeEventListener', () => {

--- a/www/PushSubscriptionNamespace.ts
+++ b/www/PushSubscriptionNamespace.ts
@@ -21,6 +21,9 @@ export default class PushSubscription {
     event: PushSubscriptionChangedState,
   ) => void)[] = [];
 
+  // Track whether native handler has been registered to avoid duplicate registrations
+  private _changeHandlerRegistered = false;
+
   private _processFunctionList(
     array: ((event: PushSubscriptionChangedState) => void)[],
     param: PushSubscriptionChangedState,
@@ -175,18 +178,23 @@ export default class PushSubscription {
     this._subscriptionObserverList.push(
       listener as (event: PushSubscriptionChangedState) => void,
     );
-    const subscriptionCallBackProcessor = (
-      state: PushSubscriptionChangedState,
-    ) => {
-      this._processFunctionList(this._subscriptionObserverList, state);
-    };
-    window.cordova.exec(
-      subscriptionCallBackProcessor,
-      noop,
-      'OneSignalPush',
-      'addPushSubscriptionObserver',
-      [],
-    );
+
+    // Only register the native handler once
+    if (!this._changeHandlerRegistered) {
+      this._changeHandlerRegistered = true;
+      const subscriptionCallBackProcessor = (
+        state: PushSubscriptionChangedState,
+      ) => {
+        this._processFunctionList(this._subscriptionObserverList, state);
+      };
+      window.cordova.exec(
+        subscriptionCallBackProcessor,
+        noop,
+        'OneSignalPush',
+        'addPushSubscriptionObserver',
+        [],
+      );
+    }
   }
 
   /**

--- a/www/PushSubscriptionNamespace.ts
+++ b/www/PushSubscriptionNamespace.ts
@@ -17,9 +17,7 @@ export default class PushSubscription {
   private _token?: string | null;
   private _optedIn?: boolean;
 
-  private _subscriptionObserverList: ((
-    event: PushSubscriptionChangedState,
-  ) => void)[] = [];
+  private _subscriptionObserverList: ((event: PushSubscriptionChangedState) => void)[] = [];
 
   // Track whether native handler has been registered to avoid duplicate registrations
   private _changeHandlerRegistered = false;
@@ -45,12 +43,7 @@ export default class PushSubscription {
     const getIdCallback = (id: string) => {
       this._id = id;
     };
-    window.cordova.exec(
-      getIdCallback,
-      noop,
-      'OneSignalPush',
-      'getPushSubscriptionId',
-    );
+    window.cordova.exec(getIdCallback, noop, 'OneSignalPush', 'getPushSubscriptionId');
 
     /**
      * Receive token
@@ -59,12 +52,7 @@ export default class PushSubscription {
     const getTokenCallback = (token: string) => {
       this._token = token;
     };
-    window.cordova.exec(
-      getTokenCallback,
-      noop,
-      'OneSignalPush',
-      'getPushSubscriptionToken',
-    );
+    window.cordova.exec(getTokenCallback, noop, 'OneSignalPush', 'getPushSubscriptionToken');
 
     /**
      * Receive opted-in status
@@ -73,12 +61,7 @@ export default class PushSubscription {
     const getOptedInCallback = (granted: boolean) => {
       this._optedIn = granted;
     };
-    window.cordova.exec(
-      getOptedInCallback,
-      noop,
-      'OneSignalPush',
-      'getPushSubscriptionOptedIn',
-    );
+    window.cordova.exec(getOptedInCallback, noop, 'OneSignalPush', 'getPushSubscriptionOptedIn');
 
     this.addEventListener('change', (subscriptionChange) => {
       console.log('subscriptionChange', subscriptionChange);
@@ -124,12 +107,7 @@ export default class PushSubscription {
    */
   getIdAsync(): Promise<string | null> {
     return new Promise<string | null>((resolve, reject) => {
-      window.cordova.exec(
-        resolve,
-        reject,
-        'OneSignalPush',
-        'getPushSubscriptionId',
-      );
+      window.cordova.exec(resolve, reject, 'OneSignalPush', 'getPushSubscriptionId');
     });
   }
 
@@ -139,12 +117,7 @@ export default class PushSubscription {
    */
   getTokenAsync(): Promise<string | null> {
     return new Promise<string | null>((resolve, reject) => {
-      window.cordova.exec(
-        resolve,
-        reject,
-        'OneSignalPush',
-        'getPushSubscriptionToken',
-      );
+      window.cordova.exec(resolve, reject, 'OneSignalPush', 'getPushSubscriptionToken');
     });
   }
 
@@ -157,12 +130,7 @@ export default class PushSubscription {
    */
   getOptedInAsync(): Promise<boolean> {
     return new Promise<boolean>((resolve, reject) => {
-      window.cordova.exec(
-        resolve,
-        reject,
-        'OneSignalPush',
-        'getPushSubscriptionOptedIn',
-      );
+      window.cordova.exec(resolve, reject, 'OneSignalPush', 'getPushSubscriptionOptedIn');
     });
   }
 
@@ -171,20 +139,13 @@ export default class PushSubscription {
    * @param  {(event: PushSubscriptionChangedState)=>void} listener
    * @returns void
    */
-  addEventListener(
-    event: 'change',
-    listener: (event: PushSubscriptionChangedState) => void,
-  ) {
-    this._subscriptionObserverList.push(
-      listener as (event: PushSubscriptionChangedState) => void,
-    );
+  addEventListener(event: 'change', listener: (event: PushSubscriptionChangedState) => void) {
+    this._subscriptionObserverList.push(listener as (event: PushSubscriptionChangedState) => void);
 
     // Only register the native handler once
     if (!this._changeHandlerRegistered) {
       this._changeHandlerRegistered = true;
-      const subscriptionCallBackProcessor = (
-        state: PushSubscriptionChangedState,
-      ) => {
+      const subscriptionCallBackProcessor = (state: PushSubscriptionChangedState) => {
         this._processFunctionList(this._subscriptionObserverList, state);
       };
       window.cordova.exec(
@@ -202,10 +163,7 @@ export default class PushSubscription {
    * @param  {(event: PushSubscriptionChangedState)=>void} listener
    * @returns void
    */
-  removeEventListener(
-    event: 'change',
-    listener: (event: PushSubscriptionChangedState) => void,
-  ) {
+  removeEventListener(event: 'change', listener: (event: PushSubscriptionChangedState) => void) {
     removeListener(this._subscriptionObserverList, listener);
   }
 

--- a/www/PushSubscriptionNamespace.ts
+++ b/www/PushSubscriptionNamespace.ts
@@ -18,9 +18,7 @@ export default class PushSubscription {
   private _optedIn?: boolean;
 
   private _subscriptionObserverList: ((event: PushSubscriptionChangedState) => void)[] = [];
-
-  // Track whether native handler has been registered to avoid duplicate registrations
-  private _changeHandlerRegistered = false;
+  private _hasRegisteredChangeListener = false;
 
   private _processFunctionList(
     array: ((event: PushSubscriptionChangedState) => void)[],
@@ -64,7 +62,6 @@ export default class PushSubscription {
     window.cordova.exec(getOptedInCallback, noop, 'OneSignalPush', 'getPushSubscriptionOptedIn');
 
     this.addEventListener('change', (subscriptionChange) => {
-      console.log('subscriptionChange', subscriptionChange);
       this._id = subscriptionChange.current.id;
       this._token = subscriptionChange.current.token;
       this._optedIn = subscriptionChange.current.optedIn;
@@ -136,15 +133,13 @@ export default class PushSubscription {
 
   /**
    * Add a callback that fires when the OneSignal push subscription state changes.
-   * @param  {(event: PushSubscriptionChangedState)=>void} listener
-   * @returns void
+   * The native bridge subscription is registered once per namespace instance;
+   * subsequent subscribers append to the local list to avoid orphaned handlers.
    */
   addEventListener(event: 'change', listener: (event: PushSubscriptionChangedState) => void) {
     this._subscriptionObserverList.push(listener as (event: PushSubscriptionChangedState) => void);
-
-    // Only register the native handler once
-    if (!this._changeHandlerRegistered) {
-      this._changeHandlerRegistered = true;
+    if (!this._hasRegisteredChangeListener) {
+      this._hasRegisteredChangeListener = true;
       const subscriptionCallBackProcessor = (state: PushSubscriptionChangedState) => {
         this._processFunctionList(this._subscriptionObserverList, state);
       };

--- a/www/PushSubscriptionNamespace.ts
+++ b/www/PushSubscriptionNamespace.ts
@@ -17,7 +17,12 @@ export default class PushSubscription {
   private _token?: string | null;
   private _optedIn?: boolean;
 
-  private _subscriptionObserverList: ((event: PushSubscriptionChangedState) => void)[] = [];
+  private _subscriptionObserverList: ((
+    event: PushSubscriptionChangedState,
+  ) => void)[] = [];
+
+  // Track whether native handler has been registered to avoid duplicate registrations
+  private _changeHandlerRegistered = false;
 
   private _processFunctionList(
     array: ((event: PushSubscriptionChangedState) => void)[],
@@ -40,7 +45,12 @@ export default class PushSubscription {
     const getIdCallback = (id: string) => {
       this._id = id;
     };
-    window.cordova.exec(getIdCallback, noop, 'OneSignalPush', 'getPushSubscriptionId');
+    window.cordova.exec(
+      getIdCallback,
+      noop,
+      'OneSignalPush',
+      'getPushSubscriptionId',
+    );
 
     /**
      * Receive token
@@ -49,7 +59,12 @@ export default class PushSubscription {
     const getTokenCallback = (token: string) => {
       this._token = token;
     };
-    window.cordova.exec(getTokenCallback, noop, 'OneSignalPush', 'getPushSubscriptionToken');
+    window.cordova.exec(
+      getTokenCallback,
+      noop,
+      'OneSignalPush',
+      'getPushSubscriptionToken',
+    );
 
     /**
      * Receive opted-in status
@@ -58,9 +73,15 @@ export default class PushSubscription {
     const getOptedInCallback = (granted: boolean) => {
       this._optedIn = granted;
     };
-    window.cordova.exec(getOptedInCallback, noop, 'OneSignalPush', 'getPushSubscriptionOptedIn');
+    window.cordova.exec(
+      getOptedInCallback,
+      noop,
+      'OneSignalPush',
+      'getPushSubscriptionOptedIn',
+    );
 
     this.addEventListener('change', (subscriptionChange) => {
+      console.log('subscriptionChange', subscriptionChange);
       this._id = subscriptionChange.current.id;
       this._token = subscriptionChange.current.token;
       this._optedIn = subscriptionChange.current.optedIn;
@@ -103,7 +124,12 @@ export default class PushSubscription {
    */
   getIdAsync(): Promise<string | null> {
     return new Promise<string | null>((resolve, reject) => {
-      window.cordova.exec(resolve, reject, 'OneSignalPush', 'getPushSubscriptionId');
+      window.cordova.exec(
+        resolve,
+        reject,
+        'OneSignalPush',
+        'getPushSubscriptionId',
+      );
     });
   }
 
@@ -113,7 +139,12 @@ export default class PushSubscription {
    */
   getTokenAsync(): Promise<string | null> {
     return new Promise<string | null>((resolve, reject) => {
-      window.cordova.exec(resolve, reject, 'OneSignalPush', 'getPushSubscriptionToken');
+      window.cordova.exec(
+        resolve,
+        reject,
+        'OneSignalPush',
+        'getPushSubscriptionToken',
+      );
     });
   }
 
@@ -126,7 +157,12 @@ export default class PushSubscription {
    */
   getOptedInAsync(): Promise<boolean> {
     return new Promise<boolean>((resolve, reject) => {
-      window.cordova.exec(resolve, reject, 'OneSignalPush', 'getPushSubscriptionOptedIn');
+      window.cordova.exec(
+        resolve,
+        reject,
+        'OneSignalPush',
+        'getPushSubscriptionOptedIn',
+      );
     });
   }
 
@@ -135,18 +171,30 @@ export default class PushSubscription {
    * @param  {(event: PushSubscriptionChangedState)=>void} listener
    * @returns void
    */
-  addEventListener(event: 'change', listener: (event: PushSubscriptionChangedState) => void) {
-    this._subscriptionObserverList.push(listener as (event: PushSubscriptionChangedState) => void);
-    const subscriptionCallBackProcessor = (state: PushSubscriptionChangedState) => {
-      this._processFunctionList(this._subscriptionObserverList, state);
-    };
-    window.cordova.exec(
-      subscriptionCallBackProcessor,
-      noop,
-      'OneSignalPush',
-      'addPushSubscriptionObserver',
-      [],
+  addEventListener(
+    event: 'change',
+    listener: (event: PushSubscriptionChangedState) => void,
+  ) {
+    this._subscriptionObserverList.push(
+      listener as (event: PushSubscriptionChangedState) => void,
     );
+
+    // Only register the native handler once
+    if (!this._changeHandlerRegistered) {
+      this._changeHandlerRegistered = true;
+      const subscriptionCallBackProcessor = (
+        state: PushSubscriptionChangedState,
+      ) => {
+        this._processFunctionList(this._subscriptionObserverList, state);
+      };
+      window.cordova.exec(
+        subscriptionCallBackProcessor,
+        noop,
+        'OneSignalPush',
+        'addPushSubscriptionObserver',
+        [],
+      );
+    }
   }
 
   /**
@@ -154,7 +202,10 @@ export default class PushSubscription {
    * @param  {(event: PushSubscriptionChangedState)=>void} listener
    * @returns void
    */
-  removeEventListener(event: 'change', listener: (event: PushSubscriptionChangedState) => void) {
+  removeEventListener(
+    event: 'change',
+    listener: (event: PushSubscriptionChangedState) => void,
+  ) {
     removeListener(this._subscriptionObserverList, listener);
   }
 

--- a/www/UserNamespace.test.ts
+++ b/www/UserNamespace.test.ts
@@ -349,6 +349,35 @@ describe('User', () => {
       expect(mockListener2).toHaveBeenCalledWith(USER_CHANGED_STATE);
       expect(mockListener3).toHaveBeenCalledWith(USER_CHANGED_STATE);
     });
+
+    test('should only register native handler once for multiple listeners', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+      const handler3 = vi.fn();
+
+      // Add first listener - should register native handler
+      user.addEventListener('change', handler1);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Add second listener - should NOT register native handler again
+      user.addEventListener('change', handler2);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Add third listener - should still be only one registration
+      user.addEventListener('change', handler3);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Trigger the event
+      mockExec.mock.calls[0][0](USER_CHANGED_STATE);
+
+      // All handlers should execute exactly once
+      expect(handler1).toHaveBeenCalledTimes(1);
+      expect(handler1).toHaveBeenCalledWith(USER_CHANGED_STATE);
+      expect(handler2).toHaveBeenCalledTimes(1);
+      expect(handler2).toHaveBeenCalledWith(USER_CHANGED_STATE);
+      expect(handler3).toHaveBeenCalledTimes(1);
+      expect(handler3).toHaveBeenCalledWith(USER_CHANGED_STATE);
+    });
   });
 
   describe('removeEventListener', () => {

--- a/www/UserNamespace.test.ts
+++ b/www/UserNamespace.test.ts
@@ -351,6 +351,35 @@ describe('User', () => {
       expect(mockListener2).toHaveBeenCalledWith(USER_CHANGED_STATE);
       expect(mockListener3).toHaveBeenCalledWith(USER_CHANGED_STATE);
     });
+
+    test('should only register native handler once for multiple listeners', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+      const handler3 = vi.fn();
+
+      // Add first listener - should register native handler
+      user.addEventListener('change', handler1);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Add second listener - should NOT register native handler again
+      user.addEventListener('change', handler2);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Add third listener - should still be only one registration
+      user.addEventListener('change', handler3);
+      expect(window.cordova.exec).toHaveBeenCalledTimes(1);
+
+      // Trigger the event
+      mockExec.mock.calls[0][0](USER_CHANGED_STATE);
+
+      // All handlers should execute exactly once
+      expect(handler1).toHaveBeenCalledTimes(1);
+      expect(handler1).toHaveBeenCalledWith(USER_CHANGED_STATE);
+      expect(handler2).toHaveBeenCalledTimes(1);
+      expect(handler2).toHaveBeenCalledWith(USER_CHANGED_STATE);
+      expect(handler3).toHaveBeenCalledTimes(1);
+      expect(handler3).toHaveBeenCalledWith(USER_CHANGED_STATE);
+    });
   });
 
   describe('removeEventListener', () => {

--- a/www/UserNamespace.ts
+++ b/www/UserNamespace.ts
@@ -50,9 +50,7 @@ export default class User {
    */
   addAlias(label: string, id: string): void {
     const jsonKeyValue = { [label]: id };
-    window.cordova.exec(noop, noop, 'OneSignalPush', 'addAliases', [
-      jsonKeyValue,
-    ]);
+    window.cordova.exec(noop, noop, 'OneSignalPush', 'addAliases', [jsonKeyValue]);
   }
 
   /**
@@ -154,9 +152,7 @@ export default class User {
         convertedTags[key] = JSON.stringify(convertedTags[key]);
       }
     });
-    window.cordova.exec(noop, noop, 'OneSignalPush', 'addTags', [
-      convertedTags,
-    ]);
+    window.cordova.exec(noop, noop, 'OneSignalPush', 'addTags', [convertedTags]);
   }
 
   /**
@@ -192,13 +188,8 @@ export default class User {
    * @param  {(event: UserChangedState)=>void} listener
    * @returns void
    */
-  addEventListener(
-    event: 'change',
-    listener: (event: UserChangedState) => void,
-  ) {
-    this._userStateObserverList.push(
-      listener as (event: UserChangedState) => void,
-    );
+  addEventListener(event: 'change', listener: (event: UserChangedState) => void) {
+    this._userStateObserverList.push(listener as (event: UserChangedState) => void);
 
     // Only register the native handler once
     if (!this._changeHandlerRegistered) {
@@ -206,13 +197,7 @@ export default class User {
       const userCallBackProcessor = (state: UserChangedState) => {
         this._processFunctionList(this._userStateObserverList, state);
       };
-      window.cordova.exec(
-        userCallBackProcessor,
-        noop,
-        'OneSignalPush',
-        'addUserStateObserver',
-        [],
-      );
+      window.cordova.exec(userCallBackProcessor, noop, 'OneSignalPush', 'addUserStateObserver', []);
     }
   }
 
@@ -221,10 +206,7 @@ export default class User {
    * @param  {(event: UserChangedState)=>void} listener
    * @returns void
    */
-  removeEventListener(
-    event: 'change',
-    listener: (event: UserChangedState) => void,
-  ) {
+  removeEventListener(event: 'change', listener: (event: UserChangedState) => void) {
     removeListener(this._userStateObserverList, listener);
   }
 
@@ -234,13 +216,7 @@ export default class User {
    */
   getOnesignalId(): Promise<string | null> {
     return new Promise<string | null>((resolve, reject) => {
-      window.cordova.exec(
-        resolve,
-        reject,
-        'OneSignalPush',
-        'getOnesignalId',
-        [],
-      );
+      window.cordova.exec(resolve, reject, 'OneSignalPush', 'getOnesignalId', []);
     });
   }
 
@@ -250,13 +226,7 @@ export default class User {
    */
   getExternalId(): Promise<string | null> {
     return new Promise<string | null>((resolve, reject) => {
-      window.cordova.exec(
-        resolve,
-        reject,
-        'OneSignalPush',
-        'getExternalId',
-        [],
-      );
+      window.cordova.exec(resolve, reject, 'OneSignalPush', 'getExternalId', []);
     });
   }
 

--- a/www/UserNamespace.ts
+++ b/www/UserNamespace.ts
@@ -17,6 +17,9 @@ export default class User {
 
   private _userStateObserverList: ((event: UserChangedState) => void)[] = [];
 
+  // Track whether native handler has been registered to avoid duplicate registrations
+  private _changeHandlerRegistered = false;
+
   private _processFunctionList(
     array: ((event: UserChangedState) => void)[],
     param: UserChangedState,
@@ -47,7 +50,9 @@ export default class User {
    */
   addAlias(label: string, id: string): void {
     const jsonKeyValue = { [label]: id };
-    window.cordova.exec(noop, noop, 'OneSignalPush', 'addAliases', [jsonKeyValue]);
+    window.cordova.exec(noop, noop, 'OneSignalPush', 'addAliases', [
+      jsonKeyValue,
+    ]);
   }
 
   /**
@@ -149,7 +154,9 @@ export default class User {
         convertedTags[key] = JSON.stringify(convertedTags[key]);
       }
     });
-    window.cordova.exec(noop, noop, 'OneSignalPush', 'addTags', [convertedTags]);
+    window.cordova.exec(noop, noop, 'OneSignalPush', 'addTags', [
+      convertedTags,
+    ]);
   }
 
   /**
@@ -185,12 +192,28 @@ export default class User {
    * @param  {(event: UserChangedState)=>void} listener
    * @returns void
    */
-  addEventListener(event: 'change', listener: (event: UserChangedState) => void) {
-    this._userStateObserverList.push(listener as (event: UserChangedState) => void);
-    const userCallBackProcessor = (state: UserChangedState) => {
-      this._processFunctionList(this._userStateObserverList, state);
-    };
-    window.cordova.exec(userCallBackProcessor, noop, 'OneSignalPush', 'addUserStateObserver', []);
+  addEventListener(
+    event: 'change',
+    listener: (event: UserChangedState) => void,
+  ) {
+    this._userStateObserverList.push(
+      listener as (event: UserChangedState) => void,
+    );
+
+    // Only register the native handler once
+    if (!this._changeHandlerRegistered) {
+      this._changeHandlerRegistered = true;
+      const userCallBackProcessor = (state: UserChangedState) => {
+        this._processFunctionList(this._userStateObserverList, state);
+      };
+      window.cordova.exec(
+        userCallBackProcessor,
+        noop,
+        'OneSignalPush',
+        'addUserStateObserver',
+        [],
+      );
+    }
   }
 
   /**
@@ -198,7 +221,10 @@ export default class User {
    * @param  {(event: UserChangedState)=>void} listener
    * @returns void
    */
-  removeEventListener(event: 'change', listener: (event: UserChangedState) => void) {
+  removeEventListener(
+    event: 'change',
+    listener: (event: UserChangedState) => void,
+  ) {
     removeListener(this._userStateObserverList, listener);
   }
 
@@ -208,7 +234,13 @@ export default class User {
    */
   getOnesignalId(): Promise<string | null> {
     return new Promise<string | null>((resolve, reject) => {
-      window.cordova.exec(resolve, reject, 'OneSignalPush', 'getOnesignalId', []);
+      window.cordova.exec(
+        resolve,
+        reject,
+        'OneSignalPush',
+        'getOnesignalId',
+        [],
+      );
     });
   }
 
@@ -218,7 +250,13 @@ export default class User {
    */
   getExternalId(): Promise<string | null> {
     return new Promise<string | null>((resolve, reject) => {
-      window.cordova.exec(resolve, reject, 'OneSignalPush', 'getExternalId', []);
+      window.cordova.exec(
+        resolve,
+        reject,
+        'OneSignalPush',
+        'getExternalId',
+        [],
+      );
     });
   }
 

--- a/www/UserNamespace.ts
+++ b/www/UserNamespace.ts
@@ -16,9 +16,7 @@ export default class User {
   pushSubscription: PushSubscription = new PushSubscription();
 
   private _userStateObserverList: ((event: UserChangedState) => void)[] = [];
-
-  // Track whether native handler has been registered to avoid duplicate registrations
-  private _changeHandlerRegistered = false;
+  private _hasRegisteredChangeListener = false;
 
   private _processFunctionList(
     array: ((event: UserChangedState) => void)[],
@@ -184,16 +182,13 @@ export default class User {
 
   /**
    * Add a callback that fires when the OneSignal User state changes.
-   * Important: When using the observer to retrieve the onesignalId, check the externalId as well to confirm the values are associated with the expected user.
-   * @param  {(event: UserChangedState)=>void} listener
-   * @returns void
+   * The native bridge subscription is registered once per namespace instance;
+   * subsequent subscribers append to the local list to avoid orphaned handlers.
    */
   addEventListener(event: 'change', listener: (event: UserChangedState) => void) {
     this._userStateObserverList.push(listener as (event: UserChangedState) => void);
-
-    // Only register the native handler once
-    if (!this._changeHandlerRegistered) {
-      this._changeHandlerRegistered = true;
+    if (!this._hasRegisteredChangeListener) {
+      this._hasRegisteredChangeListener = true;
       const userCallBackProcessor = (state: UserChangedState) => {
         this._processFunctionList(this._userStateObserverList, state);
       };


### PR DESCRIPTION
# Description
## One Line Summary
Added flags to ensure `addEventListener()` only registers each native handler once per event type, eliminating unnecessary `cordova.exec` calls.

## Details

### Motivation
I noticed that we may be creating too many native handlers, once per each invocation of `addEventListener()`. This could cause a potential memory leak in the consuming applications.

### Scope
Any `addEventListener` function across the `InAppMessages`, `Notifications`, `User`, and `PushSubscription` namespaces.

# Testing
## Unit testing
One tested added that ensures that `cordova.exec` is only called once, no matter how many event listeners are added.

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [x] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/1085)
<!-- Reviewable:end -->
