### PR TITLE
chore: Release 5.4.1

### DIFF
--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -11,7 +11,7 @@ def isOneSignalEnvFlagEnabled(String envName) {
   return value?.equalsIgnoreCase('true') || value == '1'
 }
 
-def oneSignalVersion = '5.9.4'
+def oneSignalVersion = '5.9.5'
 def oneSignalDisableLocation = isOneSignalEnvFlagEnabled('ONESIGNAL_DISABLE_LOCATION')
 
 dependencies {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onesignal-cordova-plugin",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",
   "keywords": [
     "adm",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="5.4.0">
+    version="5.4.1">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -72,7 +72,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalCordovaDependencies" git="https://github.com/OneSignal/OneSignal-Cordova-SDK.git" tag="5.4.0" />
+            <pod name="OneSignalCordovaDependencies" git="https://github.com/OneSignal/OneSignal-Cordova-SDK.git" tag="5.4.1" />
         </pods>
     </podspec>
 

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -370,7 +370,7 @@ public class OneSignalPush extends CordovaPlugin
 
         initDone = true;
         OneSignalWrapper.setSdkType("cordova");
-        OneSignalWrapper.setSdkVersion("050400");
+        OneSignalWrapper.setSdkVersion("050401");
         try {
             String appId = data.getString(0);
             OneSignal.initWithContext(this.cordova.getActivity(), appId);

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -119,7 +119,7 @@ void processNotificationClicked(OSNotificationClickEvent *event) {
 
 void initOneSignalObject(NSDictionary *launchOptions) {
   OneSignalWrapper.sdkType = @"cordova";
-  OneSignalWrapper.sdkVersion = @"050400";
+  OneSignalWrapper.sdkVersion = @"050401";
   [OneSignal initialize:nil withLaunchOptions:launchOptions];
 }
 


### PR DESCRIPTION
Channels: Current


### 🛠️ Native Dependency Updates

- Update Android SDK from 5.9.4 to 5.9.5
  - fix(notifications): guard against null PendingResult from goAsync() [SDK-4803] ([#2667](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2667))
  - fix: prevent location permission crashes from FusedLocation API calls ([#2653](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2653))
  - fix: [SDK-4672] start location updates when permission is granted ([#2663](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2663))
  - fix: [SDK-4793] prevent main-thread ANR in blocking SDK APIs during/after init ([#2666](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2666))
  - fix: [SDK-4794] prewarm dispatchers at cold-start entry points ([#2664](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2664))


