### PR TITLE
chore: Release 5.3.11

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -183,7 +183,7 @@ jobs:
           (
             cd examples/demo
             vp run setup || echo "::notice::expected pod install conflict; bumping OneSignalXCFramework"
-            (cd ios/App && pod update OneSignalXCFramework --no-repo-update)
+            (cd ios/App && pod update OneSignalXCFramework)
           )
           echo "✓ Refreshed examples/demo/ios/App/Podfile.lock"
 

--- a/examples/demo/bun.lock
+++ b/examples/demo/bun.lock
@@ -624,7 +624,7 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
-    "onesignal-cordova-plugin": ["onesignal-cordova-plugin@../../onesignal-cordova-plugin.tgz", {}, "sha512-K2dTeS8qEURpFqMMO0ZWZ6+nDXBisZNNuPt2V1n5aGIzUthst74NMHhSQh2urGeoAeyZHIesFr5GvN21H1Tc/g=="],
+    "onesignal-cordova-plugin": ["onesignal-cordova-plugin@../../onesignal-cordova-plugin.tgz", {}, "sha512-q/zsub4zf4cUAGiaPbw4tLu8etFeITbyfOjnAPm+y2YDdqd885dimERlc93wUAiOUrsXgJvyk102YNnSJha9QQ=="],
 
     "open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 

--- a/examples/demo/ios/App/App.xcodeproj/project.pbxproj
+++ b/examples/demo/ios/App/App.xcodeproj/project.pbxproj
@@ -637,7 +637,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 99SW8E36CT;
 				INFOPLIST_FILE = OneSignalNotificationServiceExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.OneSignalNotificationServiceExtensionCordova;
@@ -658,7 +658,7 @@
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 99SW8E36CT;
 				INFOPLIST_FILE = OneSignalNotificationServiceExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.NSE;

--- a/examples/demo/ios/App/Podfile.lock
+++ b/examples/demo/ios/App/Podfile.lock
@@ -12,10 +12,10 @@ PODS:
     - Capacitor
   - CordovaPluginsStatic (8.3.1):
     - CapacitorCordova
-    - OneSignalXCFramework (= 5.5.1)
-  - OneSignalXCFramework (5.5.1):
-    - OneSignalXCFramework/OneSignalComplete (= 5.5.1)
-  - OneSignalXCFramework/OneSignal (5.5.1):
+    - OneSignalXCFramework (= 5.5.2)
+  - OneSignalXCFramework (5.5.2):
+    - OneSignalXCFramework/OneSignalComplete (= 5.5.2)
+  - OneSignalXCFramework/OneSignal (5.5.2):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalExtension
     - OneSignalXCFramework/OneSignalLiveActivities
@@ -23,38 +23,41 @@ PODS:
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalComplete (5.5.1):
+  - OneSignalXCFramework/OneSignalComplete (5.5.2):
     - OneSignalXCFramework/OneSignal
     - OneSignalXCFramework/OneSignalInAppMessages
     - OneSignalXCFramework/OneSignalLocation
-  - OneSignalXCFramework/OneSignalCore (5.5.1)
-  - OneSignalXCFramework/OneSignalExtension (5.5.1):
+  - OneSignalXCFramework/OneSignalCore (5.5.2)
+  - OneSignalXCFramework/OneSignalExtension (5.5.2):
     - OneSignalXCFramework/OneSignalCore
+    - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
-  - OneSignalXCFramework/OneSignalInAppMessages (5.5.1):
+  - OneSignalXCFramework/OneSignalInAppMessages (5.5.2):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalLiveActivities (5.5.1):
+  - OneSignalXCFramework/OneSignalLiveActivities (5.5.2):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalLocation (5.5.1):
+  - OneSignalXCFramework/OneSignalLocation (5.5.2):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalNotifications (5.5.1):
+  - OneSignalXCFramework/OneSignalNotifications (5.5.2):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalExtension
+    - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
-  - OneSignalXCFramework/OneSignalOSCore (5.5.1):
+  - OneSignalXCFramework/OneSignalOSCore (5.5.2):
     - OneSignalXCFramework/OneSignalCore
-  - OneSignalXCFramework/OneSignalOutcomes (5.5.1):
+  - OneSignalXCFramework/OneSignalOutcomes (5.5.2):
     - OneSignalXCFramework/OneSignalCore
-  - OneSignalXCFramework/OneSignalUser (5.5.1):
+    - OneSignalXCFramework/OneSignalOSCore
+  - OneSignalXCFramework/OneSignalUser (5.5.2):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
@@ -97,8 +100,8 @@ SPEC CHECKSUMS:
   CapacitorHaptics: 296f771ecd89c7a1bd92a7b6826a7d268e2e70f5
   CapacitorKeyboard: 31c8285d92c9d1410071d52449f16d2c6673b6f4
   CapacitorStatusBar: 01d5763b4ed720de5ce2edbc938de6a98f4c8f32
-  CordovaPluginsStatic: 0ac3b344dc20172c14778f3b492eecc3d2c7d83c
-  OneSignalXCFramework: 2b46c36b38528b65dce33ed9d83375f8c98bf40c
+  CordovaPluginsStatic: aec218b37b85f783c287b8131dbcd75d69f775c8
+  OneSignalXCFramework: 2f46ff87ccefd9afe8e3b5f9fe357072191205ff
 
 PODFILE CHECKSUM: 892242555b0dc410fc880efd419fbc59f99aa3c7
 

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -5,14 +5,16 @@
   "description": "OneSignal Sample App",
   "scripts": {
     "setup": "../setup.sh",
-    "preandroid": "vp run setup",
-    "preios": "vp run setup",
+    "setup:android": "../setup.sh android",
+    "setup:ios": "../setup.sh ios",
+    "preandroid": "vp run setup:android",
+    "preios": "vp run setup:ios",
     "build": "tsc && vp build",
     "android:sync": "ionic cap sync android",
     "ios:sync": "ionic cap sync ios",
     "android": "ionic cap run android -l --external",
     "ios": "ionic cap run ios -l --external",
-    "update:pods": "(cd ios/App && pod update OneSignalXCFramework --no-repo-update)"
+    "update:pods": "(cd ios/App && pod update OneSignalXCFramework)"
   },
   "dependencies": {
     "@capacitor/android": "^8.3.1",

--- a/examples/demo/src/pages/HomeScreen.css
+++ b/examples/demo/src/pages/HomeScreen.css
@@ -1,6 +1,8 @@
 :root {
   /* Colors */
   --os-primary: #e54b4d;
+  --os-primary-pressed: #c33f41;
+  --os-primary-tint: rgba(229, 75, 77, 0.1);
   --os-success: #34a853;
   --os-grey-700: #616161;
   --os-grey-600: #757575;
@@ -212,6 +214,11 @@
   font-weight: 600;
   letter-spacing: 0.6px;
   margin-bottom: var(--space-card-gap);
+  transition: background-color 100ms ease-out;
+}
+
+.action-btn:active {
+  background: var(--os-primary-pressed);
 }
 
 .action-btn-content {
@@ -237,6 +244,12 @@
   background: transparent;
   border: 1px solid var(--os-primary);
   color: var(--os-primary);
+}
+
+.action-btn.outline:active {
+  background: var(--os-primary-tint);
+  border-color: var(--os-primary-pressed);
+  color: var(--os-primary-pressed);
 }
 
 .action-btn.outline:disabled {

--- a/examples/setup.sh
+++ b/examples/setup.sh
@@ -4,8 +4,17 @@ set -euo pipefail
 # Run from inside any examples/<demo> directory.
 ORIGINAL_DIR=$(pwd)
 SDK_ROOT=$(cd "$ORIGINAL_DIR/../.." && pwd)
+SYNC_PLATFORM="${1:-all}"
 
 info() { echo -e "\033[0;32m[setup]\033[0m $*"; }
+
+case "$SYNC_PLATFORM" in
+  all|android|ios) ;;
+  *)
+    echo "Usage: $0 [all|android|ios]" >&2
+    exit 2
+    ;;
+esac
 
 # ── Plugin tarball cache ─────────────────────────────────────────────────────
 # Skip rebuild/repack/`vp add` when plugin sources haven't changed.
@@ -43,14 +52,32 @@ info "Building web bundle (vite)..."
 vp run build
 
 # ── Capacitor sync cache ─────────────────────────────────────────────────────
-# `cap sync` runs `pod install` + `xcodebuild clean` (~30-60s); skip when
-# inputs are unchanged. Hash sources (not `dist/`) since bundlers emit
-# content-hashed chunk names that can drift between identical builds.
-SYNC_STAMP="$ORIGINAL_DIR/.cap-sync.stamp"
-SYNC_HASH=$(find "$ORIGINAL_DIR/src" "$ORIGINAL_DIR/index.html" \
-                 "$ORIGINAL_DIR/capacitor.config.ts" "$ORIGINAL_DIR/vite.config.ts" \
-                 "$ORIGINAL_DIR/package.json" "$ORIGINAL_DIR/bun.lock" \
-                 "$ORIGINAL_DIR/ios/App" \
+# `cap sync` can run `pod install` + `xcodebuild clean` (~30-60s); skip when
+# inputs are unchanged. Use per-platform stamps so Android-only runs do not
+# touch iOS when CocoaPods is available locally.
+SYNC_STAMP="$ORIGINAL_DIR/.cap-sync-${SYNC_PLATFORM}.stamp"
+SYNC_INPUTS=(
+  "$ORIGINAL_DIR/src"
+  "$ORIGINAL_DIR/index.html"
+  "$ORIGINAL_DIR/capacitor.config.ts"
+  "$ORIGINAL_DIR/vite.config.ts"
+  "$ORIGINAL_DIR/package.json"
+  "$ORIGINAL_DIR/bun.lock"
+)
+
+case "$SYNC_PLATFORM" in
+  android)
+    SYNC_INPUTS+=("$ORIGINAL_DIR/android")
+    ;;
+  ios)
+    SYNC_INPUTS+=("$ORIGINAL_DIR/ios/App")
+    ;;
+  all)
+    SYNC_INPUTS+=("$ORIGINAL_DIR/android" "$ORIGINAL_DIR/ios/App")
+    ;;
+esac
+
+SYNC_HASH=$(find "${SYNC_INPUTS[@]}" \
             -type f \
             ! -path "*/node_modules/*" \
             ! -path "*/Pods/*" \
@@ -69,8 +96,30 @@ SYNC_HASH=$(find "$ORIGINAL_DIR/src" "$ORIGINAL_DIR/index.html" \
             | awk '{print $1}')
 SYNC_HASH="${SYNC_HASH}-${SDK_SRC_HASH}"
 
-if [[ -d "$ORIGINAL_DIR/ios/App/App/public" ]] && [[ -f "$SYNC_STAMP" ]] && [[ "$(cat "$SYNC_STAMP")" == "$SYNC_HASH" ]]; then
+sync_outputs_exist() {
+  case "$SYNC_PLATFORM" in
+    android)
+      [[ -d "$ORIGINAL_DIR/android/app/src/main/assets/public" ]]
+      ;;
+    ios)
+      [[ -d "$ORIGINAL_DIR/ios/App/App/public" ]]
+      ;;
+    all)
+      [[ -d "$ORIGINAL_DIR/android/app/src/main/assets/public" && -d "$ORIGINAL_DIR/ios/App/App/public" ]]
+      ;;
+  esac
+}
+
+if sync_outputs_exist && [[ -f "$SYNC_STAMP" ]] && [[ "$(cat "$SYNC_STAMP")" == "$SYNC_HASH" ]]; then
   info "Capacitor sync inputs unchanged, skipping cap sync"
+elif [[ "$SYNC_PLATFORM" == "android" ]]; then
+  info "Syncing Capacitor Android..."
+  vpx cap sync android
+  echo "$SYNC_HASH" > "$SYNC_STAMP"
+elif [[ "$SYNC_PLATFORM" == "ios" ]]; then
+  info "Syncing Capacitor iOS..."
+  vpx cap sync ios
+  echo "$SYNC_HASH" > "$SYNC_STAMP"
 elif ! command -v pod >/dev/null 2>&1; then
   # CI Android jobs run on Linux where CocoaPods isn't installed.
   # Sync only Android so plain `cap sync` doesn't shell out to pod.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onesignal-cordova-plugin",
-  "version": "5.3.10",
+  "version": "5.3.11",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",
   "keywords": [
     "adm",

--- a/plugin.xml
+++ b/plugin.xml
@@ -26,7 +26,7 @@
   </engines>
 
   <platform name="android">
-    <framework src="com.onesignal:OneSignal:5.9.2" />
+    <framework src="com.onesignal:OneSignal:5.9.3" />
     <framework src="build-extras-onesignal.gradle" custom="true" type="gradleReference" />
 
     <config-file target="res/xml/config.xml" parent="/*">

--- a/plugin.xml
+++ b/plugin.xml
@@ -73,7 +73,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" spec="5.5.1" />
+            <pod name="OneSignalXCFramework" spec="5.5.2" />
         </pods>
     </podspec>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="5.3.10">
+    version="5.3.11">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -373,7 +373,7 @@ public class OneSignalPush extends CordovaPlugin
 
         initDone = true;
         OneSignalWrapper.setSdkType("cordova");
-        OneSignalWrapper.setSdkVersion("050310");
+        OneSignalWrapper.setSdkVersion("050311");
         try {
             String appId = data.getString(0);
             OneSignal.initWithContext(this.cordova.getActivity(), appId);

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -26,11 +26,8 @@
  */
 package com.onesignal.cordova;
 
-import android.app.Activity;
-import android.app.Application;
 import com.onesignal.OneSignal;
 import com.onesignal.common.OneSignalWrapper;
-import com.onesignal.core.internal.application.IApplicationService;
 import com.onesignal.debug.internal.logging.Logging;
 import com.onesignal.inAppMessages.IInAppMessage;
 import com.onesignal.inAppMessages.IInAppMessageClickEvent;
@@ -378,13 +375,6 @@ public class OneSignalPush extends CordovaPlugin
             String appId = data.getString(0);
             OneSignal.initWithContext(this.cordova.getActivity(), appId);
 
-            // If the SDK was initialized from a non-Activity context (FCM/work
-            // managers, SyncJobService) before this call, initWithContext above
-            // short-circuits and ApplicationService.start never re-runs, so its
-            // ALC missed MainActivity.onResume and isInForeground stays false.
-            // Forward the missed events now.
-            nudgeApplicationServiceForeground();
-
             // add listeners
             OneSignal.getInAppMessages().addLifecycleListener(this);
             OneSignal.getInAppMessages().addClickListener(this);
@@ -396,42 +386,6 @@ public class OneSignalPush extends CordovaPlugin
             Logging.error(TAG + "execute: Got JSON Exception " + e.getMessage(), null);
             return false;
         }
-    }
-
-    /**
-     * Forward the missed activity-resume to the SDK so isInForeground is
-     * correct on cold start. No-op if the SDK already saw the resume.
-     *
-     * TODO: Replace with a public native-SDK entry point (e.g.
-     * OneSignal.onActivityForegrounded(Activity)) once the Android SDK
-     * exposes one, instead of casting IApplicationService to
-     * ActivityLifecycleCallbacks here.
-     */
-    private void nudgeApplicationServiceForeground() {
-        final Activity activity = this.cordova.getActivity();
-        if (activity == null) return;
-
-        // cordova.execute() runs on the WebView thread, but Android's
-        // ActivityLifecycleCallbacks are normally invoked on the main thread.
-        // Hop to the UI thread so we don't race real framework callbacks.
-        activity.runOnUiThread(() -> {
-            final Activity currentActivity = this.cordova.getActivity();
-            if (currentActivity == null) return;
-
-            IApplicationService appSvc;
-            try {
-                appSvc = OneSignal.INSTANCE.getServices().getServiceOrNull(IApplicationService.class);
-            } catch (Throwable t) {
-                return;
-            }
-            if (appSvc == null) return;
-            if (appSvc.isInForeground() && appSvc.getCurrent() == currentActivity) return;
-            if (!(appSvc instanceof Application.ActivityLifecycleCallbacks)) return;
-
-            Application.ActivityLifecycleCallbacks callbacks = (Application.ActivityLifecycleCallbacks) appSvc;
-            callbacks.onActivityStarted(currentActivity);
-            callbacks.onActivityResumed(currentActivity);
-        });
     }
 
     @Override

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -119,7 +119,7 @@ void processNotificationClicked(OSNotificationClickEvent *event) {
 
 void initOneSignalObject(NSDictionary *launchOptions) {
   OneSignalWrapper.sdkType = @"cordova";
-  OneSignalWrapper.sdkVersion = @"050310";
+  OneSignalWrapper.sdkVersion = @"050311";
   [OneSignal initialize:nil withLaunchOptions:launchOptions];
 }
 


### PR DESCRIPTION
Channels: Current


### 🛠️ Native Dependency Updates

- Update Android SDK from 5.9.2 to 5.9.3
  - fix: [SDK-4732] track activity lifecycle from process start to fix late-init focus ([#2655](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2655))
  - fix: [SDK-4735] route requestPermission fallbackToSettings to settings when permanently denied ([#2656](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2656))


