### PR TITLE
fix: require iOS 12 for OneSignal iOS 5.6.0

### DIFF
--- a/OneSignalCordovaDependencies.podspec
+++ b/OneSignalCordovaDependencies.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.author = 'OneSignal'
   s.homepage = 'https://github.com/OneSignal/OneSignal-Cordova-SDK'
   s.source = { :git => 'https://github.com/OneSignal/OneSignal-Cordova-SDK.git', :tag => s.version.to_s }
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '12.0'
   s.preserve_paths = 'README.md'
 
   if onesignal_disable_location


### PR DESCRIPTION
# Description
## One Line Summary
Align the Cordova pod's minimum deployment target with OneSignal iOS 5.6.0.

## Details
### Motivation
OneSignalXCFramework 5.6.0 requires iOS 12, while the release podspec still declared iOS 11.

### Scope
Raises only the podspec deployment target from iOS 11 to iOS 12.

# Testing
No tests were added because this is package metadata only.

Validated with:
- `pod ipc spec OneSignalCordovaDependencies.podspec`
- `vp check`
- `vp test`

# Affected code checklist
- [x] Notifications
  - [x] Push Processing
- [ ] Public API changes

# Checklist
## Overview
- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
- [x] No public API changes

## Testing
- [x] Test coverage is added or explained
- [x] All applicable automated checks pass
- [x] Device testing is not applicable to package metadata

## Final pass
- [x] Code is as readable as possible
- [x] I reviewed this PR
