### PR TITLE
fix: [SDK-4743] remove Cordova activity lifecycle nudge

### DIFF
--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -26,11 +26,8 @@
  */
 package com.onesignal.cordova;
 
-import android.app.Activity;
-import android.app.Application;
 import com.onesignal.OneSignal;
 import com.onesignal.common.OneSignalWrapper;
-import com.onesignal.core.internal.application.IApplicationService;
 import com.onesignal.debug.internal.logging.Logging;
 import com.onesignal.inAppMessages.IInAppMessage;
 import com.onesignal.inAppMessages.IInAppMessageClickEvent;
@@ -378,13 +375,6 @@ public class OneSignalPush extends CordovaPlugin
             String appId = data.getString(0);
             OneSignal.initWithContext(this.cordova.getActivity(), appId);
 
-            // If the SDK was initialized from a non-Activity context (FCM/work
-            // managers, SyncJobService) before this call, initWithContext above
-            // short-circuits and ApplicationService.start never re-runs, so its
-            // ALC missed MainActivity.onResume and isInForeground stays false.
-            // Forward the missed events now.
-            nudgeApplicationServiceForeground();
-
             // add listeners
             OneSignal.getInAppMessages().addLifecycleListener(this);
             OneSignal.getInAppMessages().addClickListener(this);
@@ -396,42 +386,6 @@ public class OneSignalPush extends CordovaPlugin
             Logging.error(TAG + "execute: Got JSON Exception " + e.getMessage(), null);
             return false;
         }
-    }
-
-    /**
-     * Forward the missed activity-resume to the SDK so isInForeground is
-     * correct on cold start. No-op if the SDK already saw the resume.
-     *
-     * TODO: Replace with a public native-SDK entry point (e.g.
-     * OneSignal.onActivityForegrounded(Activity)) once the Android SDK
-     * exposes one, instead of casting IApplicationService to
-     * ActivityLifecycleCallbacks here.
-     */
-    private void nudgeApplicationServiceForeground() {
-        final Activity activity = this.cordova.getActivity();
-        if (activity == null) return;
-
-        // cordova.execute() runs on the WebView thread, but Android's
-        // ActivityLifecycleCallbacks are normally invoked on the main thread.
-        // Hop to the UI thread so we don't race real framework callbacks.
-        activity.runOnUiThread(() -> {
-            final Activity currentActivity = this.cordova.getActivity();
-            if (currentActivity == null) return;
-
-            IApplicationService appSvc;
-            try {
-                appSvc = OneSignal.INSTANCE.getServices().getServiceOrNull(IApplicationService.class);
-            } catch (Throwable t) {
-                return;
-            }
-            if (appSvc == null) return;
-            if (appSvc.isInForeground() && appSvc.getCurrent() == currentActivity) return;
-            if (!(appSvc instanceof Application.ActivityLifecycleCallbacks)) return;
-
-            Application.ActivityLifecycleCallbacks callbacks = (Application.ActivityLifecycleCallbacks) appSvc;
-            callbacks.onActivityStarted(currentActivity);
-            callbacks.onActivityResumed(currentActivity);
-        });
     }
 
     @Override


### PR DESCRIPTION
# Description

## One Line Summary

Removes the Cordova Android foreground lifecycle nudge now that lifecycle tracking is handled by the core Android SDK.

## Details

### Motivation

SDK-4732 moved activity lifecycle observation into the core Android SDK from process start, so Cordova no longer needs to manually replay activity start/resume callbacks after initialization.

### Scope

This removes the Cordova-only `nudgeApplicationServiceForeground()` helper and its call from Android initialization. It does not change the public JS API or listener registration behavior.

# Testing

Check that the examples do not error. The console in the example app should not be empty.

## Unit testing

- `bun run test`

## Manual testing

- `bun run lint`
- `bun run build`
- `./gradlew :app:compileDebugJavaWithJavac --rerun-tasks` from `examples/demo/android`
- Device/manual notification flow testing was not run.

# Affected code checklist

- [x] Notifications
  - [x] Display
  - [x] Open
  - [ ] Push Processing
  - [ ] Confirm Deliveries
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [ ] Public API changes

# Checklist

## Overview

- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
- [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [x] I have included test coverage for these changes, or explained why they are not needed
- [x] All automated tests pass, or I explained why that is not possible
- [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass

- [x] Code is as readable as possible.
- [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)