### PR TITLE
ci: skip CodeQL on pull requests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,9 +7,6 @@ concurrency:
 on:
   push:
     branches: ['main']
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: ['main']
   schedule:
     - cron: '37 19 * * 0'
 


### PR DESCRIPTION
# Description

## One Line Summary

Stop running CodeQL analysis on pull requests.

## Details

CodeQL now runs on pushes to `main` and the weekly schedule only. PR checks were adding latency without changing the default-branch scan.

`.github/codeql/codeql-config.yml` is unchanged.

# Testing

- Confirmed `on.pull_request` is removed from `.github/workflows/codeql.yml`.
- `push` to `main` and the Sunday schedule remain.

# Checklist

- [x] Workflow trigger change only
- [x] No public API changes
