### PR TITLE
chore: add tsc check for build

### DIFF
--- a/example/scripts/build.sh
+++ b/example/scripts/build.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e  # Exit on error
+
 # Get example name from argument or environment variable
 EXAMPLE_NAME="${1:-${EXAMPLE}}"
 

--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "bun run build:vite",
-    "build:tsc": "tsc --project tsconfig.prod.json",
-    "build:vite": "vite build",
+    "build": "tsc --noEmit && vite build",
     "format:spotless": "./example/IonicCapOneSignal/android/gradlew spotlessApply",
     "format:prettier": "prettier --write \"**/*.{ts,tsx}\" --ignore-path .gitignore",
     "format": "concurrently \"npm:format:spotless\" \"npm:format:prettier\"",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "node",
     "noImplicitAny": true,
     "lib": ["es2020", "dom"],
+    "skipLibCheck": true,
     "declaration": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "commonjs",
-    "types": ["cordova"]
-  },
-  "include": ["www"],
-  "exclude": ["**/*.test.ts", "mocks/**"]
-}


### PR DESCRIPTION
# Description
## One Line Summary
- updates build script to check for tsc errors first before building

## Details
- removes build:tsc script and call tsc noemit before building vite
- adds skip lib check to not evaluate node_modules like vitest
- removes unneeded extra tsconfig (prod) json

### Motivation
- want to add a static analysis check before building

### Testing
Run `bun run build`.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/1137)
<!-- Reviewable:end -->
