### PR TITLE
chore: Release 5.5.3

### DIFF
--- a/OneSignalCordovaDependencies.podspec
+++ b/OneSignalCordovaDependencies.podspec
@@ -1,7 +1,7 @@
 require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
-onesignal_xcframework_version = '5.5.5'
+onesignal_xcframework_version = '5.5.6'
 onesignal_disable_location_env = ENV['ONESIGNAL_DISABLE_LOCATION'].to_s.strip.downcase
 onesignal_disable_location = ['true', '1'].include?(onesignal_disable_location_env)
 

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apache/cordova-ios.git", from: "8.0.0"),
-        .package(url: "https://github.com/OneSignal/OneSignal-XCFramework.git", exact: "5.5.5"),
+        .package(url: "https://github.com/OneSignal/OneSignal-XCFramework.git", exact: "5.5.6"),
     ],
     targets: [
         .target(

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -11,7 +11,7 @@ def isOneSignalEnvFlagEnabled(String envName) {
   return value?.equalsIgnoreCase('true') || value == '1'
 }
 
-def oneSignalVersion = '5.9.7'
+def oneSignalVersion = '5.9.8'
 def oneSignalDisableLocation = isOneSignalEnvFlagEnabled('ONESIGNAL_DISABLE_LOCATION')
 
 dependencies {

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -11,7 +11,7 @@ def isOneSignalEnvFlagEnabled(String envName) {
   return value?.equalsIgnoreCase('true') || value == '1'
 }
 
-def oneSignalVersion = '5.9.8'
+def oneSignalVersion = '5.9.9'
 def oneSignalDisableLocation = isOneSignalEnvFlagEnabled('ONESIGNAL_DISABLE_LOCATION')
 
 dependencies {

--- a/examples/demo/bun.lock
+++ b/examples/demo/bun.lock
@@ -624,7 +624,7 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
-    "onesignal-cordova-plugin": ["onesignal-cordova-plugin@../../onesignal-cordova-plugin.tgz", {}, "sha512-mEMg4oFruQrp1Sp5aMnZ9eDT2kZCb5pRCf0Jy1fono6/1BRGx3fE4zcB447QJMjNu3CHaeQMAceNTy7BjjIL4A=="],
+    "onesignal-cordova-plugin": ["onesignal-cordova-plugin@../../onesignal-cordova-plugin.tgz", {}, "sha512-cmTrYwibNA4l6gWx0cL9Lk8PUdm4990jlT2Y5RtJ8L2EUA/YW/5kAnYld2u45LmaSEzO5fVaNjg3w1sZCbKxMA=="],
 
     "open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 

--- a/examples/demo/ios/App/App.xcodeproj/project.pbxproj
+++ b/examples/demo/ios/App/App.xcodeproj/project.pbxproj
@@ -384,7 +384,7 @@
 			repositoryURL = "https://github.com/OneSignal/OneSignal-XCFramework.git";
 			requirement = {
 				kind = exactVersion;
-				version = 5.5.5;
+				version = 5.5.6;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/demo/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/examples/demo/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/OneSignal/OneSignal-XCFramework.git",
       "state" : {
-        "revision" : "e05f7193577ddf57f6bfe57776a56a16081db2e5",
-        "version" : "5.5.5"
+        "revision" : "befe5b59232a6d8752ad3ae49bd2f86474dff932",
+        "version" : "5.5.6"
       }
     }
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onesignal-cordova-plugin",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",
   "keywords": [
     "adm",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="5.5.2">
+    version="5.5.3">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -72,7 +72,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalCordovaDependencies" git="https://github.com/OneSignal/OneSignal-Cordova-SDK.git" tag="5.5.2" nospm="true" />
+            <pod name="OneSignalCordovaDependencies" git="https://github.com/OneSignal/OneSignal-Cordova-SDK.git" tag="5.5.3" nospm="true" />
         </pods>
     </podspec>
 

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -370,7 +370,7 @@ public class OneSignalPush extends CordovaPlugin
 
         initDone = true;
         OneSignalWrapper.setSdkType("cordova");
-        OneSignalWrapper.setSdkVersion("050502");
+        OneSignalWrapper.setSdkVersion("050503");
         try {
             String appId = data.getString(0);
             OneSignal.initWithContext(this.cordova.getActivity(), appId);

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -119,7 +119,7 @@ void processNotificationClicked(OSNotificationClickEvent *event) {
 
 void initOneSignalObject(NSDictionary *launchOptions) {
   OneSignalWrapper.sdkType = @"cordova";
-  OneSignalWrapper.sdkVersion = @"050502";
+  OneSignalWrapper.sdkVersion = @"050503";
   [OneSignal initialize:nil withLaunchOptions:launchOptions];
 }
 


### PR DESCRIPTION
Channels: Current

### 🛠️ Native Dependency Updates

- Update Android SDK from 5.9.7 to 5.9.9
  - chore(logger): adopt shared KMP logger module via OneSignal-KMP-SDK submodule ([#2687](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2687))
  - chore(logger): gate otel-vs-logger switch on SDK_CUSTOM_LOGGING flag ([#2688](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2688))
  - chore(logger): wire Android FileLogStore for shared KMP legacy purge ([#2691](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2691))
  - chore(logger): log release-diagnostic info at SDK startup ([#2692](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2692))
  - chore: emit Kotlin version on remote log resource attrs ([#2713](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2713))
  - chore: adopt shared KMP feature-flags client and catalog ([#2716](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2716))
  - fix: restrict notification component exports ([#2659](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2659))
  - fix: forward PermissionsActivity theme fix ([#2701](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2701))
  - fix: skip ShortcutBadger on API 26+ to prevent SIGSEGV on Xiaomi devices ([#2570](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2570))
  - fix: destroy IAM WebView on dismiss to stop Activity leaks ([#2706](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2706))
  - fix: forward PermissionsActivity theme fix
  - fix: skip ShortcutBadger on API 26+ to prevent SIGSEGV on Xiaomi devices
  - fix: restrict notification component exports
- Update iOS SDK from 5.5.5 to 5.5.6
  - fix: resolve TOCTOU race on the current user ([OneSignal-iOS-SDK#1695](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1695))
  - fix: lock OSSubscriptionModel state to stop encode crashes ([OneSignal-iOS-SDK#1694](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1694))
  - refactor: rebuild OperationRepo unmatched delta queue on flush ([OneSignal-iOS-SDK#1693](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1693))
