### PR TITLE
chore: Release 5.5.1

### DIFF
--- a/OneSignalCordovaDependencies.podspec
+++ b/OneSignalCordovaDependencies.podspec
@@ -1,7 +1,7 @@
 require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
-onesignal_xcframework_version = '5.5.3'
+onesignal_xcframework_version = '5.5.4'
 onesignal_disable_location_env = ENV['ONESIGNAL_DISABLE_LOCATION'].to_s.strip.downcase
 onesignal_disable_location = ['true', '1'].include?(onesignal_disable_location_env)
 

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apache/cordova-ios.git", from: "8.0.0"),
-        .package(url: "https://github.com/OneSignal/OneSignal-XCFramework.git", exact: "5.5.3"),
+        .package(url: "https://github.com/OneSignal/OneSignal-XCFramework.git", exact: "5.5.4"),
     ],
     targets: [
         .target(

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -11,7 +11,7 @@ def isOneSignalEnvFlagEnabled(String envName) {
   return value?.equalsIgnoreCase('true') || value == '1'
 }
 
-def oneSignalVersion = '5.9.5'
+def oneSignalVersion = '5.9.6'
 def oneSignalDisableLocation = isOneSignalEnvFlagEnabled('ONESIGNAL_DISABLE_LOCATION')
 
 dependencies {

--- a/examples/demo/bun.lock
+++ b/examples/demo/bun.lock
@@ -624,7 +624,7 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
-    "onesignal-cordova-plugin": ["onesignal-cordova-plugin@../../onesignal-cordova-plugin.tgz", {}, "sha512-roQ9qUclbyJspHHz3WqmSoJ1D5EsUQbJWRBEr/uRZUapdO8/+VDq04c1PP7mjF7FiNCgeoeFZHDEj8ASdn/kjw=="],
+    "onesignal-cordova-plugin": ["onesignal-cordova-plugin@../../onesignal-cordova-plugin.tgz", {}, "sha512-c0ZqoXB7LVGoR+VsQlG0sfSG1J559bN1Jmt6ozNcBHe1O4gKi+nmKo3XGivHlSXDmp4R49gzaPE5ipAf6JhETg=="],
 
     "open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 

--- a/examples/demo/ios/App/App.xcodeproj/project.pbxproj
+++ b/examples/demo/ios/App/App.xcodeproj/project.pbxproj
@@ -384,7 +384,7 @@
 			repositoryURL = "https://github.com/OneSignal/OneSignal-XCFramework.git";
 			requirement = {
 				kind = exactVersion;
-				version = 5.5.3;
+				version = 5.5.4;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/demo/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/examples/demo/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "af65d5207ca8aed0b5bf5ba5ee309d8dd14489abbe6009d3dbd1e1869f7103cf",
+  "originHash" : "e75a7350e7c492bd151338671f0ed43dac7c1677096fa3f6a1771c24109ddb75",
   "pins" : [
     {
       "identity" : "capacitor-swift-pm",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/OneSignal/OneSignal-XCFramework.git",
       "state" : {
-        "revision" : "af871d3492e3dd233eb456b550aa53ce33d26c2d",
-        "version" : "5.5.3"
+        "revision" : "b4a4010657c7d79ca669159bbfcb5da60bb28c8d",
+        "version" : "5.5.4"
       }
     }
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onesignal-cordova-plugin",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",
   "keywords": [
     "adm",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="5.5.0">
+    version="5.5.1">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -72,7 +72,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalCordovaDependencies" git="https://github.com/OneSignal/OneSignal-Cordova-SDK.git" tag="5.5.0" nospm="true" />
+            <pod name="OneSignalCordovaDependencies" git="https://github.com/OneSignal/OneSignal-Cordova-SDK.git" tag="5.5.1" nospm="true" />
         </pods>
     </podspec>
 

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -370,7 +370,7 @@ public class OneSignalPush extends CordovaPlugin
 
         initDone = true;
         OneSignalWrapper.setSdkType("cordova");
-        OneSignalWrapper.setSdkVersion("050500");
+        OneSignalWrapper.setSdkVersion("050501");
         try {
             String appId = data.getString(0);
             OneSignal.initWithContext(this.cordova.getActivity(), appId);

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -119,7 +119,7 @@ void processNotificationClicked(OSNotificationClickEvent *event) {
 
 void initOneSignalObject(NSDictionary *launchOptions) {
   OneSignalWrapper.sdkType = @"cordova";
-  OneSignalWrapper.sdkVersion = @"050500";
+  OneSignalWrapper.sdkVersion = @"050501";
   [OneSignal initialize:nil withLaunchOptions:launchOptions];
 }
 


### PR DESCRIPTION
Channels: Current

### 🛠️ Native Dependency Updates

- Update Android SDK from 5.9.5 to 5.9.6
  - fix: [SDK-4513] display queued in-app messages on unpause when triggers still match ([#2682](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2682))
  - fix: [SDK-4734] move HMS notification finish() inside coroutine so entryState is set before trampoline stops ([#2678](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2678))
  - fix: [SDK-4792] keep devices subscribed when a push token fetch temporarily fails ([#2670](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2670))
  - fix: [SDK-4820] ship consumer dontwarn rule for OpenTelemetry to prevent R8 missing-class build failures ([#2677](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2677))
  - fix: [SDK-4822] make ANR watchdog app-state aware to stop false background ANRs ([#2676](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2676))
  - fix: [SDK-4841] prewarm dispatchers at process start via ActivityLifecycleInitializer ([#2680](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2680))
  - fix: [SDK-4845] always finish base notification trampoline via finally ([#2681](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2681))
- Update iOS SDK from 5.5.3 to 5.5.4
  - fix: [SDK-4814] Live Activities Confirmed Receipts exceeding Delivered count ([OneSignal-iOS-SDK#1681](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1681))
  - fix: restore local tags cleared by a concurrent FetchUser ([OneSignal-iOS-SDK#1678](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1678))
  - fix: [SDK-4757] recover startup when initialized before UIApplicationMain ([OneSignal-iOS-SDK#1677](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1677))
