### PR TITLE
ci: use shared workflows for create release workflow

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -17,7 +17,7 @@ on:
         required: false
         type: string
 
-  # For making a release pr from cordova github actions
+  #For making a release pr from cordova github actions.
   workflow_dispatch:
     inputs:
       cordova_version:
@@ -39,9 +39,15 @@ jobs:
     with:
       version: ${{ inputs.cordova_version }}
 
+  # Cordova specific steps
   update-version:
     needs: prep
     runs-on: macos-latest
+    outputs:
+      cordova_from: ${{ steps.current_versions.outputs.cordova_from }}
+      android_from: ${{ steps.current_versions.outputs.android_from }}
+      ios_from: ${{ steps.current_versions.outputs.ios_from }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -59,16 +65,19 @@ jobs:
       - name: Get current native SDK versions
         id: current_versions
         run: |
+          # Current cordova version
+          CURRENT_VERSION=$(jq -r .version package.json)
+
           # Extract current Android SDK version
           ANDROID_VERSION=$(sed -n 's/.*com\.onesignal:OneSignal:\([0-9.]*\).*/\1/p' plugin.xml | head -1)
 
           # Extract current iOS SDK version
           IOS_VERSION=$(sed -n 's/.*OneSignalXCFramework.*spec="\([0-9.]*\)".*/\1/p' plugin.xml | head -1)
 
+          echo "cordova_from=$CURRENT_VERSION" >> $GITHUB_OUTPUT
           echo "android_from=$ANDROID_VERSION" >> $GITHUB_OUTPUT
           echo "ios_from=$IOS_VERSION" >> $GITHUB_OUTPUT
 
-      # Cordova specific steps
       - name: Setup Capacitor
         run: |
           bun link
@@ -154,101 +163,14 @@ jobs:
           git commit -m "Release $NEW_VERSION"
           git push
 
-      - name: Document native sdk changes
-        id: native_deps
-        run: |
-          # Get the current plugin.xml
-          CURRENT_PLUGIN=$(cat plugin.xml)
-
-          # Extract current Android SDK version
-          ANDROID_VERSION=$(sed -n 's/.*com\.onesignal:OneSignal:\([0-9.]*\).*/\1/p' <<< "$CURRENT_PLUGIN" | head -1)
-          PREVIOUS_ANDROID="${{ steps.current_versions.outputs.prev_android }}"
-
-          # Extract current iOS SDK version
-          IOS_VERSION=$(sed -n 's/.*OneSignalXCFramework.*spec="\([0-9.]*\)".*/\1/p' <<< "$CURRENT_PLUGIN" | head -1)
-          PREVIOUS_IOS="${{ steps.current_versions.outputs.prev_ios }}"
-
-          # Build output for native dependency changes
-          NATIVE_UPDATES=""
-          if [[ "$ANDROID_VERSION" != "$PREVIOUS_ANDROID" && ! -z "$PREVIOUS_ANDROID" ]]; then
-            printf -v NATIVE_UPDATES '%sANDROID_UPDATE=true\nANDROID_FROM=%s\nANDROID_TO=%s\n' "$NATIVE_UPDATES" "$PREVIOUS_ANDROID" "$ANDROID_VERSION"
-          fi
-
-          if [[ "$IOS_VERSION" != "$PREVIOUS_IOS" && ! -z "$PREVIOUS_IOS" ]]; then
-            printf -v NATIVE_UPDATES '%sIOS_UPDATE=true\nIOS_FROM=%s\nIOS_TO=%s\n' "$NATIVE_UPDATES" "$PREVIOUS_IOS" "$IOS_VERSION"
-          fi
-
-          # Output the variables
-          echo "$NATIVE_UPDATES" >> $GITHUB_OUTPUT
-
-      - name: Generate release notes
-        id: release_notes
-        uses: actions/github-script@v8
-        with:
-          script: |
-            // Trim whitespace from PR titles
-            const prs = JSON.parse('${{ steps.get_prs.outputs.prs }}').map(pr => ({
-              ...pr,
-              title: pr.title.trim()
-            }));
-
-            // Categorize PRs (exclude internal changes like ci/chore)
-            const features = prs.filter(pr => /^feat/i.test(pr.title));
-            const fixes = prs.filter(pr => /^fix/i.test(pr.title));
-            const improvements = prs.filter(pr => /^(perf|refactor)/i.test(pr.title));
-
-            // Helper function to build section
-            const buildSection = (title, prs) => {
-              if (prs.length === 0) return '';
-              let section = `### ${title}\n\n`;
-              prs.forEach(pr => {
-                section += `- ${pr.title} (#${pr.number})\n`;
-              });
-              return section + '\n';
-            };
-
-            let releaseNotes = `Channels: ${{ steps.release_type.outputs.release-type }}\n\n`;
-            releaseNotes += buildSection('🚀 New Features', features);
-            releaseNotes += buildSection('🐛 Bug Fixes', fixes);
-            releaseNotes += buildSection('✨ Improvements', improvements);
-
-            // Check for native dependency changes
-            const hasAndroidUpdate = '${{ steps.native_deps.outputs.ANDROID_UPDATE }}' === 'true';
-            const hasIosUpdate = '${{ steps.native_deps.outputs.IOS_UPDATE }}' === 'true';
-
-            if (hasAndroidUpdate || hasIosUpdate) {
-              releaseNotes += '\n### 🛠️ Native Dependency Updates\n\n';
-              if (hasAndroidUpdate) {
-                releaseNotes += `- Update Android SDK from ${{ steps.native_deps.outputs.ANDROID_FROM }} to ${{ steps.native_deps.outputs.ANDROID_TO }}\n`;
-                releaseNotes += `  - See [release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases) for full details\n`;
-              }
-              if (hasIosUpdate) {
-                releaseNotes += `- Update iOS SDK from ${{ steps.native_deps.outputs.IOS_FROM }} to ${{ steps.native_deps.outputs.IOS_TO }}\n`;
-                releaseNotes += `  - See [release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases) for full details\n`;
-              }
-              releaseNotes += '\n';
-            }
-
-            core.setOutput('notes', releaseNotes);
-
-      - name: Create release PR
-        run: |
-          NEW_VERSION="${{ inputs.cordova_version }}"
-          RELEASE_TYPE="${{ steps.release_type.outputs.release-type }}"
-
-          # Determine base branch based on release type
-          if [[ "$RELEASE_TYPE" == "Current" ]]; then
-            BASE_BRANCH="main"
-          else
-            BASE_BRANCH="${{ steps.release_branch.outputs.releaseBranch }}"
-          fi
-
-          # Write release notes to file to avoid shell interpretation
-          cat > release_notes.md << 'EOF'
-          ${{ steps.release_notes.outputs.notes }}
-          EOF
-
-          gh pr create \
-            --title "chore: Release $NEW_VERSION" \
-            --body-file release_notes.md \
-            --base "$BASE_BRANCH"
+  create-pr:
+    needs: [prep, update-version]
+    uses: OneSignal/sdk-actions/.github/workflows/create-release.yml@main
+    with:
+      release_branch: ${{ needs.prep.outputs.release_branch }}
+      version_from: ${{ needs.update-version.outputs.cordova_from }}
+      version_to: ${{ inputs.cordova_version }}
+      android_from: ${{ needs.update-version.outputs.android_from }}
+      android_to: ${{ inputs.android_version }}
+      ios_from: ${{ needs.update-version.outputs.ios_from }}
+      ios_to: ${{ inputs.ios_version }}


### PR DESCRIPTION
# Description
## One Line Summary
- use shared sdk-actions workflow to clean up create-release-pr workflow

## Details
- use shared action prep-release to handle creation of release-pr
- use shared aciton create-release to handle getting release changes/notes and create the release pr

### Motivation
- want to re-use as much of shared actions as we can for all the wrapper sdks

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/1103)
<!-- Reviewable:end -->
