### PR TITLE
chore: Release 5.2.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.2.19",
+  "version": "5.2.20",
   "name": "onesignal-cordova-plugin",
   "author": "Josh Kasten, Brad Hesse, Rodrigo Gomez-Palacio",
   "files": [

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="5.2.19">
+    version="5.2.20">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -369,7 +369,7 @@ public class OneSignalPush extends CordovaPlugin
 
         initDone = true;
         OneSignalWrapper.setSdkType("cordova");
-        OneSignalWrapper.setSdkVersion("050219");
+        OneSignalWrapper.setSdkVersion("050220");
         try {
             String appId = data.getString(0);
             OneSignal.initWithContext(this.cordova.getActivity(), appId);

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -119,7 +119,7 @@ void processNotificationClicked(OSNotificationClickEvent *event) {
 
 void initOneSignalObject(NSDictionary *launchOptions) {
   OneSignalWrapper.sdkType = @"cordova";
-  OneSignalWrapper.sdkVersion = @"050219";
+  OneSignalWrapper.sdkVersion = @"050220";
   [OneSignal initialize:nil withLaunchOptions:launchOptions];
 }
 


### PR DESCRIPTION
Channels: Current


### 🛠️ Native Dependency Updates

- Update Android SDK from 5.1.38 to 5.4.0
  - 5.2.x - Identity Verification (JWT) - Feature is still in beta
  - 5.3.x - Custom Outcomes - Feature is still in beta
  - improvement: Offloaded work on background threads. ([#2394](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2394))
  - improvement: Using a OneSignal Threadpool to execute all OneSignal related operations
  - improvement: Added newer suspend methods that could be used in ViewModels to init the SDK, login and logout
  - improvement: Improved code quality around PermissionsActivity.
  - Feat: Detect for timezone changes and update the user ([#2378](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2378))
  - add: security hardening around webview javaScriptEnabled ([#2377](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2377))
  - Fix: ANR on POST to Outcomes endpoint ([#2371](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2371))
  - ANR GmsLocationController timing out ([#2396]https://github.com/OneSignal/OneSignal-Android-SDK/issues/2396)
  - ANR https://github.com/OneSignal/OneSignal-Android-SDK/issues/2335
  - ANR https://github.com/OneSignal/OneSignal-Android-SDK/issues/2266
  - ANR https://github.com/OneSignal/OneSignal-Android-SDK/issues/2397
  - ANR https://github.com/OneSignal/OneSignal-Android-SDK/issues/2399
  - ANR https://github.com/OneSignal/OneSignal-Android-SDK/issues/2400
  - Crash/ANR https://github.com/OneSignal/OneSignal-Android-SDK/issues/2192
  - - -
  - Feat: Detect for timezone changes and update the user ([#2378](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2378))
  - Fix: ANR on POST to Outcomes endpoint ([#2371](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2371))
  - add: security hardening around webview javaScriptEnabled ([#2377](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2377))
  - - -
  - feat: Add Kotlin MainApplication and suspend initialization support ([#2374](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2374))
  - - -
  - **Non-blocking initialization**
  - OneSignal.initWithContext has been refactored so heavy disk and network work are moved off the main thread. ANRs related to initialization should now be effectively eliminated when the SDK is used in the recommended way (see Notes below).
  - **Performance Improvements**
  - In our testing, the time spent on the main thread during initialization dropped by ~80% (e.g., from ~47–49 ms down to ~8 ms on a cold start in debug builds).
  - If your app calls OneSignal accessors (ex. OneSignal.User.oneSignalID) immediately after initWithContext, we recommend moving all OneSignal accessor calls off the main thread.
  - No breaking API changes; existing initWithContext(context) continues to work as before.
  - JWT: Resolve IAM conditions after user create to allow fetching of IAMs in https://github.com/OneSignal/OneSignal-Android-SDK/pull/2337
  - rebased with 5.1.35 which include the following:
  - #2327
  - #2329
  - #2328
  - #2330
  - #2332
  - #2333
  - This limitation will be addressed in the next version
  - Switched publishing to use the Central Publisher Portal
  - _No changes to those using the SDK in their project_
  - Rebased to 5.1.34 for more bug fixes and stability improvements.
  - Adds the following new public methods #2311:
  - `OneSignal.Debug.addLogListener`
  - `OneSignal.Debug.removeLogListener`
  - Rebased to 5.1.33 for more bug fixes and stability improvement.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/1133)
<!-- Reviewable:end -->
