### PR TITLE
chore: [SDK-4219] add live activities support to demo app

### DIFF
--- a/examples/demo/.env.example
+++ b/examples/demo/.env.example
@@ -1,0 +1,1 @@
+VITE_ONESIGNAL_API_KEY=your_rest_api_key

--- a/examples/demo/.gitignore
+++ b/examples/demo/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/examples/demo/bun.lock
+++ b/examples/demo/bun.lock
@@ -883,7 +883,7 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
-    "onesignal-cordova-plugin": ["onesignal-cordova-plugin@../../onesignal-cordova-plugin.tgz", {}, "sha512-2799imOAAuzaJU8k5o8pxjs7LApIf0HGsEGNazsfmD3Hx6s8/696/VjhDBMzwwyPGg0WWxmTZMRUgRTJ45mlPQ=="],
+    "onesignal-cordova-plugin": ["onesignal-cordova-plugin@../../onesignal-cordova-plugin.tgz", {}, "sha512-aMwwAJvduEgg4+eYft8aBeZ6SHw/hIeSwTC31nIXYgohjvmp6q2fq3AQSeSNSsvKlGoM3hKJgoyoU8YRondgfA=="],
 
     "open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 

--- a/examples/demo/ios/App/App/Info.plist
+++ b/examples/demo/ios/App/App/Info.plist
@@ -45,6 +45,8 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>

--- a/examples/demo/ios/App/OneSignalWidget/OneSignalWidgetLiveActivity.swift
+++ b/examples/demo/ios/App/OneSignalWidget/OneSignalWidgetLiveActivity.swift
@@ -3,44 +3,140 @@ import WidgetKit
 import SwiftUI
 import OneSignalLiveActivities
 
-struct OneSignalWidgetAttributes: OneSignalLiveActivityAttributes  {
-    public struct ContentState: OneSignalLiveActivityContentState {
-        var emoji: String
-        var onesignal: OneSignalLiveActivityContentStateData?
-    }
-    var name: String
-    var onesignal: OneSignalLiveActivityAttributeData
-}
-
+@available(iOS 16.2, *)
 struct OneSignalWidgetLiveActivity: Widget {
+
+    private func statusIcon(for status: String) -> String {
+        switch status {
+        case "on_the_way": return "box.truck.fill"
+        case "delivered":  return "checkmark.circle.fill"
+        default:           return "bag.fill"
+        }
+    }
+
+    private func statusColor(for status: String) -> Color {
+        switch status {
+        case "on_the_way": return .blue
+        case "delivered":  return .green
+        default:           return .orange
+        }
+    }
+
+    private func statusLabel(for status: String) -> String {
+        switch status {
+        case "on_the_way": return "On the Way"
+        case "delivered":  return "Delivered"
+        default:           return "Preparing"
+        }
+    }
+
     var body: some WidgetConfiguration {
-        ActivityConfiguration(for: OneSignalWidgetAttributes.self) { context in
-            VStack {
-                Text("Hello \(context.attributes.name) \(context.state.emoji)")
+        ActivityConfiguration(for: DefaultLiveActivityAttributes.self) { context in
+            let orderNumber = context.attributes.data["orderNumber"]?.asString() ?? "Order"
+            let status = context.state.data["status"]?.asString() ?? "preparing"
+            let message = context.state.data["message"]?.asString() ?? "Your order is being prepared"
+            let eta = context.state.data["estimatedTime"]?.asString() ?? ""
+
+            VStack(spacing: 10) {
+                HStack {
+                    Text(orderNumber)
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                    Spacer()
+                    if !eta.isEmpty {
+                        Text(eta)
+                            .font(.caption)
+                            .foregroundColor(.white.opacity(0.7))
+                    }
+                }
+
+                HStack(spacing: 12) {
+                    Image(systemName: statusIcon(for: status))
+                        .font(.title2)
+                        .foregroundColor(statusColor(for: status))
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(statusLabel(for: status))
+                            .font(.headline)
+                            .foregroundColor(.white)
+                        Text(message)
+                            .font(.subheadline)
+                            .foregroundColor(.white.opacity(0.8))
+                            .lineLimit(1)
+                    }
+                    Spacer()
+                }
+
+                DeliveryProgressBar(status: status)
             }
-            .activityBackgroundTint(Color.cyan)
-            .activitySystemActionForegroundColor(Color.black)
+            .padding()
+            .activityBackgroundTint(Color(red: 0.11, green: 0.13, blue: 0.19))
+            .activitySystemActionForegroundColor(.white)
 
         } dynamicIsland: { context in
-            DynamicIsland {
+            let status = context.state.data["status"]?.asString() ?? "preparing"
+            let message = context.state.data["message"]?.asString() ?? "Preparing"
+            let eta = context.state.data["estimatedTime"]?.asString() ?? ""
+
+            return DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
-                    Text("Leading")
+                    Image(systemName: statusIcon(for: status))
+                        .font(.title2)
+                        .foregroundColor(statusColor(for: status))
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    Text(statusLabel(for: status))
+                        .font(.headline)
                 }
                 DynamicIslandExpandedRegion(.trailing) {
-                    Text("Trailing")
+                    if !eta.isEmpty {
+                        Text(eta)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
                 }
                 DynamicIslandExpandedRegion(.bottom) {
-                    Text("Bottom \(context.state.emoji)")
+                    Text(message)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
                 }
             } compactLeading: {
-                Text("L")
+                Image(systemName: statusIcon(for: status))
+                    .foregroundColor(statusColor(for: status))
             } compactTrailing: {
-                Text("T \(context.state.emoji)")
+                Text(statusLabel(for: status))
+                    .font(.caption)
             } minimal: {
-                Text(context.state.emoji)
+                Image(systemName: statusIcon(for: status))
+                    .foregroundColor(statusColor(for: status))
             }
-            .widgetURL(URL(string: "http://www.apple.com"))
-            .keylineTint(Color.red)
         }
+    }
+}
+
+@available(iOS 16.2, *)
+struct DeliveryProgressBar: View {
+    let status: String
+
+    private var progress: CGFloat {
+        switch status {
+        case "on_the_way": return 0.6
+        case "delivered":  return 1.0
+        default:           return 0.25
+        }
+    }
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(Color.white.opacity(0.2))
+                    .frame(height: 6)
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(progress >= 1.0 ? Color.green : Color.blue)
+                    .frame(width: geo.size.width * progress, height: 6)
+            }
+        }
+        .frame(height: 6)
     }
 }

--- a/examples/demo/src/components/sections/LiveActivitySection.tsx
+++ b/examples/demo/src/components/sections/LiveActivitySection.tsx
@@ -24,11 +24,7 @@ const ORDER_STATUSES = [
 interface LiveActivitySectionProps {
   hasApiKey: boolean;
   onInfoTap?: () => void;
-  onStart: (
-    activityId: string,
-    attributes: object,
-    content: object,
-  ) => void;
+  onStart: (activityId: string, attributes: object, content: object) => void;
   onUpdate: (
     activityId: string,
     eventUpdates: Record<string, unknown>,

--- a/examples/demo/src/components/sections/LiveActivitySection.tsx
+++ b/examples/demo/src/components/sections/LiveActivitySection.tsx
@@ -81,10 +81,12 @@ const LiveActivitySection: FC<LiveActivitySectionProps> = ({
   const handleEnd = async () => {
     setUpdating(true);
     try {
-      await onEnd(activityId);
+      const success = await onEnd(activityId);
+      if (success) {
+        setStatusIndex(0);
+      }
     } finally {
       setUpdating(false);
-      setStatusIndex(0);
     }
   };
 

--- a/examples/demo/src/components/sections/LiveActivitySection.tsx
+++ b/examples/demo/src/components/sections/LiveActivitySection.tsx
@@ -1,0 +1,158 @@
+import { useState } from 'react';
+import type { FC } from 'react';
+import ActionButton from '../ActionButton';
+import SectionCard from '../SectionCard';
+
+const ORDER_STATUSES = [
+  {
+    status: 'preparing',
+    message: 'Your order is being prepared',
+    estimatedTime: '15 min',
+  },
+  {
+    status: 'on_the_way',
+    message: 'Driver is heading your way',
+    estimatedTime: '10 min',
+  },
+  {
+    status: 'delivered',
+    message: 'Order delivered!',
+    estimatedTime: '',
+  },
+];
+
+interface LiveActivitySectionProps {
+  hasApiKey: boolean;
+  onInfoTap?: () => void;
+  onStart: (
+    activityId: string,
+    attributes: object,
+    content: object,
+  ) => void;
+  onUpdate: (
+    activityId: string,
+    eventUpdates: Record<string, unknown>,
+  ) => Promise<boolean>;
+  onEnd: (activityId: string) => Promise<boolean>;
+}
+
+const LiveActivitySection: FC<LiveActivitySectionProps> = ({
+  hasApiKey,
+  onInfoTap,
+  onStart,
+  onUpdate,
+  onEnd,
+}) => {
+  const [activityId, setActivityId] = useState('order-1');
+  const [orderNumber, setOrderNumber] = useState('ORD-1234');
+  const [statusIndex, setStatusIndex] = useState(0);
+  const [updating, setUpdating] = useState(false);
+
+  const handleStart = () => {
+    setStatusIndex(0);
+    const initial = ORDER_STATUSES[0];
+    onStart(
+      activityId,
+      { orderNumber },
+      {
+        status: initial.status,
+        message: initial.message,
+        estimatedTime: initial.estimatedTime,
+      },
+    );
+  };
+
+  const handleUpdate = async () => {
+    const nextIndex = (statusIndex + 1) % ORDER_STATUSES.length;
+    const next = ORDER_STATUSES[nextIndex];
+    setUpdating(true);
+    try {
+      const success = await onUpdate(activityId, {
+        data: {
+          status: next.status,
+          message: next.message,
+          estimatedTime: next.estimatedTime,
+        },
+      });
+      if (success) {
+        setStatusIndex(nextIndex);
+      }
+    } finally {
+      setUpdating(false);
+    }
+  };
+
+  const handleEnd = async () => {
+    setUpdating(true);
+    try {
+      await onEnd(activityId);
+    } finally {
+      setUpdating(false);
+      setStatusIndex(0);
+    }
+  };
+
+  const nextStatus = ORDER_STATUSES[(statusIndex + 1) % ORDER_STATUSES.length];
+  const isEmpty = !activityId.trim();
+
+  return (
+    <SectionCard title="LIVE ACTIVITIES" onInfoTap={onInfoTap}>
+      <div className="card">
+        <div className="inline-input-row">
+          <label className="inline-input-label" htmlFor="la-activity-id">
+            Activity ID
+          </label>
+          <input
+            id="la-activity-id"
+            className="inline-input-field"
+            type="text"
+            value={activityId}
+            onChange={(e) => setActivityId(e.target.value)}
+            placeholder="Activity ID"
+            autoCapitalize="none"
+            autoCorrect="off"
+          />
+        </div>
+        <div className="divider" />
+        <div className="inline-input-row">
+          <label className="inline-input-label" htmlFor="la-order-number">
+            Order #
+          </label>
+          <input
+            id="la-order-number"
+            className="inline-input-field"
+            type="text"
+            value={orderNumber}
+            onChange={(e) => setOrderNumber(e.target.value)}
+            placeholder="Order #"
+            autoCapitalize="none"
+            autoCorrect="off"
+          />
+        </div>
+      </div>
+
+      <ActionButton type="button" onClick={handleStart} disabled={isEmpty}>
+        START LIVE ACTIVITY
+      </ActionButton>
+
+      <ActionButton
+        type="button"
+        onClick={handleUpdate}
+        disabled={isEmpty || updating || !hasApiKey}
+      >
+        {`UPDATE → ${nextStatus.status.replace(/_/g, ' ').toUpperCase()}`}
+      </ActionButton>
+
+      <ActionButton
+        variant="outline"
+        type="button"
+        onClick={handleEnd}
+        disabled={isEmpty || updating || !hasApiKey}
+      >
+        END LIVE ACTIVITY
+      </ActionButton>
+    </SectionCard>
+  );
+};
+
+export default LiveActivitySection;

--- a/examples/demo/src/context/AppContext.tsx
+++ b/examples/demo/src/context/AppContext.tsx
@@ -776,7 +776,7 @@ export function AppContextProvider({ children }: Props) {
   const endLiveActivity = useCallback(
     async (activityId: string): Promise<boolean> => {
       const success = await repository.updateLiveActivity(activityId, 'end', {
-        message: 'Ended Live Activity',
+        data: { status: 'delivered', message: 'Ended Live Activity' },
       });
       addLog(
         success

--- a/examples/demo/src/context/AppContext.tsx
+++ b/examples/demo/src/context/AppContext.tsx
@@ -1,3 +1,6 @@
+import { Capacitor } from "@capacitor/core";
+import OneSignal from "onesignal-cordova-plugin";
+import type { ReactNode } from "react";
 import {
   createContext,
   useCallback,
@@ -6,14 +9,11 @@ import {
   useMemo,
   useReducer,
   useRef,
-} from 'react';
-import type { ReactNode } from 'react';
-import { Capacitor } from '@capacitor/core';
-import OneSignal from 'onesignal-cordova-plugin';
-import { NotificationType } from '../models/NotificationType';
-import OneSignalRepository from '../repositories/OneSignalRepository';
-import PreferencesService from '../services/PreferencesService';
-import LogManager from '../services/LogManager';
+} from "react";
+import { NotificationType } from "../models/NotificationType";
+import OneSignalRepository from "../repositories/OneSignalRepository";
+import LogManager from "../services/LogManager";
+import PreferencesService from "../services/PreferencesService";
 
 type Pair = [string, string];
 
@@ -37,7 +37,7 @@ export interface AppState {
 }
 
 const initialState: AppState = {
-  appId: '77e32082-ea27-42e3-a898-c72e141824ef',
+  appId: "77e32082-ea27-42e3-a898-c72e141824ef",
   consentRequired: false,
   privacyConsentGiven: false,
   externalUserId: undefined,
@@ -56,10 +56,10 @@ const initialState: AppState = {
 };
 
 type AppAction =
-  | { type: 'SET_LOADING'; payload: boolean }
-  | { type: 'SET_INITIAL_STATE'; payload: Partial<AppState> }
+  | { type: "SET_LOADING"; payload: boolean }
+  | { type: "SET_INITIAL_STATE"; payload: Partial<AppState> }
   | {
-      type: 'SET_USER_DATA';
+      type: "SET_USER_DATA";
       payload: {
         aliasesList: Pair[];
         tagsList: Pair[];
@@ -68,33 +68,33 @@ type AppAction =
         externalUserId: string | undefined;
       };
     }
-  | { type: 'SET_EXTERNAL_USER_ID'; payload: string | undefined }
+  | { type: "SET_EXTERNAL_USER_ID"; payload: string | undefined }
   | {
-      type: 'SET_PUSH_SUBSCRIPTION';
+      type: "SET_PUSH_SUBSCRIPTION";
       payload: { id: string | undefined; optedIn: boolean };
     }
-  | { type: 'SET_HAS_NOTIFICATION_PERMISSION'; payload: boolean }
-  | { type: 'SET_CONSENT_REQUIRED'; payload: boolean }
-  | { type: 'SET_PRIVACY_CONSENT_GIVEN'; payload: boolean }
-  | { type: 'SET_PUSH_ENABLED'; payload: boolean }
-  | { type: 'SET_IAM_PAUSED'; payload: boolean }
-  | { type: 'SET_LOCATION_SHARED'; payload: boolean }
-  | { type: 'ADD_ALIAS'; payload: Pair }
-  | { type: 'ADD_ALIASES'; payload: Pair[] }
-  | { type: 'CLEAR_USER_DATA' }
-  | { type: 'ADD_EMAIL'; payload: string }
-  | { type: 'REMOVE_EMAIL'; payload: string }
-  | { type: 'ADD_SMS'; payload: string }
-  | { type: 'REMOVE_SMS'; payload: string }
-  | { type: 'ADD_TAG'; payload: Pair }
-  | { type: 'ADD_TAGS'; payload: Pair[] }
-  | { type: 'REMOVE_SELECTED_TAGS'; payload: string[] }
-  | { type: 'ADD_TRIGGER'; payload: Pair }
-  | { type: 'ADD_TRIGGERS'; payload: Pair[] }
-  | { type: 'REMOVE_SELECTED_TRIGGERS'; payload: string[] }
-  | { type: 'CLEAR_TRIGGERS' }
-  | { type: 'ADD_LOG'; payload: string }
-  | { type: 'CLEAR_LOGS' };
+  | { type: "SET_HAS_NOTIFICATION_PERMISSION"; payload: boolean }
+  | { type: "SET_CONSENT_REQUIRED"; payload: boolean }
+  | { type: "SET_PRIVACY_CONSENT_GIVEN"; payload: boolean }
+  | { type: "SET_PUSH_ENABLED"; payload: boolean }
+  | { type: "SET_IAM_PAUSED"; payload: boolean }
+  | { type: "SET_LOCATION_SHARED"; payload: boolean }
+  | { type: "ADD_ALIAS"; payload: Pair }
+  | { type: "ADD_ALIASES"; payload: Pair[] }
+  | { type: "CLEAR_USER_DATA" }
+  | { type: "ADD_EMAIL"; payload: string }
+  | { type: "REMOVE_EMAIL"; payload: string }
+  | { type: "ADD_SMS"; payload: string }
+  | { type: "REMOVE_SMS"; payload: string }
+  | { type: "ADD_TAG"; payload: Pair }
+  | { type: "ADD_TAGS"; payload: Pair[] }
+  | { type: "REMOVE_SELECTED_TAGS"; payload: string[] }
+  | { type: "ADD_TRIGGER"; payload: Pair }
+  | { type: "ADD_TRIGGERS"; payload: Pair[] }
+  | { type: "REMOVE_SELECTED_TRIGGERS"; payload: string[] }
+  | { type: "CLEAR_TRIGGERS" }
+  | { type: "ADD_LOG"; payload: string }
+  | { type: "CLEAR_LOGS" };
 
 function upsertPairs(existing: Pair[], incoming: Pair[]): Pair[] {
   const next = new Map(existing);
@@ -106,40 +106,40 @@ function upsertPairs(existing: Pair[], incoming: Pair[]): Pair[] {
 
 function appReducer(state: AppState, action: AppAction): AppState {
   switch (action.type) {
-    case 'SET_LOADING':
+    case "SET_LOADING":
       return { ...state, isLoading: action.payload };
-    case 'SET_INITIAL_STATE':
+    case "SET_INITIAL_STATE":
       return { ...state, ...action.payload };
-    case 'SET_USER_DATA':
+    case "SET_USER_DATA":
       return { ...state, ...action.payload, isLoading: false };
-    case 'SET_EXTERNAL_USER_ID':
+    case "SET_EXTERNAL_USER_ID":
       return { ...state, externalUserId: action.payload };
-    case 'SET_PUSH_SUBSCRIPTION':
+    case "SET_PUSH_SUBSCRIPTION":
       return {
         ...state,
         pushSubscriptionId: action.payload.id,
         isPushEnabled: action.payload.optedIn,
       };
-    case 'SET_HAS_NOTIFICATION_PERMISSION':
+    case "SET_HAS_NOTIFICATION_PERMISSION":
       return { ...state, hasNotificationPermission: action.payload };
-    case 'SET_CONSENT_REQUIRED':
+    case "SET_CONSENT_REQUIRED":
       return { ...state, consentRequired: action.payload };
-    case 'SET_PRIVACY_CONSENT_GIVEN':
+    case "SET_PRIVACY_CONSENT_GIVEN":
       return { ...state, privacyConsentGiven: action.payload };
-    case 'SET_PUSH_ENABLED':
+    case "SET_PUSH_ENABLED":
       return { ...state, isPushEnabled: action.payload };
-    case 'SET_IAM_PAUSED':
+    case "SET_IAM_PAUSED":
       return { ...state, inAppMessagesPaused: action.payload };
-    case 'SET_LOCATION_SHARED':
+    case "SET_LOCATION_SHARED":
       return { ...state, locationShared: action.payload };
-    case 'ADD_ALIAS':
+    case "ADD_ALIAS":
       return { ...state, aliasesList: [...state.aliasesList, action.payload] };
-    case 'ADD_ALIASES':
+    case "ADD_ALIASES":
       return {
         ...state,
         aliasesList: [...state.aliasesList, ...action.payload],
       };
-    case 'CLEAR_USER_DATA':
+    case "CLEAR_USER_DATA":
       return {
         ...state,
         aliasesList: [],
@@ -148,66 +148,62 @@ function appReducer(state: AppState, action: AppAction): AppState {
         tagsList: [],
         triggersList: [],
       };
-    case 'ADD_EMAIL':
+    case "ADD_EMAIL":
       return { ...state, emailsList: [...state.emailsList, action.payload] };
-    case 'REMOVE_EMAIL':
+    case "REMOVE_EMAIL":
       return {
         ...state,
-        emailsList: state.emailsList.filter(
-          (email) => email !== action.payload,
-        ),
+        emailsList: state.emailsList.filter((email) => email !== action.payload),
       };
-    case 'ADD_SMS':
+    case "ADD_SMS":
       return {
         ...state,
         smsNumbersList: [...state.smsNumbersList, action.payload],
       };
-    case 'REMOVE_SMS':
+    case "REMOVE_SMS":
       return {
         ...state,
-        smsNumbersList: state.smsNumbersList.filter(
-          (sms) => sms !== action.payload,
-        ),
+        smsNumbersList: state.smsNumbersList.filter((sms) => sms !== action.payload),
       };
-    case 'ADD_TAG':
+    case "ADD_TAG":
       return {
         ...state,
         tagsList: upsertPairs(state.tagsList, [action.payload]),
       };
-    case 'ADD_TAGS':
+    case "ADD_TAGS":
       return {
         ...state,
         tagsList: upsertPairs(state.tagsList, action.payload),
       };
-    case 'REMOVE_SELECTED_TAGS': {
+    case "REMOVE_SELECTED_TAGS": {
       const keys = new Set(action.payload);
       return {
         ...state,
         tagsList: state.tagsList.filter(([key]) => !keys.has(key)),
       };
     }
-    case 'ADD_TRIGGER':
+    case "ADD_TRIGGER":
       return {
         ...state,
         triggersList: upsertPairs(state.triggersList, [action.payload]),
       };
-    case 'ADD_TRIGGERS':
+    case "ADD_TRIGGERS":
       return {
         ...state,
         triggersList: upsertPairs(state.triggersList, action.payload),
       };
-    case 'REMOVE_SELECTED_TRIGGERS': {
+    case "REMOVE_SELECTED_TRIGGERS": {
       const keys = new Set(action.payload);
       return {
         ...state,
         triggersList: state.triggersList.filter(([key]) => !keys.has(key)),
       };
     }
-    case 'CLEAR_TRIGGERS':
+    case "CLEAR_TRIGGERS":
       return { ...state, triggersList: [] };
-    case 'ADD_LOG':
+    case "ADD_LOG":
       return { ...state, logs: [action.payload, ...state.logs].slice(0, 100) };
-    case 'CLEAR_LOGS':
+    case "CLEAR_LOGS":
       return { ...state, logs: [] };
     default:
       return state;
@@ -245,18 +241,11 @@ type AppContextValue = {
   addTriggers: (pairs: Record<string, string>) => Promise<void>;
   removeSelectedTriggers: (keys: string[]) => Promise<void>;
   clearTriggers: () => Promise<void>;
-  trackEvent: (
-    name: string,
-    properties?: Record<string, unknown>,
-  ) => Promise<void>;
+  trackEvent: (name: string, properties?: Record<string, unknown>) => Promise<void>;
   setLocationShared: (shared: boolean) => Promise<void>;
   requestLocationPermission: () => Promise<void>;
   hasApiKey: boolean;
-  startDefaultLiveActivity: (
-    activityId: string,
-    attributes: object,
-    content: object,
-  ) => void;
+  startDefaultLiveActivity: (activityId: string, attributes: object, content: object) => void;
   updateLiveActivity: (
     activityId: string,
     eventUpdates: Record<string, unknown>,
@@ -284,8 +273,8 @@ export function AppContextProvider({ children }: Props) {
   const requestSequenceRef = useRef(0);
 
   const addLog = useCallback((message: string) => {
-    dispatch({ type: 'ADD_LOG', payload: message });
-    logManager.i('AppContext', message);
+    dispatch({ type: "ADD_LOG", payload: message });
+    logManager.i("AppContext", message);
   }, []);
 
   const refreshPushState = useCallback(async () => {
@@ -294,7 +283,7 @@ export function AppContextProvider({ children }: Props) {
       repository.isPushOptedIn(),
     ]);
     dispatch({
-      type: 'SET_PUSH_SUBSCRIPTION',
+      type: "SET_PUSH_SUBSCRIPTION",
       payload: {
         id: id ?? undefined,
         optedIn,
@@ -309,7 +298,7 @@ export function AppContextProvider({ children }: Props) {
     const onesignalId = await repository.getOnesignalId();
     if (!onesignalId) {
       if (mountedRef.current && requestSequenceRef.current === requestId) {
-        dispatch({ type: 'SET_LOADING', payload: false });
+        dispatch({ type: "SET_LOADING", payload: false });
       }
       return;
     }
@@ -317,7 +306,7 @@ export function AppContextProvider({ children }: Props) {
     const userData = await repository.fetchUser(onesignalId);
     if (!userData) {
       if (mountedRef.current && requestSequenceRef.current === requestId) {
-        dispatch({ type: 'SET_LOADING', payload: false });
+        dispatch({ type: "SET_LOADING", payload: false });
       }
       return;
     }
@@ -328,7 +317,7 @@ export function AppContextProvider({ children }: Props) {
     }
 
     dispatch({
-      type: 'SET_USER_DATA',
+      type: "SET_USER_DATA",
       payload: {
         aliasesList: Object.entries(userData.aliases),
         tagsList: Object.entries(userData.tags),
@@ -340,7 +329,7 @@ export function AppContextProvider({ children }: Props) {
 
     await new Promise((resolve) => setTimeout(resolve, 100));
     if (mountedRef.current && requestSequenceRef.current === requestId) {
-      dispatch({ type: 'SET_LOADING', payload: false });
+      dispatch({ type: "SET_LOADING", payload: false });
     }
   }, []);
 
@@ -361,7 +350,7 @@ export function AppContextProvider({ children }: Props) {
       const locationShared = preferences.getLocationShared();
 
       dispatch({
-        type: 'SET_INITIAL_STATE',
+        type: "SET_INITIAL_STATE",
         payload: {
           appId,
           consentRequired,
@@ -385,7 +374,7 @@ export function AppContextProvider({ children }: Props) {
 
       await refreshPushState();
       dispatch({
-        type: 'SET_HAS_NOTIFICATION_PERMISSION',
+        type: "SET_HAS_NOTIFICATION_PERMISSION",
         payload: repository.hasPermission(),
       });
 
@@ -394,15 +383,15 @@ export function AppContextProvider({ children }: Props) {
         return;
       }
       if (onesignalId) {
-        dispatch({ type: 'SET_LOADING', payload: true });
+        dispatch({ type: "SET_LOADING", payload: true });
         await fetchUserDataFromApi();
       }
     };
 
     init().catch(() => {
-      addLog('Initialization failed');
+      addLog("Initialization failed");
       if (mountedRef.current) {
-        dispatch({ type: 'SET_LOADING', payload: false });
+        dispatch({ type: "SET_LOADING", payload: false });
       }
     });
   }, [addLog, fetchUserDataFromApi, refreshPushState]);
@@ -416,7 +405,7 @@ export function AppContextProvider({ children }: Props) {
       if (!mountedRef.current) {
         return;
       }
-      dispatch({ type: 'SET_HAS_NOTIFICATION_PERMISSION', payload: granted });
+      dispatch({ type: "SET_HAS_NOTIFICATION_PERMISSION", payload: granted });
       addLog(`Permission changed: ${granted}`);
     };
 
@@ -425,7 +414,7 @@ export function AppContextProvider({ children }: Props) {
         return;
       }
       await refreshPushState();
-      addLog('Push subscription changed');
+      addLog("Push subscription changed");
     };
 
     const onUserChange = async () => {
@@ -437,70 +426,58 @@ export function AppContextProvider({ children }: Props) {
         return;
       }
       dispatch({
-        type: 'SET_EXTERNAL_USER_ID',
+        type: "SET_EXTERNAL_USER_ID",
         payload: externalId ?? undefined,
       });
-      addLog('User changed');
-      dispatch({ type: 'SET_LOADING', payload: true });
+      addLog("User changed");
+      dispatch({ type: "SET_LOADING", payload: true });
       await fetchUserDataFromApi();
     };
 
-    OneSignal.Notifications.addEventListener(
-      'permissionChange',
-      onPermissionChange,
-    );
-    OneSignal.User.pushSubscription.addEventListener(
-      'change',
-      onPushSubscriptionChange,
-    );
-    OneSignal.User.addEventListener('change', onUserChange);
+    OneSignal.Notifications.addEventListener("permissionChange", onPermissionChange);
+    OneSignal.User.pushSubscription.addEventListener("change", onPushSubscriptionChange);
+    OneSignal.User.addEventListener("change", onUserChange);
 
     return () => {
-      OneSignal.Notifications.removeEventListener(
-        'permissionChange',
-        onPermissionChange,
-      );
-      OneSignal.User.pushSubscription.removeEventListener(
-        'change',
-        onPushSubscriptionChange,
-      );
-      OneSignal.User.removeEventListener('change', onUserChange);
+      OneSignal.Notifications.removeEventListener("permissionChange", onPermissionChange);
+      OneSignal.User.pushSubscription.removeEventListener("change", onPushSubscriptionChange);
+      OneSignal.User.removeEventListener("change", onUserChange);
     };
   }, [addLog, fetchUserDataFromApi, refreshPushState]);
 
   const clearLogs = useCallback(() => {
-    dispatch({ type: 'CLEAR_LOGS' });
+    dispatch({ type: "CLEAR_LOGS" });
     logManager.clear();
   }, []);
 
   const loginUser = useCallback(
     async (externalUserId: string) => {
-      dispatch({ type: 'SET_LOADING', payload: true });
+      dispatch({ type: "SET_LOADING", payload: true });
       repository.loginUser(externalUserId);
       preferences.setExternalUserId(externalUserId);
-      dispatch({ type: 'SET_EXTERNAL_USER_ID', payload: externalUserId });
-      dispatch({ type: 'CLEAR_USER_DATA' });
+      dispatch({ type: "SET_EXTERNAL_USER_ID", payload: externalUserId });
+      dispatch({ type: "CLEAR_USER_DATA" });
       addLog(`Logged in as: ${externalUserId}`);
     },
     [addLog],
   );
 
   const logoutUser = useCallback(async () => {
-    dispatch({ type: 'SET_LOADING', payload: true });
+    dispatch({ type: "SET_LOADING", payload: true });
     repository.logoutUser();
     preferences.setExternalUserId(null);
-    dispatch({ type: 'SET_EXTERNAL_USER_ID', payload: undefined });
-    dispatch({ type: 'CLEAR_USER_DATA' });
-    dispatch({ type: 'CLEAR_TRIGGERS' });
-    dispatch({ type: 'SET_LOADING', payload: false });
-    addLog('Logged out');
+    dispatch({ type: "SET_EXTERNAL_USER_ID", payload: undefined });
+    dispatch({ type: "CLEAR_USER_DATA" });
+    dispatch({ type: "CLEAR_TRIGGERS" });
+    dispatch({ type: "SET_LOADING", payload: false });
+    addLog("Logged out");
   }, [addLog]);
 
   const setConsentRequired = useCallback(
     async (required: boolean) => {
       repository.setConsentRequired(required);
       preferences.setConsentRequired(required);
-      dispatch({ type: 'SET_CONSENT_REQUIRED', payload: required });
+      dispatch({ type: "SET_CONSENT_REQUIRED", payload: required });
       addLog(`Consent required: ${required}`);
     },
     [addLog],
@@ -510,7 +487,7 @@ export function AppContextProvider({ children }: Props) {
     async (granted: boolean) => {
       repository.setConsentGiven(granted);
       preferences.setConsentGiven(granted);
-      dispatch({ type: 'SET_PRIVACY_CONSENT_GIVEN', payload: granted });
+      dispatch({ type: "SET_PRIVACY_CONSENT_GIVEN", payload: granted });
       addLog(`Consent given: ${granted}`);
     },
     [addLog],
@@ -518,7 +495,7 @@ export function AppContextProvider({ children }: Props) {
 
   const promptPush = useCallback(async () => {
     const granted = await repository.requestPermission(true);
-    dispatch({ type: 'SET_HAS_NOTIFICATION_PERMISSION', payload: granted });
+    dispatch({ type: "SET_HAS_NOTIFICATION_PERMISSION", payload: granted });
     addLog(`Push permission prompt result: ${granted}`);
   }, [addLog]);
 
@@ -529,45 +506,41 @@ export function AppContextProvider({ children }: Props) {
       } else {
         repository.optOutPush();
       }
-      dispatch({ type: 'SET_PUSH_ENABLED', payload: enabled });
-      addLog(enabled ? 'Push enabled' : 'Push disabled');
+      dispatch({ type: "SET_PUSH_ENABLED", payload: enabled });
+      addLog(enabled ? "Push enabled" : "Push disabled");
     },
     [addLog],
   );
 
   const sendSimpleNotification = useCallback(async () => {
     const sent = await repository.sendNotification(NotificationType.Simple);
-    addLog(sent ? 'Notification sent: Simple' : 'Failed to send notification');
+    addLog(sent ? "Notification sent: Simple" : "Failed to send notification");
   }, [addLog]);
 
   const sendImageNotification = useCallback(async () => {
     const sent = await repository.sendNotification(NotificationType.WithImage);
-    addLog(
-      sent ? 'Notification sent: WithImage' : 'Failed to send notification',
-    );
+    addLog(sent ? "Notification sent: WithImage" : "Failed to send notification");
   }, [addLog]);
 
   const sendCustomNotification = useCallback(
     async (title: string, body: string) => {
       const sent = await repository.sendCustomNotification(title, body);
-      addLog(
-        sent ? `Notification sent: ${title}` : 'Failed to send notification',
-      );
+      addLog(sent ? `Notification sent: ${title}` : "Failed to send notification");
     },
     [addLog],
   );
 
   const clearAllNotifications = useCallback(async () => {
     repository.clearAllNotifications();
-    addLog('All notifications cleared');
+    addLog("All notifications cleared");
   }, [addLog]);
 
   const setIamPaused = useCallback(
     async (paused: boolean) => {
       repository.setPaused(paused);
       preferences.setIamPaused(paused);
-      dispatch({ type: 'SET_IAM_PAUSED', payload: paused });
-      addLog(paused ? 'In-app messages paused' : 'In-app messages resumed');
+      dispatch({ type: "SET_IAM_PAUSED", payload: paused });
+      addLog(paused ? "In-app messages paused" : "In-app messages resumed");
     },
     [addLog],
   );
@@ -575,7 +548,7 @@ export function AppContextProvider({ children }: Props) {
   const addTrigger = useCallback(
     async (key: string, value: string) => {
       repository.addTrigger(key, value);
-      dispatch({ type: 'ADD_TRIGGER', payload: [key, value] });
+      dispatch({ type: "ADD_TRIGGER", payload: [key, value] });
       addLog(`Trigger added: ${key}`);
     },
     [addLog],
@@ -585,7 +558,7 @@ export function AppContextProvider({ children }: Props) {
     async (pairs: Record<string, string>) => {
       repository.addTriggers(pairs);
       const entries = toPairs(pairs);
-      dispatch({ type: 'ADD_TRIGGERS', payload: entries });
+      dispatch({ type: "ADD_TRIGGERS", payload: entries });
       addLog(`${entries.length} trigger(s) added`);
     },
     [addLog],
@@ -593,14 +566,14 @@ export function AppContextProvider({ children }: Props) {
 
   const clearTriggers = useCallback(async () => {
     repository.clearTriggers();
-    dispatch({ type: 'CLEAR_TRIGGERS' });
-    addLog('All triggers cleared');
+    dispatch({ type: "CLEAR_TRIGGERS" });
+    addLog("All triggers cleared");
   }, [addLog]);
 
   const removeSelectedTriggers = useCallback(
     async (keys: string[]) => {
       repository.removeTriggers(keys);
-      dispatch({ type: 'REMOVE_SELECTED_TRIGGERS', payload: keys });
+      dispatch({ type: "REMOVE_SELECTED_TRIGGERS", payload: keys });
       addLog(`${keys.length} trigger(s) removed`);
     },
     [addLog],
@@ -608,7 +581,7 @@ export function AppContextProvider({ children }: Props) {
 
   const sendIamTrigger = useCallback(
     async (iamType: string) => {
-      await addTrigger('iam_type', iamType);
+      await addTrigger("iam_type", iamType);
     },
     [addTrigger],
   );
@@ -616,7 +589,7 @@ export function AppContextProvider({ children }: Props) {
   const addAlias = useCallback(
     async (label: string, id: string) => {
       repository.addAlias(label, id);
-      dispatch({ type: 'ADD_ALIAS', payload: [label, id] });
+      dispatch({ type: "ADD_ALIAS", payload: [label, id] });
       addLog(`Alias added: ${label}`);
     },
     [addLog],
@@ -626,7 +599,7 @@ export function AppContextProvider({ children }: Props) {
     async (pairs: Record<string, string>) => {
       repository.addAliases(pairs);
       const entries = toPairs(pairs);
-      dispatch({ type: 'ADD_ALIASES', payload: entries });
+      dispatch({ type: "ADD_ALIASES", payload: entries });
       addLog(`${entries.length} alias(es) added`);
     },
     [addLog],
@@ -635,7 +608,7 @@ export function AppContextProvider({ children }: Props) {
   const addEmail = useCallback(
     async (email: string) => {
       repository.addEmail(email);
-      dispatch({ type: 'ADD_EMAIL', payload: email });
+      dispatch({ type: "ADD_EMAIL", payload: email });
       addLog(`Email added: ${email}`);
     },
     [addLog],
@@ -644,7 +617,7 @@ export function AppContextProvider({ children }: Props) {
   const removeEmail = useCallback(
     async (email: string) => {
       repository.removeEmail(email);
-      dispatch({ type: 'REMOVE_EMAIL', payload: email });
+      dispatch({ type: "REMOVE_EMAIL", payload: email });
       addLog(`Email removed: ${email}`);
     },
     [addLog],
@@ -653,7 +626,7 @@ export function AppContextProvider({ children }: Props) {
   const addSms = useCallback(
     async (sms: string) => {
       repository.addSms(sms);
-      dispatch({ type: 'ADD_SMS', payload: sms });
+      dispatch({ type: "ADD_SMS", payload: sms });
       addLog(`SMS added: ${sms}`);
     },
     [addLog],
@@ -662,7 +635,7 @@ export function AppContextProvider({ children }: Props) {
   const removeSms = useCallback(
     async (sms: string) => {
       repository.removeSms(sms);
-      dispatch({ type: 'REMOVE_SMS', payload: sms });
+      dispatch({ type: "REMOVE_SMS", payload: sms });
       addLog(`SMS removed: ${sms}`);
     },
     [addLog],
@@ -671,7 +644,7 @@ export function AppContextProvider({ children }: Props) {
   const addTag = useCallback(
     async (key: string, value: string) => {
       repository.addTag(key, value);
-      dispatch({ type: 'ADD_TAG', payload: [key, value] });
+      dispatch({ type: "ADD_TAG", payload: [key, value] });
       addLog(`Tag added: ${key}`);
     },
     [addLog],
@@ -681,7 +654,7 @@ export function AppContextProvider({ children }: Props) {
     async (pairs: Record<string, string>) => {
       repository.addTags(pairs);
       const entries = toPairs(pairs);
-      dispatch({ type: 'ADD_TAGS', payload: entries });
+      dispatch({ type: "ADD_TAGS", payload: entries });
       addLog(`${entries.length} tag(s) added`);
     },
     [addLog],
@@ -690,7 +663,7 @@ export function AppContextProvider({ children }: Props) {
   const removeSelectedTags = useCallback(
     async (keys: string[]) => {
       repository.removeTags(keys);
-      dispatch({ type: 'REMOVE_SELECTED_TAGS', payload: keys });
+      dispatch({ type: "REMOVE_SELECTED_TAGS", payload: keys });
       addLog(`${keys.length} tag(s) removed`);
     },
     [addLog],
@@ -732,15 +705,15 @@ export function AppContextProvider({ children }: Props) {
     async (shared: boolean) => {
       repository.setLocationShared(shared);
       preferences.setLocationShared(shared);
-      dispatch({ type: 'SET_LOCATION_SHARED', payload: shared });
-      addLog(shared ? 'Location sharing enabled' : 'Location sharing disabled');
+      dispatch({ type: "SET_LOCATION_SHARED", payload: shared });
+      addLog(shared ? "Location sharing enabled" : "Location sharing disabled");
     },
     [addLog],
   );
 
   const requestLocationPermission = useCallback(async () => {
     repository.requestLocationPermission();
-    addLog('Location permission prompt triggered');
+    addLog("Location permission prompt triggered");
   }, [addLog]);
 
   const hasApiKey = repository.hasApiKey();
@@ -754,20 +727,9 @@ export function AppContextProvider({ children }: Props) {
   );
 
   const updateLiveActivity = useCallback(
-    async (
-      activityId: string,
-      eventUpdates: Record<string, unknown>,
-    ): Promise<boolean> => {
-      const success = await repository.updateLiveActivity(
-        activityId,
-        'update',
-        eventUpdates,
-      );
-      addLog(
-        success
-          ? `Updated Live Activity: ${activityId}`
-          : 'Failed to update Live Activity',
-      );
+    async (activityId: string, eventUpdates: Record<string, unknown>): Promise<boolean> => {
+      const success = await repository.updateLiveActivity(activityId, "update", eventUpdates);
+      addLog(success ? `Updated Live Activity: ${activityId}` : "Failed to update Live Activity");
       return success;
     },
     [addLog],
@@ -775,14 +737,10 @@ export function AppContextProvider({ children }: Props) {
 
   const endLiveActivity = useCallback(
     async (activityId: string): Promise<boolean> => {
-      const success = await repository.updateLiveActivity(activityId, 'end', {
-        data: { status: 'delivered', message: 'Ended Live Activity' },
+      const success = await repository.updateLiveActivity(activityId, "end", {
+        data: {},
       });
-      addLog(
-        success
-          ? `Ended Live Activity: ${activityId}`
-          : 'Failed to end Live Activity',
-      );
+      addLog(success ? `Ended Live Activity: ${activityId}` : "Failed to end Live Activity");
       return success;
     },
     [addLog],
@@ -875,7 +833,7 @@ export function AppContextProvider({ children }: Props) {
 export function useAppContext(): AppContextValue {
   const context = useContext(AppContext);
   if (!context) {
-    throw new Error('useAppContext must be used within AppContextProvider');
+    throw new Error("useAppContext must be used within AppContextProvider");
   }
   return context;
 }

--- a/examples/demo/src/context/AppContext.tsx
+++ b/examples/demo/src/context/AppContext.tsx
@@ -251,6 +251,17 @@ type AppContextValue = {
   ) => Promise<void>;
   setLocationShared: (shared: boolean) => Promise<void>;
   requestLocationPermission: () => Promise<void>;
+  hasApiKey: boolean;
+  startDefaultLiveActivity: (
+    activityId: string,
+    attributes: object,
+    content: object,
+  ) => void;
+  updateLiveActivity: (
+    activityId: string,
+    eventUpdates: Record<string, unknown>,
+  ) => Promise<boolean>;
+  endLiveActivity: (activityId: string) => Promise<boolean>;
 };
 
 const AppContext = createContext<AppContextValue | null>(null);
@@ -364,6 +375,7 @@ export function AppContextProvider({ children }: Props) {
       repository.setConsentRequired(consentRequired);
       repository.setConsentGiven(consentGiven);
       repository.initialize(appId);
+      repository.setupDefaultLiveActivity();
       repository.setPaused(iamPaused);
       repository.setLocationShared(locationShared);
 
@@ -731,6 +743,51 @@ export function AppContextProvider({ children }: Props) {
     addLog('Location permission prompt triggered');
   }, [addLog]);
 
+  const hasApiKey = repository.hasApiKey();
+
+  const startDefaultLiveActivity = useCallback(
+    (activityId: string, attributes: object, content: object) => {
+      repository.startDefaultLiveActivity(activityId, attributes, content);
+      addLog(`Started Live Activity: ${activityId}`);
+    },
+    [addLog],
+  );
+
+  const updateLiveActivity = useCallback(
+    async (
+      activityId: string,
+      eventUpdates: Record<string, unknown>,
+    ): Promise<boolean> => {
+      const success = await repository.updateLiveActivity(
+        activityId,
+        'update',
+        eventUpdates,
+      );
+      addLog(
+        success
+          ? `Updated Live Activity: ${activityId}`
+          : 'Failed to update Live Activity',
+      );
+      return success;
+    },
+    [addLog],
+  );
+
+  const endLiveActivity = useCallback(
+    async (activityId: string): Promise<boolean> => {
+      const success = await repository.updateLiveActivity(activityId, 'end', {
+        message: 'Ended Live Activity',
+      });
+      addLog(
+        success
+          ? `Ended Live Activity: ${activityId}`
+          : 'Failed to end Live Activity',
+      );
+      return success;
+    },
+    [addLog],
+  );
+
   const value = useMemo<AppContextValue>(
     () => ({
       state,
@@ -766,6 +823,10 @@ export function AppContextProvider({ children }: Props) {
       trackEvent,
       setLocationShared,
       requestLocationPermission,
+      hasApiKey,
+      startDefaultLiveActivity,
+      updateLiveActivity,
+      endLiveActivity,
     }),
     [
       state,
@@ -801,6 +862,10 @@ export function AppContextProvider({ children }: Props) {
       trackEvent,
       setLocationShared,
       requestLocationPermission,
+      hasApiKey,
+      startDefaultLiveActivity,
+      updateLiveActivity,
+      endLiveActivity,
     ],
   );
 

--- a/examples/demo/src/pages/Home.css
+++ b/examples/demo/src/pages/Home.css
@@ -500,6 +500,36 @@
   color: var(--os-success);
 }
 
+.inline-input-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.inline-input-label {
+  font-size: var(--font-size-body);
+  color: var(--os-grey-600);
+  min-width: 80px;
+  flex-shrink: 0;
+}
+
+.inline-input-field {
+  flex: 1;
+  text-align: right;
+  font-size: var(--font-size-body);
+  color: #212121;
+  padding: 4px 0;
+  border: none;
+  background: transparent;
+  outline: none;
+  min-width: 0;
+}
+
+.inline-input-field::placeholder {
+  color: var(--os-grey-500);
+}
+
 .loading-overlay {
   position: fixed;
   inset: 0;

--- a/examples/demo/src/pages/Home.css
+++ b/examples/demo/src/pages/Home.css
@@ -228,10 +228,23 @@
   justify-content: flex-start;
 }
 
+.action-btn:disabled {
+  background: var(--os-grey-500);
+  color: #fff;
+  opacity: 0.6;
+}
+
 .action-btn.outline {
   background: transparent;
   border: 1px solid var(--os-primary);
   color: var(--os-primary);
+}
+
+.action-btn.outline:disabled {
+  border-color: var(--os-grey-500);
+  color: var(--os-grey-500);
+  background: transparent;
+  opacity: 0.6;
 }
 
 .toggle-card ion-toggle {

--- a/examples/demo/src/pages/Home.css
+++ b/examples/demo/src/pages/Home.css
@@ -330,7 +330,7 @@
   align-items: center;
   justify-content: center;
   padding: 24px 16px;
-  z-index: 10;
+  z-index: 50;
 }
 
 .modal-card {

--- a/examples/demo/src/pages/Home.tsx
+++ b/examples/demo/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import { IonContent, IonPage, IonToast } from '@ionic/react';
 import { useHistory } from 'react-router-dom';
 import { useEffect, useMemo, useState } from 'react';
+import { Capacitor } from '@capacitor/core';
 import oneSignalLogo from '../assets/onesignal_logo.svg';
 import ActionButton from '../components/ActionButton';
 import LoadingOverlay from '../components/LoadingOverlay';
@@ -18,6 +19,7 @@ import AppSection from '../components/sections/AppSection';
 import UserSection from '../components/sections/UserSection';
 import EmailsSection from '../components/sections/EmailsSection';
 import InAppSection from '../components/sections/InAppSection';
+import LiveActivitySection from '../components/sections/LiveActivitySection';
 import LocationSection from '../components/sections/LocationSection';
 import OutcomesSection from '../components/sections/OutcomesSection';
 import PushSection from '../components/sections/PushSection';
@@ -83,6 +85,10 @@ const Home: React.FC = () => {
     sendImageNotification,
     sendCustomNotification,
     clearAllNotifications,
+    hasApiKey,
+    startDefaultLiveActivity,
+    updateLiveActivity,
+    endLiveActivity,
   } = useAppContext();
 
   const history = useHistory();
@@ -330,6 +336,16 @@ const Home: React.FC = () => {
                 )
               }
             />
+
+            {Capacitor.getPlatform() === 'ios' && (
+              <LiveActivitySection
+                hasApiKey={hasApiKey}
+                onInfoTap={() => showTooltipModal('liveActivities')}
+                onStart={startDefaultLiveActivity}
+                onUpdate={updateLiveActivity}
+                onEnd={endLiveActivity}
+              />
+            )}
 
             <section className="section">
               <ActionButton

--- a/examples/demo/src/repositories/OneSignalRepository.ts
+++ b/examples/demo/src/repositories/OneSignalRepository.ts
@@ -207,4 +207,33 @@ export default class OneSignalRepository {
   fetchUser(onesignalId: string): Promise<UserData | null> {
     return this.apiService.fetchUser(onesignalId);
   }
+
+  setupDefaultLiveActivity(): void {
+    if (!this.isNative()) return;
+    OneSignal.LiveActivities.setupDefault({
+      enablePushToStart: true,
+      enablePushToUpdate: true,
+    });
+  }
+
+  startDefaultLiveActivity(
+    activityId: string,
+    attributes: object,
+    content: object,
+  ): void {
+    if (!this.isNative()) return;
+    OneSignal.LiveActivities.startDefault(activityId, attributes, content);
+  }
+
+  async updateLiveActivity(
+    activityId: string,
+    event: 'update' | 'end',
+    eventUpdates?: Record<string, unknown>,
+  ): Promise<boolean> {
+    return this.apiService.updateLiveActivity(activityId, event, eventUpdates);
+  }
+
+  hasApiKey(): boolean {
+    return this.apiService.hasApiKey();
+  }
 }

--- a/examples/demo/src/services/OneSignalApiService.ts
+++ b/examples/demo/src/services/OneSignalApiService.ts
@@ -1,6 +1,9 @@
 import { NotificationType } from '../models/NotificationType';
 import { userDataFromJson } from '../models/UserData';
 import type { UserData } from '../models/UserData';
+import LogManager from './LogManager';
+
+const TAG = 'OneSignalApiService';
 
 export const IMAGE_NOTIFICATION_URL =
   'https://media.onesignal.com/automated_push_templates/ratings_template.png';
@@ -16,6 +19,11 @@ class OneSignalApiService {
   private static instance: OneSignalApiService;
 
   private appId = '';
+  private apiKey: string;
+
+  constructor() {
+    this.apiKey = (import.meta.env.VITE_ONESIGNAL_API_KEY ?? '').trim();
+  }
 
   static getInstance(): OneSignalApiService {
     if (!OneSignalApiService.instance) {
@@ -30,6 +38,10 @@ class OneSignalApiService {
 
   getAppId(): string {
     return this.appId;
+  }
+
+  hasApiKey(): boolean {
+    return this.apiKey.length > 0;
   }
 
   async sendNotification(
@@ -101,6 +113,50 @@ class OneSignalApiService {
 
       return response.ok;
     } catch {
+      return false;
+    }
+  }
+
+  async updateLiveActivity(
+    activityId: string,
+    event: 'update' | 'end',
+    eventUpdates: Record<string, unknown> = {},
+  ): Promise<boolean> {
+    if (!this.appId || !this.hasApiKey()) {
+      return false;
+    }
+
+    try {
+      const url = `https://api.onesignal.com/apps/${this.appId}/live_activities/${activityId}/notifications`;
+      const payload: Record<string, unknown> = {
+        event,
+        event_updates: eventUpdates,
+        name: event === 'end' ? 'End Live Activity' : 'Live Activity Update',
+        priority: 10,
+      };
+
+      if (event === 'end') {
+        payload.dismissal_date = Math.floor(Date.now() / 1000);
+      }
+
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Key ${this.apiKey}`,
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        LogManager.getInstance().e(TAG, `${event} live activity failed: ${text}`);
+        return false;
+      }
+
+      return true;
+    } catch (err) {
+      LogManager.getInstance().e(TAG, `${event} live activity error: ${String(err)}`);
       return false;
     }
   }

--- a/examples/demo/src/services/OneSignalApiService.ts
+++ b/examples/demo/src/services/OneSignalApiService.ts
@@ -125,7 +125,7 @@ class OneSignalApiService {
     }
 
     try {
-      const url = `https://api.onesignal.com/apps/${this.appId}/live_activities/${activityId}/notifications`;
+      const url = `https://api.onesignal.com/apps/${this.appId}/live_activities/${encodeURIComponent(activityId)}/notifications`;
       const data: Record<string, unknown> = {
         event,
         event_updates: eventUpdates,

--- a/examples/demo/src/services/OneSignalApiService.ts
+++ b/examples/demo/src/services/OneSignalApiService.ts
@@ -1,3 +1,4 @@
+import { CapacitorHttp } from '@capacitor/core';
 import { NotificationType } from '../models/NotificationType';
 import { userDataFromJson } from '../models/UserData';
 import type { UserData } from '../models/UserData';
@@ -15,15 +16,12 @@ export const IMAGE_NOTIFICATION_PAYLOAD = {
   },
 } as const;
 
+const API_KEY = (import.meta.env.VITE_ONESIGNAL_API_KEY ?? '').trim();
+
 class OneSignalApiService {
   private static instance: OneSignalApiService;
 
   private appId = '';
-  private apiKey: string;
-
-  constructor() {
-    this.apiKey = (import.meta.env.VITE_ONESIGNAL_API_KEY ?? '').trim();
-  }
 
   static getInstance(): OneSignalApiService {
     if (!OneSignalApiService.instance) {
@@ -41,7 +39,7 @@ class OneSignalApiService {
   }
 
   hasApiKey(): boolean {
-    return this.apiKey.length > 0;
+    return API_KEY.length > 0;
   }
 
   async sendNotification(
@@ -128,7 +126,7 @@ class OneSignalApiService {
 
     try {
       const url = `https://api.onesignal.com/apps/${this.appId}/live_activities/${activityId}/notifications`;
-      const payload: Record<string, unknown> = {
+      const data: Record<string, unknown> = {
         event,
         event_updates: eventUpdates,
         name: event === 'end' ? 'End Live Activity' : 'Live Activity Update',
@@ -136,21 +134,20 @@ class OneSignalApiService {
       };
 
       if (event === 'end') {
-        payload.dismissal_date = Math.floor(Date.now() / 1000);
+        data.dismissal_date = Math.floor(Date.now() / 1000);
       }
 
-      const response = await fetch(url, {
-        method: 'POST',
+      const response = await CapacitorHttp.post({
+        url,
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Key ${this.apiKey}`,
+          Authorization: `Key ${API_KEY}`,
         },
-        body: JSON.stringify(payload),
+        data,
       });
 
-      if (!response.ok) {
-        const text = await response.text();
-        LogManager.getInstance().e(TAG, `${event} live activity failed: ${text}`);
+      if (response.status < 200 || response.status >= 300) {
+        LogManager.getInstance().e(TAG, `${event} live activity failed: ${JSON.stringify(response.data)}`);
         return false;
       }
 

--- a/examples/demo/src/services/OneSignalApiService.ts
+++ b/examples/demo/src/services/OneSignalApiService.ts
@@ -147,13 +147,19 @@ class OneSignalApiService {
       });
 
       if (response.status < 200 || response.status >= 300) {
-        LogManager.getInstance().e(TAG, `${event} live activity failed: ${JSON.stringify(response.data)}`);
+        LogManager.getInstance().e(
+          TAG,
+          `${event} live activity failed: ${JSON.stringify(response.data)}`,
+        );
         return false;
       }
 
       return true;
     } catch (err) {
-      LogManager.getInstance().e(TAG, `${event} live activity error: ${String(err)}`);
+      LogManager.getInstance().e(
+        TAG,
+        `${event} live activity error: ${String(err)}`,
+      );
       return false;
     }
   }

--- a/examples/demo/src/vite-env.d.ts
+++ b/examples/demo/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_ONESIGNAL_API_KEY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/examples/setup.sh
+++ b/examples/setup.sh
@@ -16,6 +16,8 @@ cd "$ORIGINAL_DIR"
 bun remove onesignal-cordova-plugin
 bun add file:../../onesignal-cordova-plugin.tgz
 
+bun run build
+
 pod_update() {
   cd ios/App && pod update OneSignalXCFramework --no-repo-update && cd ../..
 }

--- a/www/LiveActivitiesNamespace.ts
+++ b/www/LiveActivitiesNamespace.ts
@@ -39,6 +39,7 @@ export default class LiveActivities {
    * @param  {Function} onSuccess
    * @param  {Function} onFailure
    * @returns void
+   * @deprecated Currently unsupported, avoid using this method.
    */
   exit(
     activityId: string,


### PR DESCRIPTION
# Description
## One Line Summary
Add Live Activities section to the Cordova demo app with start, update, and end functionality via the OneSignal SDK and REST API.


<img width="567" height="1082" alt="Screenshot 2026-04-07 at 1 52 54 PM" src="https://github.com/user-attachments/assets/c947fbc6-f34a-442a-8631-ea5419d0495f" />
<img width="567" height="1082" alt="Screenshot 2026-04-07 at 1 52 27 PM" src="https://github.com/user-attachments/assets/6c2cb5b8-c249-48d8-965d-102a02a8df7d" />
<img width="567" height="1082" alt="Screenshot 2026-04-07 at 1 42 40 PM" src="https://github.com/user-attachments/assets/ea7eacb3-9fa1-4ead-8bce-c40be618a0d4" />
<img width="567" height="1082" alt="Screenshot 2026-04-07 at 1 39 55 PM" src="https://github.com/user-attachments/assets/a927d45e-3944-438c-8533-576cc4dcdbcb" />

## Details

### Motivation
The demo app was missing Live Activities support. This brings the Cordova demo in line with the React Native, Flutter, and Unity demos by adding a full Live Activities UI section with delivery tracking status cycling.

### Scope
- **Demo app**: New Live Activities section (iOS only) with Activity ID and Order # inputs, Start/Update/End buttons, and order status cycling (preparing → on the way → delivered)
- **Widget extension**: Replaced placeholder widget with the shared reference implementation using `DefaultLiveActivityAttributes`, featuring lock screen banner, Dynamic Island, and status-based theming
- **API service**: Added `updateLiveActivity` method using `CapacitorHttp.post` to bypass WKWebView CORS restrictions for REST API calls
- **SDK**: Deprecated the `exit` method on `LiveActivities` namespace
- **Build**: Added web asset build step to `setup.sh` before `cap sync`

# Testing

## Manual testing
- Tested on iOS 26.2 simulator
- Verified Live Activities section appears only on iOS
- Tested starting a live activity via `OneSignal.LiveActivities.startDefault`
- Tested updating and ending live activities via REST API
- Verified disabled button states when API key is not configured
- Verified tooltip modal renders above all content

# Affected code checklist
   - [ ] Notifications
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [x] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)