### PR TITLE
chore: Release 5.3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.3.6",
+  "version": "5.3.7",
   "name": "onesignal-cordova-plugin",
   "files": [
     "dist",

--- a/plugin.xml
+++ b/plugin.xml
@@ -26,7 +26,7 @@
   </engines>
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:5.7.6" />
+    <framework src="com.onesignal:OneSignal:5.7.7" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
     <framework src="org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10" />
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="5.3.6">
+    version="5.3.7">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>

--- a/plugin.xml
+++ b/plugin.xml
@@ -74,7 +74,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" spec="5.5.0" />
+            <pod name="OneSignalXCFramework" spec="5.5.1" />
         </pods>
     </podspec>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -26,7 +26,7 @@
   </engines>
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:5.7.7" />
+    <framework src="com.onesignal:OneSignal:5.8.0" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
     <framework src="org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10" />
 

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -370,7 +370,7 @@ public class OneSignalPush extends CordovaPlugin
 
         initDone = true;
         OneSignalWrapper.setSdkType("cordova");
-        OneSignalWrapper.setSdkVersion("050306");
+        OneSignalWrapper.setSdkVersion("050307");
         try {
             String appId = data.getString(0);
             OneSignal.initWithContext(this.cordova.getActivity(), appId);

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -119,7 +119,7 @@ void processNotificationClicked(OSNotificationClickEvent *event) {
 
 void initOneSignalObject(NSDictionary *launchOptions) {
   OneSignalWrapper.sdkType = @"cordova";
-  OneSignalWrapper.sdkVersion = @"050306";
+  OneSignalWrapper.sdkVersion = @"050307";
   [OneSignal initialize:nil withLaunchOptions:launchOptions];
 }
 


### PR DESCRIPTION
Channels: Current

### ✨ Improvements

- refactor(demo): [SDK-4387] align Cordova demo with RN structure for Appium (#1171)

### 🛠️ Native Dependency Updates

- Update Android SDK from 5.7.6 to 5.8.0
  - feat: hash PII (email/SMS) in SharedPreferences at rest ([#2620](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2620))
  - feat: SDK-4176: gate background threading behind remote feature flag ([#2595](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2595))
  - feat: SDK-4210: Standardize BACKGROUND_THREADING feature flag key naming ([#2598](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2598))
  - feat: SDK-4363: Turbine remote SDK feature flags and foreground refresh ([#2612](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2612))
  - bug: catch exception if opening a notification fails ([#2508](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2508))
  - Fix: a rare NPE from PermissionViewModel ([#2504](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2504))
  - fix: add retry for notification opened confirmation ([#2606](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2606))
  - fix: end initialization early if device storage is locked ([#2520](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2520))
  - fix: [SDK-4192] downgrade Kotlin from 2.2.0 to 1.9.25 ([#2601](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2601))
- Update iOS SDK from 5.5.0 to 5.5.1
  - fix: update unattributed outcomes to match attributed outcomes and Android SDK ([OneSignal-iOS-SDK#1655](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1655))
