### PR TITLE
chore: Release 5.5.2

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -105,10 +105,10 @@ jobs:
           VERSION="${{ inputs.android_version }}"
 
           # Validate version exists on GitHub
-          RELEASE=$(curl -s -H "Authorization: token ${{ github.token }}" \
-            "https://api.github.com/repos/OneSignal/OneSignal-Android-SDK/releases/tags/${VERSION}")
-
-          if [ -z "$RELEASE" ]; then
+          if ! curl --fail --silent --show-error --retry 4 --retry-delay 30 \
+            -H "Authorization: token ${{ github.token }}" \
+            "https://api.github.com/repos/OneSignal/OneSignal-Android-SDK/releases/tags/${VERSION}" \
+            >/dev/null; then
             echo "✗ Android SDK version ${VERSION} not found on GitHub"
             exit 1
           fi
@@ -129,10 +129,10 @@ jobs:
           VERSION="${{ inputs.ios_version }}"
 
           # Validate version exists on GitHub
-          RELEASE=$(curl -s -H "Authorization: token ${{ github.token }}" \
-            "https://api.github.com/repos/OneSignal/OneSignal-iOS-SDK/releases/tags/${VERSION}")
-
-          if [ -z "$RELEASE" ]; then
+          if ! curl --fail --silent --show-error --retry 4 --retry-delay 30 \
+            -H "Authorization: token ${{ github.token }}" \
+            "https://api.github.com/repos/OneSignal/OneSignal-iOS-SDK/releases/tags/${VERSION}" \
+            >/dev/null; then
             echo "✗ iOS SDK version ${VERSION} not found"
             exit 1
           fi

--- a/OneSignalCordovaDependencies.podspec
+++ b/OneSignalCordovaDependencies.podspec
@@ -1,7 +1,7 @@
 require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
-onesignal_xcframework_version = '5.5.4'
+onesignal_xcframework_version = '5.5.5'
 onesignal_disable_location_env = ENV['ONESIGNAL_DISABLE_LOCATION'].to_s.strip.downcase
 onesignal_disable_location = ['true', '1'].include?(onesignal_disable_location_env)
 

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apache/cordova-ios.git", from: "8.0.0"),
-        .package(url: "https://github.com/OneSignal/OneSignal-XCFramework.git", exact: "5.5.4"),
+        .package(url: "https://github.com/OneSignal/OneSignal-XCFramework.git", exact: "5.5.5"),
     ],
     targets: [
         .target(

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -11,7 +11,7 @@ def isOneSignalEnvFlagEnabled(String envName) {
   return value?.equalsIgnoreCase('true') || value == '1'
 }
 
-def oneSignalVersion = '5.9.6'
+def oneSignalVersion = '5.9.7'
 def oneSignalDisableLocation = isOneSignalEnvFlagEnabled('ONESIGNAL_DISABLE_LOCATION')
 
 dependencies {

--- a/examples/demo/bun.lock
+++ b/examples/demo/bun.lock
@@ -624,7 +624,7 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
-    "onesignal-cordova-plugin": ["onesignal-cordova-plugin@../../onesignal-cordova-plugin.tgz", {}, "sha512-c0ZqoXB7LVGoR+VsQlG0sfSG1J559bN1Jmt6ozNcBHe1O4gKi+nmKo3XGivHlSXDmp4R49gzaPE5ipAf6JhETg=="],
+    "onesignal-cordova-plugin": ["onesignal-cordova-plugin@../../onesignal-cordova-plugin.tgz", {}, "sha512-mEMg4oFruQrp1Sp5aMnZ9eDT2kZCb5pRCf0Jy1fono6/1BRGx3fE4zcB447QJMjNu3CHaeQMAceNTy7BjjIL4A=="],
 
     "open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 

--- a/examples/demo/ios/App/App.xcodeproj/project.pbxproj
+++ b/examples/demo/ios/App/App.xcodeproj/project.pbxproj
@@ -384,7 +384,7 @@
 			repositoryURL = "https://github.com/OneSignal/OneSignal-XCFramework.git";
 			requirement = {
 				kind = exactVersion;
-				version = 5.5.4;
+				version = 5.5.5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/demo/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/examples/demo/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/OneSignal/OneSignal-XCFramework.git",
       "state" : {
-        "revision" : "b4a4010657c7d79ca669159bbfcb5da60bb28c8d",
-        "version" : "5.5.4"
+        "revision" : "e05f7193577ddf57f6bfe57776a56a16081db2e5",
+        "version" : "5.5.5"
       }
     }
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onesignal-cordova-plugin",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",
   "keywords": [
     "adm",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="5.5.1">
+    version="5.5.2">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -72,7 +72,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalCordovaDependencies" git="https://github.com/OneSignal/OneSignal-Cordova-SDK.git" tag="5.5.1" nospm="true" />
+            <pod name="OneSignalCordovaDependencies" git="https://github.com/OneSignal/OneSignal-Cordova-SDK.git" tag="5.5.2" nospm="true" />
         </pods>
     </podspec>
 

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -370,7 +370,7 @@ public class OneSignalPush extends CordovaPlugin
 
         initDone = true;
         OneSignalWrapper.setSdkType("cordova");
-        OneSignalWrapper.setSdkVersion("050501");
+        OneSignalWrapper.setSdkVersion("050502");
         try {
             String appId = data.getString(0);
             OneSignal.initWithContext(this.cordova.getActivity(), appId);

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -119,7 +119,7 @@ void processNotificationClicked(OSNotificationClickEvent *event) {
 
 void initOneSignalObject(NSDictionary *launchOptions) {
   OneSignalWrapper.sdkType = @"cordova";
-  OneSignalWrapper.sdkVersion = @"050501";
+  OneSignalWrapper.sdkVersion = @"050502";
   [OneSignal initialize:nil withLaunchOptions:launchOptions];
 }
 


### PR DESCRIPTION
Channels: Current

### 🛠️ Native Dependency Updates

- Update Android SDK from 5.9.6 to 5.9.7
  - fix: narrow overly broad consumer ProGuard/R8 keep rules ([#2679](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2679))
  - fix: preserve WorkDatabase constructor under R8 ([#2685](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2685))
- Update iOS SDK from 5.5.4 to 5.5.5
  - fix: single-flight UpdateSubscription to stop in-flight PATCH races ([OneSignal-iOS-SDK#1689](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1689))
  - fix: prevent stale UpdateSubscription leaving users Never Subscribed ([OneSignal-iOS-SDK#1687](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1687))
