### PR TITLE
fix: [SDK-5150] preserve delayed foreground notification display

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -371,9 +371,9 @@ OneSignal.Notifications.removeEventListener('permissionChange', listener);
 
 ```typescript
 const listener = (event: NotificationWillDisplayEvent) => {
-  // Use preventDefault() to not display
+  // Call preventDefault() synchronously before starting any async work
   event.preventDefault();
-  // Use notification.display() to display the notification after some async work
+  // Use notification.display() within ~25 seconds to display after async work
   event.getNotification().display();
 };
 OneSignal.Notifications.addEventListener('foregroundWillDisplay', listener);

--- a/examples/demo/bun.lock
+++ b/examples/demo/bun.lock
@@ -624,7 +624,7 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
-    "onesignal-cordova-plugin": ["onesignal-cordova-plugin@../../onesignal-cordova-plugin.tgz", {}, "sha512-cmTrYwibNA4l6gWx0cL9Lk8PUdm4990jlT2Y5RtJ8L2EUA/YW/5kAnYld2u45LmaSEzO5fVaNjg3w1sZCbKxMA=="],
+    "onesignal-cordova-plugin": ["onesignal-cordova-plugin@../../onesignal-cordova-plugin.tgz", {}, "sha512-QaiSVZTgKZzGV8PHJ1iC7ZeQLjOQazGqu/f4Z/r+GLbgQwYth+lc9jruJJRS6KCPTiweiRWNUYgehop6ut2PoA=="],
 
     "open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 

--- a/examples/demo/src/hooks/useOneSignal.ts
+++ b/examples/demo/src/hooks/useOneSignal.ts
@@ -243,7 +243,7 @@ export function useOneSignal(): UseOneSignalReturn {
       // e.preventDefault();
 
       // can call this after preventDefault (within ~25 seconds) to force display of notification
-      // e.getNotification().display()
+      // e.getNotification().display();
     };
 
     const pushSubHandler = (event: PushSubscriptionChangedState) => {

--- a/examples/demo/src/hooks/useOneSignal.ts
+++ b/examples/demo/src/hooks/useOneSignal.ts
@@ -238,7 +238,12 @@ export function useOneSignal(): UseOneSignalReturn {
 
     const handleForegroundWillDisplay = (e: NotificationWillDisplayEvent) => {
       console.log(`Notification foregroundWillDisplay: ${e.getNotification().title ?? ''}`);
-      e.getNotification().display();
+
+      // uncomment to test preventing the default display behavior
+      // e.preventDefault();
+
+      // can call this after preventDefault (within ~25 seconds) to force display of notification
+      // e.getNotification().display()
     };
 
     const pushSubHandler = (event: PushSubscriptionChangedState) => {

--- a/www/NotificationReceivedEvent.test.ts
+++ b/www/NotificationReceivedEvent.test.ts
@@ -16,6 +16,7 @@ describe('NotificationWillDisplayEvent', () => {
 
   test('should instantiate NotificationWillDisplayEvent class', () => {
     expect(notificationEvent).toBeInstanceOf(NotificationWillDisplayEvent);
+    expect(notificationEvent.defaultPrevented).toBe(false);
   });
 
   test('should create OSNotification instance in constructor', () => {
@@ -31,6 +32,7 @@ describe('NotificationWillDisplayEvent', () => {
     test('should call cordova.exec for preventDefault with default (false)', () => {
       notificationEvent.preventDefault();
 
+      expect(notificationEvent.defaultPrevented).toBe(true);
       expect(window.cordova.exec).toHaveBeenCalledWith(
         expect.any(Function),
         expect.any(Function),

--- a/www/NotificationReceivedEvent.ts
+++ b/www/NotificationReceivedEvent.ts
@@ -3,9 +3,11 @@ import { OSNotification } from './OSNotification';
 
 export class NotificationWillDisplayEvent {
   private notification: OSNotification;
+  private readonly onPreventDefault?: () => void;
 
-  constructor(displayEvent: OSNotification) {
+  constructor(displayEvent: OSNotification, onPreventDefault?: () => void) {
     this.notification = new OSNotification(displayEvent);
+    this.onPreventDefault = onPreventDefault;
   }
 
   /**
@@ -17,6 +19,7 @@ export class NotificationWillDisplayEvent {
    * possibility of displaying it in the future.
    */
   preventDefault(discard: boolean = false): void {
+    this.onPreventDefault?.();
     window.cordova.exec(noop, noop, 'OneSignalPush', 'preventDefault', [
       this.notification.notificationId,
       discard,

--- a/www/NotificationReceivedEvent.ts
+++ b/www/NotificationReceivedEvent.ts
@@ -3,23 +3,27 @@ import { OSNotification } from './OSNotification';
 
 export class NotificationWillDisplayEvent {
   private notification: OSNotification;
-  private readonly onPreventDefault?: () => void;
+  private _defaultPrevented = false;
 
-  constructor(displayEvent: OSNotification, onPreventDefault?: () => void) {
+  constructor(displayEvent: OSNotification) {
     this.notification = new OSNotification(displayEvent);
-    this.onPreventDefault = onPreventDefault;
+  }
+
+  get defaultPrevented(): boolean {
+    return this._defaultPrevented;
   }
 
   /**
    * Call this to prevent OneSignal from displaying the notification automatically.
    * This method can be called up to two times with false and then true, if processing time is needed.
-   * Typically this is only possible within a short
-   * time-frame (~30 seconds) after the notification is received on the device.
+   * Call this synchronously inside the listener before starting any asynchronous work.
+   * Typically this is only possible within a short time-frame (~25 seconds) after the
+   * notification is received on the device.
    * @param discard an [preventDefault] set to true to dismiss the notification with no
    * possibility of displaying it in the future.
    */
   preventDefault(discard: boolean = false): void {
-    this.onPreventDefault?.();
+    this._defaultPrevented = true;
     window.cordova.exec(noop, noop, 'OneSignalPush', 'preventDefault', [
       this.notification.notificationId,
       discard,

--- a/www/NotificationsNamespace.test.ts
+++ b/www/NotificationsNamespace.test.ts
@@ -253,7 +253,8 @@ describe('Notifications', () => {
 
       const displayEvent = mockListener.mock.calls[0][0];
       expect(displayEvent).toBeInstanceOf(NotificationWillDisplayEvent);
-      expect(mockListener2).toHaveBeenCalledWith(displayEvent);
+      expect(displayEvent.getNotification().notificationId).toBe(notificationData.notificationId);
+      expect(mockListener2.mock.calls[0][0]).toBe(displayEvent);
 
       expect(window.cordova.exec).toHaveBeenCalledWith(
         expect.any(Function),
@@ -298,6 +299,28 @@ describe('Notifications', () => {
         'OneSignalPush',
         'displayNotification',
         [notificationData.notificationId],
+      );
+    });
+
+    test('should not proceed when the second foreground listener prevents display', () => {
+      const firstListener = vi.fn();
+      const secondListener = vi.fn((event: NotificationWillDisplayEvent) => {
+        event.preventDefault();
+      });
+      notifications.addEventListener('foregroundWillDisplay', firstListener);
+      notifications.addEventListener('foregroundWillDisplay', secondListener);
+
+      const foregroundCallback = mockExec.mock.calls[0][0];
+      foregroundCallback(mockNotification());
+
+      expect(firstListener).toHaveBeenCalledOnce();
+      expect(secondListener).toHaveBeenCalledOnce();
+      expect(window.cordova.exec).not.toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.any(Function),
+        'OneSignalPush',
+        'proceedWithWillDisplay',
+        expect.anything(),
       );
     });
 

--- a/www/NotificationsNamespace.test.ts
+++ b/www/NotificationsNamespace.test.ts
@@ -251,8 +251,8 @@ describe('Notifications', () => {
       const notificationData = mockNotification();
       foregroundCallback(notificationData);
 
-      const displayEvent = new NotificationWillDisplayEvent(notificationData);
-      expect(mockListener).toHaveBeenCalledWith(displayEvent);
+      const displayEvent = mockListener.mock.calls[0][0];
+      expect(displayEvent).toBeInstanceOf(NotificationWillDisplayEvent);
       expect(mockListener2).toHaveBeenCalledWith(displayEvent);
 
       expect(window.cordova.exec).toHaveBeenCalledWith(
@@ -260,6 +260,43 @@ describe('Notifications', () => {
         expect.any(Function),
         'OneSignalPush',
         'proceedWithWillDisplay',
+        [notificationData.notificationId],
+      );
+    });
+
+    test('should not proceed automatically when a foreground listener prevents display', () => {
+      let displayEvent: NotificationWillDisplayEvent | undefined;
+      const mockListener = vi.fn((event: NotificationWillDisplayEvent) => {
+        displayEvent = event;
+        event.preventDefault();
+      });
+      notifications.addEventListener('foregroundWillDisplay', mockListener);
+
+      const foregroundCallback = mockExec.mock.calls[0][0];
+      const notificationData = mockNotification();
+      foregroundCallback(notificationData);
+
+      expect(window.cordova.exec).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.any(Function),
+        'OneSignalPush',
+        'preventDefault',
+        [notificationData.notificationId, false],
+      );
+      expect(window.cordova.exec).not.toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.any(Function),
+        'OneSignalPush',
+        'proceedWithWillDisplay',
+        expect.anything(),
+      );
+
+      displayEvent?.getNotification().display();
+      expect(window.cordova.exec).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.any(Function),
+        'OneSignalPush',
+        'displayNotification',
         [notificationData.notificationId],
       );
     });

--- a/www/NotificationsNamespace.ts
+++ b/www/NotificationsNamespace.ts
@@ -153,14 +153,9 @@ export default class Notifications {
       if (!this._hasRegisteredForegroundWillDisplayListener) {
         this._hasRegisteredForegroundWillDisplayListener = true;
         const foregroundParsingHandler = (notification: OSNotification) => {
-          let defaultPrevented = false;
-          const displayEvent = new NotificationWillDisplayEvent(notification, () => {
-            defaultPrevented = true;
-          });
-          this._notificationWillDisplayListeners.forEach((listener) => {
-            listener(displayEvent);
-          });
-          if (!defaultPrevented) {
+          const displayEvent = new NotificationWillDisplayEvent(notification);
+          this._processFunctionList(this._notificationWillDisplayListeners, displayEvent);
+          if (!displayEvent.defaultPrevented) {
             window.cordova.exec(noop, noop, 'OneSignalPush', 'proceedWithWillDisplay', [
               notification.notificationId,
             ]);

--- a/www/NotificationsNamespace.ts
+++ b/www/NotificationsNamespace.ts
@@ -153,12 +153,18 @@ export default class Notifications {
       if (!this._hasRegisteredForegroundWillDisplayListener) {
         this._hasRegisteredForegroundWillDisplayListener = true;
         const foregroundParsingHandler = (notification: OSNotification) => {
-          this._notificationWillDisplayListeners.forEach((listener) => {
-            listener(new NotificationWillDisplayEvent(notification));
+          let defaultPrevented = false;
+          const displayEvent = new NotificationWillDisplayEvent(notification, () => {
+            defaultPrevented = true;
           });
-          window.cordova.exec(noop, noop, 'OneSignalPush', 'proceedWithWillDisplay', [
-            notification.notificationId,
-          ]);
+          this._notificationWillDisplayListeners.forEach((listener) => {
+            listener(displayEvent);
+          });
+          if (!defaultPrevented) {
+            window.cordova.exec(noop, noop, 'OneSignalPush', 'proceedWithWillDisplay', [
+              notification.notificationId,
+            ]);
+          }
         };
         window.cordova.exec(
           foregroundParsingHandler,


### PR DESCRIPTION
# Description

## One Line Summary

Preserve delayed foreground notification display after `preventDefault()`.

## Details

### Motivation

The Cordova JavaScript bridge always called `proceedWithWillDisplay` after foreground listeners returned, even when a listener synchronously called `preventDefault()`. On iOS this could consume the native display lifecycle before a delayed explicit `display()` call.

### Scope

Track prevention synchronously while dispatching foreground listeners and skip automatic proceed when prevented. Default display, immediate prevention, and immediate forced display behavior remain unchanged.

# Testing

## Unit testing

Added coverage verifying that prevented foreground events do not automatically proceed and can still explicitly display later.

## Manual testing

Tested on Android and iOS with:

- A foreground handler containing only a log
- `preventDefault()`
- `preventDefault()` followed by `display()`
- `preventDefault()` followed by `display()` after approximately 25 seconds

Automated validation:

- `vp check`
- `vp test` (176 tests)
- `vp run build`
- Demo production build

# Affected code checklist

- [x] Notifications
  - [x] Display
  - [ ] Open
  - [ ] Push Processing
  - [ ] Confirm Deliveries
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [ ] Public API changes

# Checklist

## Overview

- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
- [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [x] I have included test coverage for these changes, or explained why they are not needed
- [x] All automated tests pass, or I explained why that is not possible
- [x] I have personally tested this on my device, or explained why that is not possible

## Final pass

- [x] Code is as readable as possible.
- [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)