### PR TITLE
chore: rename sdk-actions to sdk-shared

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,6 +17,6 @@ jobs:
     if: |
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.title, 'chore: Release')
-    uses: OneSignal/sdk-actions/.github/workflows/publish-npm-github.yml@main
+    uses: OneSignal/sdk-shared/.github/workflows/publish-npm-github.yml@main
     with:
       branch: ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,4 +10,4 @@ concurrency:
 
 jobs:
   call:
-    uses: OneSignal/sdk-actions/.github/workflows/wrapper-js-ci.yml@main
+    uses: OneSignal/sdk-shared/.github/workflows/wrapper-js-ci.yml@main

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -49,12 +49,12 @@ on:
 
 jobs:
   prep:
-    uses: OneSignal/sdk-actions/.github/workflows/prep-release.yml@main
+    uses: OneSignal/sdk-shared/.github/workflows/prep-release.yml@main
     secrets:
-      # Need this cross-repo token (sdk-actions & this repo) to perform changes
+      # Need this cross-repo token (sdk-shared & this repo) to perform changes
       GH_PUSH_TOKEN: ${{ secrets.GH_PUSH_TOKEN }}
     with:
-      # Need target_repo otherwise caller would set github.repository to the caller itself (e.g. sdk-actions)
+      # Need target_repo otherwise caller would set github.repository to the caller itself (e.g. sdk-shared)
       target_repo: OneSignal/OneSignal-Cordova-SDK
       version: ${{ inputs.cordova_version }}
 
@@ -71,13 +71,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          # Need repository otherwise caller would set github.repository to the caller itself (e.g. sdk-actions)
+          # Need repository otherwise caller would set github.repository to the caller itself (e.g. sdk-shared)
           repository: OneSignal/OneSignal-Cordova-SDK
           ref: ${{ needs.prep.outputs.release_branch }}
           token: ${{ secrets.GH_PUSH_TOKEN || github.token }}
 
       - name: Setup Git User
-        uses: OneSignal/sdk-actions/.github/actions/setup-git-user@main
+        uses: OneSignal/sdk-shared/.github/actions/setup-git-user@main
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -191,12 +191,12 @@ jobs:
 
   create-pr:
     needs: [prep, update_version]
-    uses: OneSignal/sdk-actions/.github/workflows/create-release.yml@main
+    uses: OneSignal/sdk-shared/.github/workflows/create-release.yml@main
     secrets:
-      # Need this cross-repo token (sdk-actions & this repo) to perform changes
+      # Need this cross-repo token (sdk-shared & this repo) to perform changes
       GH_PUSH_TOKEN: ${{ secrets.GH_PUSH_TOKEN }}
     with:
-      # Need target_repo otherwise caller would set github.repository to the caller itself (e.g. sdk-actions)
+      # Need target_repo otherwise caller would set github.repository to the caller itself (e.g. sdk-shared)
       target_repo: OneSignal/OneSignal-Cordova-SDK
       release_branch: ${{ needs.prep.outputs.release_branch }}
       target_branch: ${{ inputs.target_branch }}

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   call:
-    uses: OneSignal/sdk-actions/.github/workflows/lint-pr-title.yml@main
+    uses: OneSignal/sdk-shared/.github/workflows/lint-pr-title.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary
Update all GitHub workflow references from `sdk-actions` to `sdk-shared` to reflect the repo rename.

Made with [Cursor](https://cursor.com)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Cordova-SDK/1155)
<!-- Reviewable:end -->
