### PR TITLE
Make manual Cordova release version optional

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -30,8 +30,8 @@ on:
   workflow_dispatch:
     inputs:
       cordova_version:
-        description: 'New Cordova Version (e.g., 5.2.15 or 5.2.15-beta.1)'
-        required: true
+        description: 'Override the auto-detected version (e.g., 5.2.15 or 5.2.15-beta.1). Leave blank to auto-detect.'
+        required: false
         type: string
       android_version:
         description: 'New Android SDK Version (e.g., 2.3.0). Leave blank to skip.'
@@ -48,7 +48,24 @@ on:
         default: main
 
 jobs:
+  determine_version:
+    runs-on: ubuntu-latest
+    outputs:
+      cordova_version: ${{ inputs.cordova_version || steps.next_version.outputs.version }}
+      release_needed: ${{ inputs.cordova_version != '' || steps.next_version.outputs.release-needed == 'true' }}
+    steps:
+      - name: Determine Cordova SDK version
+        if: github.event_name == 'workflow_dispatch' && inputs.cordova_version == ''
+        id: next_version
+        uses: OneSignal/sdk-shared/.github/actions/determine-next-version@main
+        with:
+          github-token: ${{ secrets.GH_PUSH_TOKEN || github.token }}
+          target-repo: OneSignal/OneSignal-Cordova-SDK
+          target-branch: ${{ inputs.target_branch }}
+
   prep:
+    needs: determine_version
+    if: needs.determine_version.outputs.release_needed == 'true'
     uses: OneSignal/sdk-shared/.github/workflows/prep-release.yml@main
     secrets:
       # Need this cross-repo token (sdk-shared & this repo) to perform changes
@@ -56,12 +73,12 @@ jobs:
     with:
       # Need target_repo otherwise caller would set github.repository to the caller itself (e.g. sdk-shared)
       target_repo: OneSignal/OneSignal-Cordova-SDK
-      version: ${{ inputs.cordova_version }}
+      version: ${{ needs.determine_version.outputs.cordova_version }}
       target_branch: ${{ inputs.target_branch }}
 
   # Cordova specific steps
   update_version:
-    needs: prep
+    needs: [determine_version, prep]
     runs-on: macos-latest
     outputs:
       cordova_from: ${{ steps.current_versions.outputs.cordova_from }}
@@ -153,7 +170,7 @@ jobs:
 
       - name: Update sdk version
         run: |
-          NEW_VERSION="${{ inputs.cordova_version }}"
+          NEW_VERSION="${{ needs.determine_version.outputs.cordova_version }}"
 
           # Convert version format for OneSignal wrapper (e.g., 5.2.15 -> 050215)
           # For pre-releases, extract base version first (e.g., 5.2.15-alpha.1 -> 5.2.15)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description

## One Line Summary

Make `cordova_version` optional for manual release workflow runs and auto-detect the next version when omitted.

## Details

### Motivation

This matches the React Native SDK's `create-release-pr` auto-detection flow while preserving the required `cordova_version` input for reusable workflow callers.

### Scope

Only the Cordova release PR workflow changes. Android/iOS optional inputs, native version updates, and public SDK APIs are unchanged.

# Testing

## Manual testing

- Compared the job dependencies, outputs, and conditions against the React Native `create-release-pr.yml` pattern.
- Checked the workflow diff for whitespace errors.
- Workflow YAML validation will be completed before marking ready.

# Affected code checklist

- [ ] Notifications
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [ ] Public API changes

# Checklist

## Overview

- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
- [x] No public API changes

## Testing

- [x] Test coverage is not needed for this workflow-only change
- [ ] All relevant automated validation passes
- [x] Device testing is not applicable to this workflow-only change

## Final pass

- [x] Code is as readable as possible
- [x] I have reviewed this PR myself
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29b5b029-ea53-4a2d-ba04-b17335e1c56c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29b5b029-ea53-4a2d-ba04-b17335e1c56c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

