### PR TITLE
fix(demo): add shared App scheme for headless Appium iOS build

### DIFF
--- a/examples/demo/ios/App/App.xcodeproj/xcshareddata/xcschemes/App.xcscheme
+++ b/examples/demo/ios/App/App.xcodeproj/xcshareddata/xcschemes/App.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Committed intentionally: `cap add ios`/setup.sh don't emit a shared "App"
+     scheme and xcodebuild only auto-creates schemes in the IDE, so headless
+     CI builds (`xcodebuild -scheme App`) for the Appium E2E suite fail without
+     this file. -->
+<Scheme
+   LastUpgradeVersion="1500"
+   version="1.7">
+   <BuildAction
+      parallelizeBuildables="YES"
+      buildImplicitDependencies="YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting="YES"
+            buildForRunning="YES"
+            buildForProfiling="YES"
+            buildForArchiving="YES"
+            buildForAnalyzing="YES">
+            <BuildableReference
+               BuildableIdentifier="primary"
+               BlueprintIdentifier="504EC3031FED79650016851F"
+               BuildableName="App.app"
+               BlueprintName="App"
+               ReferencedContainer="container:App.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration="Debug"
+      selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv="YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration="Debug"
+      selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle="0"
+      useCustomWorkingDirectory="NO"
+      ignoresPersistentStateOnLaunch="NO"
+      debugDocumentVersioning="YES"
+      debugServiceExtension="internal"
+      allowLocationSimulation="YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode="0">
+         <BuildableReference
+            BuildableIdentifier="primary"
+            BlueprintIdentifier="504EC3031FED79650016851F"
+            BuildableName="App.app"
+            BlueprintName="App"
+            ReferencedContainer="container:App.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration="Release"
+      shouldUseLaunchSchemeArgsEnv="YES"
+      savedToolIdentifier=""
+      useCustomWorkingDirectory="NO"
+      debugDocumentVersioning="YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode="0">
+         <BuildableReference
+            BuildableIdentifier="primary"
+            BlueprintIdentifier="504EC3031FED79650016851F"
+            BuildableName="App.app"
+            BlueprintName="App"
+            ReferencedContainer="container:App.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration="Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration="Release"
+      revealArchiveInOrganizer="YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## What
Commits a shared Xcode scheme for the demo's `App` target:
`examples/demo/ios/App/App.xcodeproj/xcshareddata/xcschemes/App.xcscheme`.

## Why
The Appium E2E iOS build runs `xcodebuild -scheme App` headlessly (via sdk-shared's `run-local.sh` / CI). But `npx cap add ios` and the demo's `setup.sh` don't emit a **shared** scheme, and Xcode only auto-creates schemes when the project is opened in the IDE. So on a fresh checkout there is no `App` scheme and the build fails with:

```
xcodebuild: error: The workspace named "App" does not contain a scheme named "App"
```

Committing the shared scheme makes the demo buildable headlessly, unblocking cordova/iOS in the Appium E2E suite. Verified locally: cordova/iOS now builds and passes **34/34** specs.

## Notes
- Scheme targets the standard Capacitor `App` target; no other project changes.
- Follow-up (harness, not this PR): `build.sh` should run the demo's `setup.sh` (`cap add`) when the iOS project is incomplete, so this class of issue self-heals.