### PR TITLE
chore: Release 5.5.5

### DIFF
--- a/OneSignalCordovaDependencies.podspec
+++ b/OneSignalCordovaDependencies.podspec
@@ -1,7 +1,7 @@
 require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
-onesignal_xcframework_version = '5.6.0'
+onesignal_xcframework_version = '5.6.1'
 onesignal_disable_location_env = ENV['ONESIGNAL_DISABLE_LOCATION'].to_s.strip.downcase
 onesignal_disable_location = ['true', '1'].include?(onesignal_disable_location_env)
 

--- a/OneSignalCordovaDependencies.podspec
+++ b/OneSignalCordovaDependencies.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.author = 'OneSignal'
   s.homepage = 'https://github.com/OneSignal/OneSignal-Cordova-SDK'
   s.source = { :git => 'https://github.com/OneSignal/OneSignal-Cordova-SDK.git', :tag => s.version.to_s }
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '12.0'
   s.preserve_paths = 'README.md'
 
   if onesignal_disable_location

--- a/OneSignalCordovaDependencies.podspec
+++ b/OneSignalCordovaDependencies.podspec
@@ -1,7 +1,7 @@
 require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
-onesignal_xcframework_version = '5.5.6'
+onesignal_xcframework_version = '5.6.0'
 onesignal_disable_location_env = ENV['ONESIGNAL_DISABLE_LOCATION'].to_s.strip.downcase
 onesignal_disable_location = ['true', '1'].include?(onesignal_disable_location_env)
 

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apache/cordova-ios.git", from: "8.0.0"),
-        .package(url: "https://github.com/OneSignal/OneSignal-XCFramework.git", exact: "5.5.6"),
+        .package(url: "https://github.com/OneSignal/OneSignal-XCFramework.git", exact: "5.6.0"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apache/cordova-ios.git", from: "8.0.0"),
-        .package(url: "https://github.com/OneSignal/OneSignal-XCFramework.git", exact: "5.6.0"),
+        .package(url: "https://github.com/OneSignal/OneSignal-XCFramework.git", exact: "5.6.1"),
     ],
     targets: [
         .target(

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -11,7 +11,7 @@ def isOneSignalEnvFlagEnabled(String envName) {
   return value?.equalsIgnoreCase('true') || value == '1'
 }
 
-def oneSignalVersion = '5.9.9'
+def oneSignalVersion = '5.10.0'
 def oneSignalDisableLocation = isOneSignalEnvFlagEnabled('ONESIGNAL_DISABLE_LOCATION')
 
 dependencies {

--- a/examples/demo/bun.lock
+++ b/examples/demo/bun.lock
@@ -624,7 +624,7 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
-    "onesignal-cordova-plugin": ["onesignal-cordova-plugin@../../onesignal-cordova-plugin.tgz", {}, "sha512-QaiSVZTgKZzGV8PHJ1iC7ZeQLjOQazGqu/f4Z/r+GLbgQwYth+lc9jruJJRS6KCPTiweiRWNUYgehop6ut2PoA=="],
+    "onesignal-cordova-plugin": ["onesignal-cordova-plugin@../../onesignal-cordova-plugin.tgz", {}, "sha512-1a2BkXVWBD7d9qjeu1OwwW7p9X/GMXNyh6P7D9s1M+pnLZTNQvja+PsQSSiBL9hbgHh0DYE8P9e04MkERxLlNg=="],
 
     "open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 

--- a/examples/demo/bun.lock
+++ b/examples/demo/bun.lock
@@ -624,7 +624,7 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
-    "onesignal-cordova-plugin": ["onesignal-cordova-plugin@../../onesignal-cordova-plugin.tgz", {}, "sha512-1a2BkXVWBD7d9qjeu1OwwW7p9X/GMXNyh6P7D9s1M+pnLZTNQvja+PsQSSiBL9hbgHh0DYE8P9e04MkERxLlNg=="],
+    "onesignal-cordova-plugin": ["onesignal-cordova-plugin@../../onesignal-cordova-plugin.tgz", {}, "sha512-FYM+NHUYT1RLelIwGKk+5ZlGOOzMf9hBus+WAaAvo/J1ofhGFrWzrFXqYw6Q/h+rmif2GBIPQqGWFDGMO6Wy2A=="],
 
     "open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 

--- a/examples/demo/ios/App/App.xcodeproj/project.pbxproj
+++ b/examples/demo/ios/App/App.xcodeproj/project.pbxproj
@@ -384,7 +384,7 @@
 			repositoryURL = "https://github.com/OneSignal/OneSignal-XCFramework.git";
 			requirement = {
 				kind = exactVersion;
-				version = 5.6.0;
+				version = 5.6.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/demo/ios/App/App.xcodeproj/project.pbxproj
+++ b/examples/demo/ios/App/App.xcodeproj/project.pbxproj
@@ -384,7 +384,7 @@
 			repositoryURL = "https://github.com/OneSignal/OneSignal-XCFramework.git";
 			requirement = {
 				kind = exactVersion;
-				version = 5.5.6;
+				version = 5.6.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/demo/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/examples/demo/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/OneSignal/OneSignal-XCFramework.git",
       "state" : {
-        "revision" : "1341884ef88315788182352a199e00cf02138b50",
-        "version" : "5.6.0"
+        "revision" : "2d6af6b0139d0eb31422092a866150183befc388",
+        "version" : "5.6.1"
       }
     }
   ],

--- a/examples/demo/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/examples/demo/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/OneSignal/OneSignal-XCFramework.git",
       "state" : {
-        "revision" : "befe5b59232a6d8752ad3ae49bd2f86474dff932",
-        "version" : "5.5.6"
+        "revision" : "1341884ef88315788182352a199e00cf02138b50",
+        "version" : "5.6.0"
       }
     }
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onesignal-cordova-plugin",
-  "version": "5.5.4",
+  "version": "5.5.5",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",
   "keywords": [
     "adm",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="5.5.4">
+    version="5.5.5">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -72,7 +72,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalCordovaDependencies" git="https://github.com/OneSignal/OneSignal-Cordova-SDK.git" tag="5.5.4" nospm="true" />
+            <pod name="OneSignalCordovaDependencies" git="https://github.com/OneSignal/OneSignal-Cordova-SDK.git" tag="5.5.5" nospm="true" />
         </pods>
     </podspec>
 

--- a/src/android/com/onesignal/cordova/OneSignalPush.java
+++ b/src/android/com/onesignal/cordova/OneSignalPush.java
@@ -370,7 +370,7 @@ public class OneSignalPush extends CordovaPlugin
 
         initDone = true;
         OneSignalWrapper.setSdkType("cordova");
-        OneSignalWrapper.setSdkVersion("050504");
+        OneSignalWrapper.setSdkVersion("050505");
         try {
             String appId = data.getString(0);
             OneSignal.initWithContext(this.cordova.getActivity(), appId);

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -119,7 +119,7 @@ void processNotificationClicked(OSNotificationClickEvent *event) {
 
 void initOneSignalObject(NSDictionary *launchOptions) {
   OneSignalWrapper.sdkType = @"cordova";
-  OneSignalWrapper.sdkVersion = @"050504";
+  OneSignalWrapper.sdkVersion = @"050505";
   [OneSignal initialize:nil withLaunchOptions:launchOptions];
 }
 


### PR DESCRIPTION
Channels: Current

### 🛠️ Native Dependency Updates

- Update Android SDK from 5.9.9 to 5.10.0
  - feat: detect restored notifications and stop them re-alerting ([#2723](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2723))
  - feat: send host FID-readiness signals on API request headers ([#2729](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2729))
  - refactor: remove the otel observability path and OpenTelemetry dependency ([#2724](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2724))
- Update iOS SDK from 5.5.6 to 5.6.1
  - fix: restore the deprecated 2-arg NSE selector ([OneSignal-iOS-SDK#1737](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1737))
  - feat: report host app build toolchain on iOS logs ([OneSignal-iOS-SDK#1728](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1728))
  - feat: call KMP features API and wire flags into OSFeatureManager ([OneSignal-iOS-SDK#1723](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1723))
  - feat: drive iOS logging from remote params ([OneSignal-iOS-SDK#1722](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1722))
  - feat: enable KMP logger on Mac Catalyst ([OneSignal-iOS-SDK#1714](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1714))
  - feat: add iOS KMP crash capture and upload ([OneSignal-iOS-SDK#1713](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1713))
  - feat: wire KMP remote logging lifecycle ([OneSignal-iOS-SDK#1703](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1703))
  - feat: add Swift adapters for KMP logger ([OneSignal-iOS-SDK#1702](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1702))
  - fix: report unbuildable log requests as a permanent failure ([OneSignal-iOS-SDK#1727](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1727))
  - fix: bound the crash-record cache on iOS ([OneSignal-iOS-SDK#1725](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1725))
  - refactor: delegate KMP bumps to shared workflow ([OneSignal-iOS-SDK#1720](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1720))
