### PR TITLE
chore(demo): support release branch pod fallback

### DIFF
--- a/examples/build.md
+++ b/examples/build.md
@@ -58,6 +58,8 @@ vp run android
 
 The demo setup script packs the local Cordova plugin, installs the app dependencies, creates native platforms if needed, and runs Capacitor sync with `ONESIGNAL_DISABLE_LOCATION=true` in the environment. Its normal app flow initializes OneSignal and requests push permission without calling `OneSignal.Location`; the explicit location test button confirms those calls resolve safely when the native location module is absent.
 
+By default, iOS setup validates the generated `OneSignalCordovaDependencies` git source. On `rel/*` branches, the generated Podfile is repointed from the release tag to the matching remote release branch so pre-release validation tests branch HEAD. Use `vp run ios:local` from a demo directory to patch the generated Podfile to the locally packed plugin path while iterating on the podspec.
+
 ### vite-plus / vp toolchain
 
 The demo's `package.json` scripts use `vp` (not plain `bun` or `vite`). `vite.config.ts` imports from `vite-plus` rather than `vite`:

--- a/examples/demo-no-location/README.md
+++ b/examples/demo-no-location/README.md
@@ -11,6 +11,16 @@ vp run ios
 vp run android
 ```
 
+`vp run ios` validates the same CocoaPods source path that consumers use. The generated Podfile resolves `OneSignalCordovaDependencies` from this repository by git tag; when the Cordova SDK checkout is on a `rel/*` branch, setup repoints that generated pod line to the matching remote git branch so pre-release validation exercises branch HEAD before the release tag exists.
+
+For local podspec iteration, use:
+
+```sh
+vp run ios:local
+```
+
+`ios:local` patches the generated Podfile to use the locally packed plugin path instead of the remote git source.
+
 ## Setup
 
 Copy `.env.example` to `.env` and set your OneSignal app ID:
@@ -43,7 +53,7 @@ vpx cap add ios --packagemanager CocoaPods
 
 If an existing generated `ios/` folder is using SPM, the setup script recreates it with CocoaPods.
 
-The setup script also adds the local `OneSignalCordovaDependencies` pod to the generated `ios/App/Podfile` before rerunning CocoaPods.
+By default, setup leaves `OneSignalCordovaDependencies` on the generated git source. Use `vp run ios:local` when you need the helper podspec to come from the local checkout.
 
 The generated iOS app is patched with the Push Notifications entitlement (`aps-environment`) after sync.
 

--- a/examples/demo-no-location/package.json
+++ b/examples/demo-no-location/package.json
@@ -5,13 +5,16 @@
   "type": "module",
   "scripts": {
     "setup": "bash ./setup.sh",
+    "setup:local": "bash ./setup.sh --local-pod",
     "setup:android": "bash ./setup.sh android",
     "setup:ios": "bash ./setup.sh ios",
+    "setup:ios:local": "bash ./setup.sh ios --local-pod",
     "preandroid": "vp run setup:android",
     "preios": "vp run setup:ios",
     "build": "tsc && vp build",
     "android": "ONESIGNAL_DISABLE_LOCATION=true vpx cap run android --no-sync",
     "ios": "ONESIGNAL_DISABLE_LOCATION=true vpx cap run ios --no-sync",
+    "ios:local": "vp run setup:ios:local && ONESIGNAL_DISABLE_LOCATION=true vpx cap run ios --no-sync",
     "android:sync": "ONESIGNAL_DISABLE_LOCATION=true vpx cap sync android",
     "ios:sync": "ONESIGNAL_DISABLE_LOCATION=true vpx cap sync ios"
   },

--- a/examples/demo-no-location/setup.sh
+++ b/examples/demo-no-location/setup.sh
@@ -115,6 +115,7 @@ run_capacitor_sync() {
 
   if [[ "$USE_LOCAL_POD" == true ]]; then
     patch_ios_podfile_local
+    info "Using OneSignalCordovaDependencies from the local plugin path."
     install_or_update_pods
 
     if [[ "$status" -ne 0 ]]; then
@@ -123,13 +124,20 @@ run_capacitor_sync() {
     return
   fi
 
-  if [[ "$status" -ne 0 ]]; then
-    if ! patch_ios_podfile_git_branch; then
-      return "$status"
-    fi
+  if patch_ios_podfile_git_branch; then
     install_or_update_pods
-    info "Recovered iOS sync after repointing OneSignalCordovaDependencies to the release branch."
+
+    if [[ "$status" -ne 0 ]]; then
+      info "Recovered iOS sync after repointing OneSignalCordovaDependencies to the release branch."
+    fi
+    return
   fi
+
+  if [[ "$status" -ne 0 ]]; then
+    return "$status"
+  fi
+
+  info "Using OneSignalCordovaDependencies from the generated git tag."
 }
 
 patch_ios_apns_capability() {

--- a/examples/demo-no-location/setup.sh
+++ b/examples/demo-no-location/setup.sh
@@ -3,16 +3,21 @@ set -euo pipefail
 
 DEMO_DIR=$(cd "$(dirname "$0")" && pwd)
 SDK_ROOT=$(cd "$DEMO_DIR/../.." && pwd)
-SYNC_PLATFORM="${1:-all}"
+SYNC_PLATFORM="all"
+USE_LOCAL_POD=false
 export ONESIGNAL_DISABLE_LOCATION=true
 
 info() { echo -e "\033[0;32m[demo-no-location]\033[0m $*"; }
 
-patch_ios_podfile() {
+usage() {
+  echo "Usage: $0 [all|android|ios] [--local-pod]" >&2
+}
+
+patch_ios_podfile_local() {
   local podfile="$DEMO_DIR/ios/App/Podfile"
 
   if [[ ! -f "$podfile" ]]; then
-    return
+    return 1
   fi
 
   PODFILE="$podfile" python3 <<'PY'
@@ -37,6 +42,56 @@ podfile.write_text(text)
 PY
 }
 
+patch_ios_podfile_git_branch() {
+  local podfile="$DEMO_DIR/ios/App/Podfile"
+  local branch
+
+  if [[ ! -f "$podfile" ]]; then
+    return 1
+  fi
+
+  branch=$(git -C "$SDK_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  if [[ "$branch" != rel/* ]]; then
+    return 1
+  fi
+
+  info "Repointing OneSignalCordovaDependencies pod to git branch ${branch}..."
+  PODFILE="$podfile" BRANCH="$branch" python3 <<'PY'
+import os
+import re
+from pathlib import Path
+
+podfile = Path(os.environ["PODFILE"])
+branch = os.environ["BRANCH"]
+text = podfile.read_text()
+pod_line = (
+    "  pod 'OneSignalCordovaDependencies', "
+    ":git => 'https://github.com/OneSignal/OneSignal-Cordova-SDK.git', "
+    f":branch => '{branch}'"
+)
+
+text, count = re.subn(
+    r"^.*pod 'OneSignalCordovaDependencies'.*\n",
+    f"{pod_line}\n",
+    text,
+    flags=re.MULTILINE,
+)
+if count == 0:
+    raise SystemExit("Unable to find OneSignalCordovaDependencies pod in Podfile")
+
+podfile.write_text(text)
+PY
+}
+
+install_or_update_pods() {
+  local app_dir="$DEMO_DIR/ios/App"
+
+  if ! (cd "$app_dir" && pod install); then
+    info "Refreshing OneSignalXCFramework after local dependency changes..."
+    (cd "$app_dir" && pod update OneSignalXCFramework)
+  fi
+}
+
 run_capacitor_sync() {
   local platform="${1:-all}"
   local status=0
@@ -58,14 +113,22 @@ run_capacitor_sync() {
     return "$status"
   fi
 
-  patch_ios_podfile
-  if ! (cd "$DEMO_DIR/ios/App" && pod install); then
-    info "Refreshing OneSignalXCFramework after local dependency changes..."
-    (cd "$DEMO_DIR/ios/App" && pod update OneSignalXCFramework)
+  if [[ "$USE_LOCAL_POD" == true ]]; then
+    patch_ios_podfile_local
+    install_or_update_pods
+
+    if [[ "$status" -ne 0 ]]; then
+      info "Recovered iOS sync after repointing OneSignalCordovaDependencies to the local plugin."
+    fi
+    return
   fi
 
   if [[ "$status" -ne 0 ]]; then
-    info "Recovered iOS sync after repointing OneSignalCordovaDependencies to the local plugin."
+    if ! patch_ios_podfile_git_branch; then
+      return "$status"
+    fi
+    install_or_update_pods
+    info "Recovered iOS sync after repointing OneSignalCordovaDependencies to the release branch."
   fi
 }
 
@@ -129,13 +192,20 @@ project_file.write_text(text)
 PY
 }
 
-case "$SYNC_PLATFORM" in
-  all|android|ios) ;;
-  *)
-    echo "Usage: $0 [all|android|ios]" >&2
-    exit 2
-    ;;
-esac
+for arg in "$@"; do
+  case "$arg" in
+    all|android|ios)
+      SYNC_PLATFORM="$arg"
+      ;;
+    --local-pod)
+      USE_LOCAL_POD=true
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
 
 info "Building Cordova plugin and packing local tarball..."
 (cd "$SDK_ROOT" && vp run build)
@@ -186,7 +256,11 @@ if [[ "$SYNC_PLATFORM" == "all" || "$SYNC_PLATFORM" == "ios" ]]; then
         info "Patching generated Podfile before rerunning CocoaPods..."
       fi
     fi
-    patch_ios_podfile
+    if [[ "$USE_LOCAL_POD" == true ]]; then
+      patch_ios_podfile_local
+    else
+      patch_ios_podfile_git_branch || true
+    fi
   fi
 fi
 
@@ -196,12 +270,10 @@ case "$SYNC_PLATFORM" in
     run_capacitor_sync android
     ;;
   ios)
-    patch_ios_podfile
     run_capacitor_sync ios
     patch_ios_apns_capability
     ;;
   all)
-    patch_ios_podfile
     run_capacitor_sync all
     patch_ios_apns_capability
     ;;

--- a/examples/demo/ios/App/Podfile
+++ b/examples/demo/ios/App/Podfile
@@ -15,7 +15,7 @@ def capacitor_pods
   pod 'CapacitorHaptics', :path => '../../node_modules/@capacitor/haptics'
   pod 'CapacitorKeyboard', :path => '../../node_modules/@capacitor/keyboard'
   pod 'CapacitorStatusBar', :path => '../../node_modules/@capacitor/status-bar'
-  pod 'OneSignalCordovaDependencies', :path => '../../node_modules/onesignal-cordova-plugin'
+  pod 'OneSignalCordovaDependencies', :git => 'https://github.com/OneSignal/OneSignal-Cordova-SDK.git', :tag => '5.4.0'
   pod 'CordovaPluginsStatic', :path => '../capacitor-cordova-ios-plugins'
 end
 

--- a/examples/demo/ios/App/Podfile.lock
+++ b/examples/demo/ios/App/Podfile.lock
@@ -13,11 +13,11 @@ PODS:
   - CordovaPluginsStatic (8.3.1):
     - CapacitorCordova
     - OneSignalCordovaDependencies
-  - OneSignalCordovaDependencies (5.3.11):
-    - OneSignalXCFramework (= 5.5.2)
-  - OneSignalXCFramework (5.5.2):
-    - OneSignalXCFramework/OneSignalComplete (= 5.5.2)
-  - OneSignalXCFramework/OneSignal (5.5.2):
+  - OneSignalCordovaDependencies (5.4.0):
+    - OneSignalXCFramework (= 5.5.3)
+  - OneSignalXCFramework (5.5.3):
+    - OneSignalXCFramework/OneSignalComplete (= 5.5.3)
+  - OneSignalXCFramework/OneSignal (5.5.3):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalExtension
     - OneSignalXCFramework/OneSignalLiveActivities
@@ -73,7 +73,7 @@ DEPENDENCIES:
   - "CapacitorKeyboard (from `../../node_modules/@capacitor/keyboard`)"
   - "CapacitorStatusBar (from `../../node_modules/@capacitor/status-bar`)"
   - CordovaPluginsStatic (from `../capacitor-cordova-ios-plugins`)
-  - OneSignalCordovaDependencies (from `../../node_modules/onesignal-cordova-plugin`)
+  - OneSignalCordovaDependencies (from `https://github.com/OneSignal/OneSignal-Cordova-SDK.git`, tag `5.4.0`)
   - OneSignalXCFramework (< 6.0, >= 5.0.0)
 
 SPEC REPOS:
@@ -96,19 +96,25 @@ EXTERNAL SOURCES:
   CordovaPluginsStatic:
     :path: "../capacitor-cordova-ios-plugins"
   OneSignalCordovaDependencies:
-    :path: "../../node_modules/onesignal-cordova-plugin"
+    :git: https://github.com/OneSignal/OneSignal-Cordova-SDK.git
+    :tag: 5.4.0
+
+CHECKOUT OPTIONS:
+  OneSignalCordovaDependencies:
+    :git: https://github.com/OneSignal/OneSignal-Cordova-SDK.git
+    :tag: 5.4.0
 
 SPEC CHECKSUMS:
-  Capacitor: 66895d1f43f02264d13e9eb1ea3fbc9c3e02224b
-  CapacitorApp: a4d8d936cc4390859a3766f141048abe55d4076f
+  Capacitor: 46dbaa89c1d1cd121b9fc2dc839c1f39cc49e326
+  CapacitorApp: 449ffe26375e96f8aaaee625ac6e01e5c57c8650
   CapacitorCordova: 9010447fe25e869705fcf525e5f490facde87608
   CapacitorHaptics: 296f771ecd89c7a1bd92a7b6826a7d268e2e70f5
   CapacitorKeyboard: 31c8285d92c9d1410071d52449f16d2c6673b6f4
   CapacitorStatusBar: 01d5763b4ed720de5ce2edbc938de6a98f4c8f32
   CordovaPluginsStatic: 4f45b329e013a402b361c251628627e6774346b4
-  OneSignalCordovaDependencies: 39921fded1ab05f190a3c8031a803e356612d48e
-  OneSignalXCFramework: 2f46ff87ccefd9afe8e3b5f9fe357072191205ff
+  OneSignalCordovaDependencies: 78aff5a33f7e668a32d84ce71d9a1c3288574fe8
+  OneSignalXCFramework: f4505256255ae5fccfd33ba2eb1871ba2d4ce2bb
 
-PODFILE CHECKSUM: 82a91c3e1495dadbc5694e747bd1fb2cdb79ddab
+PODFILE CHECKSUM: 41493d2e61efb661f5db5bac4ca58c0471d9f36f
 
 COCOAPODS: 1.16.2

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -5,8 +5,10 @@
   "description": "OneSignal Sample App",
   "scripts": {
     "setup": "../setup.sh",
+    "setup:local": "../setup.sh --local-pod",
     "setup:android": "../setup.sh android",
     "setup:ios": "../setup.sh ios",
+    "setup:ios:local": "../setup.sh ios --local-pod",
     "preandroid": "vp run setup:android",
     "preios": "vp run setup:ios",
     "build": "tsc && vp build",
@@ -14,6 +16,7 @@
     "ios:sync": "ionic cap sync ios",
     "android": "ionic cap run android -l --external",
     "ios": "ionic cap run ios -l --external",
+    "ios:local": "vp run setup:ios:local && ionic cap run ios -l --external --no-sync",
     "update:pods": "(cd ios/App && pod update OneSignalXCFramework)"
   },
   "dependencies": {

--- a/examples/setup.sh
+++ b/examples/setup.sh
@@ -115,6 +115,7 @@ run_capacitor_sync() {
 
   if [[ "$USE_LOCAL_POD" == true ]]; then
     patch_ios_podfile_local
+    info "Using OneSignalCordovaDependencies from the local plugin path."
     install_or_update_pods
 
     if [[ "$status" -ne 0 ]]; then
@@ -123,13 +124,20 @@ run_capacitor_sync() {
     return
   fi
 
-  if [[ "$status" -ne 0 ]]; then
-    if ! patch_ios_podfile_git_branch; then
-      return "$status"
-    fi
+  if patch_ios_podfile_git_branch; then
     install_or_update_pods
-    info "Recovered iOS sync after repointing OneSignalCordovaDependencies to the release branch."
+
+    if [[ "$status" -ne 0 ]]; then
+      info "Recovered iOS sync after repointing OneSignalCordovaDependencies to the release branch."
+    fi
+    return
   fi
+
+  if [[ "$status" -ne 0 ]]; then
+    return "$status"
+  fi
+
+  info "Using OneSignalCordovaDependencies from the generated git tag."
 }
 
 for arg in "$@"; do

--- a/examples/setup.sh
+++ b/examples/setup.sh
@@ -4,15 +4,20 @@ set -euo pipefail
 # Run from inside any examples/<demo> directory.
 ORIGINAL_DIR=$(pwd)
 SDK_ROOT=$(cd "$ORIGINAL_DIR/../.." && pwd)
-SYNC_PLATFORM="${1:-all}"
+SYNC_PLATFORM="all"
+USE_LOCAL_POD=false
 
 info() { echo -e "\033[0;32m[setup]\033[0m $*"; }
 
-patch_ios_podfile() {
+usage() {
+  echo "Usage: $0 [all|android|ios] [--local-pod]" >&2
+}
+
+patch_ios_podfile_local() {
   local podfile="$ORIGINAL_DIR/ios/App/Podfile"
 
   if [[ ! -f "$podfile" ]]; then
-    return
+    return 1
   fi
 
   PODFILE="$podfile" python3 <<'PY'
@@ -37,6 +42,56 @@ podfile.write_text(text)
 PY
 }
 
+patch_ios_podfile_git_branch() {
+  local podfile="$ORIGINAL_DIR/ios/App/Podfile"
+  local branch
+
+  if [[ ! -f "$podfile" ]]; then
+    return 1
+  fi
+
+  branch=$(git -C "$SDK_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  if [[ "$branch" != rel/* ]]; then
+    return 1
+  fi
+
+  info "Repointing OneSignalCordovaDependencies pod to git branch ${branch}..."
+  PODFILE="$podfile" BRANCH="$branch" python3 <<'PY'
+import os
+import re
+from pathlib import Path
+
+podfile = Path(os.environ["PODFILE"])
+branch = os.environ["BRANCH"]
+text = podfile.read_text()
+pod_line = (
+    "  pod 'OneSignalCordovaDependencies', "
+    ":git => 'https://github.com/OneSignal/OneSignal-Cordova-SDK.git', "
+    f":branch => '{branch}'"
+)
+
+text, count = re.subn(
+    r"^.*pod 'OneSignalCordovaDependencies'.*\n",
+    f"{pod_line}\n",
+    text,
+    flags=re.MULTILINE,
+)
+if count == 0:
+    raise SystemExit("Unable to find OneSignalCordovaDependencies pod in Podfile")
+
+podfile.write_text(text)
+PY
+}
+
+install_or_update_pods() {
+  local app_dir="$ORIGINAL_DIR/ios/App"
+
+  if ! (cd "$app_dir" && pod install); then
+    info "Refreshing OneSignalXCFramework after local dependency changes..."
+    (cd "$app_dir" && pod update OneSignalXCFramework)
+  fi
+}
+
 run_capacitor_sync() {
   local platform="${1:-all}"
   local status=0
@@ -58,24 +113,39 @@ run_capacitor_sync() {
     return "$status"
   fi
 
-  patch_ios_podfile
-  if ! (cd "$ORIGINAL_DIR/ios/App" && pod install); then
-    info "Refreshing OneSignalXCFramework after local dependency changes..."
-    (cd "$ORIGINAL_DIR/ios/App" && pod update OneSignalXCFramework)
+  if [[ "$USE_LOCAL_POD" == true ]]; then
+    patch_ios_podfile_local
+    install_or_update_pods
+
+    if [[ "$status" -ne 0 ]]; then
+      info "Recovered iOS sync after repointing OneSignalCordovaDependencies to the local plugin."
+    fi
+    return
   fi
 
   if [[ "$status" -ne 0 ]]; then
-    info "Recovered iOS sync after repointing OneSignalCordovaDependencies to the local plugin."
+    if ! patch_ios_podfile_git_branch; then
+      return "$status"
+    fi
+    install_or_update_pods
+    info "Recovered iOS sync after repointing OneSignalCordovaDependencies to the release branch."
   fi
 }
 
-case "$SYNC_PLATFORM" in
-  all|android|ios) ;;
-  *)
-    echo "Usage: $0 [all|android|ios]" >&2
-    exit 2
-    ;;
-esac
+for arg in "$@"; do
+  case "$arg" in
+    all|android|ios)
+      SYNC_PLATFORM="$arg"
+      ;;
+    --local-pod)
+      USE_LOCAL_POD=true
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
 
 # ── Plugin tarball cache ─────────────────────────────────────────────────────
 # Skip rebuild/repack/`vp add` when plugin sources haven't changed.


### PR DESCRIPTION
# Description

## One Line Summary

Adds Cordova demo setup support for release-branch pod recovery and explicit local pod setup.

## Details

With the new ability to exclude location module for iOS and Android, we change pod installation path to use git clone of this sdk repo.
So we need flags like --local-pod to patch the pod installation path so we can test for release branches since new version wouldn't be available for the git installation path of our pod.

### Motivation

Cordova iOS demo setup can fail when `OneSignalCordovaDependencies` needs to resolve from the active Cordova release branch instead of the locally packed plugin. This PR makes the demo setup scripts recover that state while keeping local pod development available through an explicit `--local-pod` mode.

### Scope

- Adds `--local-pod` handling to the Cordova demo setup scripts.
- Adds package scripts for local iOS setup/run flows.
- Repoints `OneSignalCordovaDependencies` to the active `rel/*` branch when iOS sync fails and a release branch is available.
- Refreshes CocoaPods through `pod install` with a `pod update OneSignalXCFramework` fallback.
- Does not change Cordova plugin runtime APIs or notification behavior.

# Testing

Check that the examples do not error. The console in the example app should not be empty.

## Unit testing

Not added; this change is limited to demo setup shell scripts and generated example Pod state.

## Manual testing

Not run for this PR update. Branch was clean and already pushed before PR creation.

# Affected code checklist

- [ ] Notifications
  - [ ] Display
  - [ ] Open
  - [ ] Push Processing
  - [ ] Confirm Deliveries
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [ ] Public API changes

# Checklist

## Overview

- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
  - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
- [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [x] I have included test coverage for these changes, or explained why they are not needed
- [x] All automated tests pass, or I explained why that is not possible
- [x] I have personally tested this on my device, or explained why that is not possible

## Final pass

- [x] Code is as readable as possible.
  - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
- [x] I have reviewed this PR myself, ensuring it meets each checklist item
  - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with \"WIP\" to indicate this.

Made with [Cursor](https://cursor.com)