### PR TITLE
ci: [SDK-4486] fix project token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,5 +11,3 @@ concurrency:
 jobs:
   call:
     uses: OneSignal/sdk-shared/.github/workflows/wrapper-js-ci.yml@main
-    with:
-      toolchain: vite-plus

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           # SDK Cross-Platform Project
           project-url: https://github.com/orgs/OneSignal/projects/10
-          github-token: ${{ secrets.GH_PROJECTS_TOKEN }}
+          github-token: ${{ secrets.GH_PUSH_TOKEN }}


### PR DESCRIPTION
# Description

## One Line Summary
Remove the `toolchain: vite-plus` override from the shared JS CI wrapper and switch the project automation workflow to `GH_PUSH_TOKEN`.

## Details

### Motivation
- The shared `wrapper-js-ci.yml` no longer needs an explicit `toolchain` input; defaulting to the wrapper's standard config keeps this repo aligned with the other JS SDKs.
- `GH_PROJECTS_TOKEN` is being retired in favor of the `GH_PUSH_TOKEN` org secret used across the SDK repos for adding issues to the SDK Cross-Platform Project board.

### Scope
Only `.github/workflows/ci.yml` and `.github/workflows/project.yml`. No SDK source code, public API, or runtime behavior changes.

# Testing

## Manual testing
- CI workflow will run on this PR with the default toolchain to confirm it still passes.
- Project workflow will be verified post-merge by opening an issue and confirming it gets added to project 10.

# Affected code checklist

- [ ] Notifications
  - [ ] Display
  - [ ] Open
  - [ ] Push Processing
  - [ ] Confirm Deliveries
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [ ] Public API changes

# Checklist

## Overview
- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing (CI/workflow housekeeping)
- [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
- [x] I have included test coverage for these changes, or explained why they are not needed (CI-only change)
- [x] All automated tests pass, or I explained why that is not possible
- [x] I have personally tested this on my device, or explained why that is not possible (workflow change, validated via CI run / post-merge)

## Final pass
- [x] Code is as readable as possible.
- [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)