### PR TITLE
fix: update rawpayload type to an object

### DIFF
--- a/www/OSNotification.ts
+++ b/www/OSNotification.ts
@@ -9,7 +9,7 @@ export class OSNotification {
   sound?: string;
   title?: string;
   launchURL?: string;
-  rawPayload: string;
+  rawPayload: object;
   actionButtons?: object[];
   additionalData: object;
   notificationId: string;
@@ -60,7 +60,6 @@ export class OSNotification {
     if (typeof receivedEvent.rawPayload === 'string') {
       this.rawPayload = JSON.parse(receivedEvent.rawPayload);
     } else {
-      // @ts-expect-error - rawPayload is an object but will update typings in the future
       this.rawPayload = receivedEvent.rawPayload;
     }
 


### PR DESCRIPTION
# Description
## One Line Summary
- updates OSNotification rawPayload to an object

## Details
- In the constructor of OSNotification the rawPayload will either JSON.parse the recieved event payload (string) or takes the value of the the payload if its an object. So the type of OSNotification should be an object

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/1086)
<!-- Reviewable:end -->
