### PR TITLE
fix: hide notification prevention state

### DIFF
--- a/examples/demo/bun.lock
+++ b/examples/demo/bun.lock
@@ -624,7 +624,7 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
-    "onesignal-cordova-plugin": ["onesignal-cordova-plugin@../../onesignal-cordova-plugin.tgz", {}, "sha512-QaiSVZTgKZzGV8PHJ1iC7ZeQLjOQazGqu/f4Z/r+GLbgQwYth+lc9jruJJRS6KCPTiweiRWNUYgehop6ut2PoA=="],
+    "onesignal-cordova-plugin": ["onesignal-cordova-plugin@../../onesignal-cordova-plugin.tgz", {}, "sha512-JyTgVONUVJV6WNAutos2XUpNdTAfvUGOryr+CPCiUmjUo59WGDHQ0HYQoMafTHgarO+4031SoRaXb09tIgFQxA=="],
 
     "open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 

--- a/examples/demo/src/hooks/useOneSignal.ts
+++ b/examples/demo/src/hooks/useOneSignal.ts
@@ -241,13 +241,16 @@ export function useOneSignal(): UseOneSignalReturn {
       console.log(`[OneSignal] Notification click: ${e.notification.title ?? ''}`);
 
       // uncomment to see the full event object
-      // console.log('[OneSignal] event: ', e);
+      // console.log('[OneSignal] click event: ', e);
     };
 
     const handleForegroundWillDisplay = (e: NotificationWillDisplayEvent) => {
       console.log(
         `[OneSignal] Notification foregroundWillDisplay: ${e.getNotification().title ?? ''}`,
       );
+
+      // uncomment to see the full event object
+      // console.log('[OneSignal] will display event: ', e.getNotification());
 
       // uncomment to test preventing the default display behavior
       // e.preventDefault();

--- a/www/NotificationReceivedEvent.test.ts
+++ b/www/NotificationReceivedEvent.test.ts
@@ -16,7 +16,8 @@ describe('NotificationWillDisplayEvent', () => {
 
   test('should instantiate NotificationWillDisplayEvent class', () => {
     expect(notificationEvent).toBeInstanceOf(NotificationWillDisplayEvent);
-    expect(notificationEvent.defaultPrevented).toBe(false);
+    expect(notificationEvent).not.toHaveProperty('_defaultPrevented');
+    expect(notificationEvent).not.toHaveProperty('defaultPrevented');
   });
 
   test('should create OSNotification instance in constructor', () => {
@@ -32,7 +33,6 @@ describe('NotificationWillDisplayEvent', () => {
     test('should call cordova.exec for preventDefault with default (false)', () => {
       notificationEvent.preventDefault();
 
-      expect(notificationEvent.defaultPrevented).toBe(true);
       expect(window.cordova.exec).toHaveBeenCalledWith(
         expect.any(Function),
         expect.any(Function),

--- a/www/NotificationReceivedEvent.ts
+++ b/www/NotificationReceivedEvent.ts
@@ -1,16 +1,17 @@
 import { noop } from './helpers';
 import { OSNotification } from './OSNotification';
 
+const defaultPreventedEvents = new WeakSet<NotificationWillDisplayEvent>();
+
+export function isDefaultPrevented(event: NotificationWillDisplayEvent): boolean {
+  return defaultPreventedEvents.has(event);
+}
+
 export class NotificationWillDisplayEvent {
   private notification: OSNotification;
-  private _defaultPrevented = false;
 
   constructor(displayEvent: OSNotification) {
     this.notification = new OSNotification(displayEvent);
-  }
-
-  get defaultPrevented(): boolean {
-    return this._defaultPrevented;
   }
 
   /**
@@ -23,7 +24,7 @@ export class NotificationWillDisplayEvent {
    * possibility of displaying it in the future.
    */
   preventDefault(discard: boolean = false): void {
-    this._defaultPrevented = true;
+    defaultPreventedEvents.add(this);
     window.cordova.exec(noop, noop, 'OneSignalPush', 'preventDefault', [
       this.notification.notificationId,
       discard,

--- a/www/NotificationsNamespace.ts
+++ b/www/NotificationsNamespace.ts
@@ -1,5 +1,5 @@
 import { noop, removeListener } from './helpers';
-import { NotificationWillDisplayEvent } from './NotificationReceivedEvent';
+import { isDefaultPrevented, NotificationWillDisplayEvent } from './NotificationReceivedEvent';
 import { OSNotification } from './OSNotification';
 import type {
   NotificationClickEvent,
@@ -160,7 +160,7 @@ export default class Notifications {
         const foregroundParsingHandler = (notification: OSNotification) => {
           const displayEvent = new NotificationWillDisplayEvent(notification);
           this._processFunctionList(this._notificationWillDisplayListeners, displayEvent);
-          if (!displayEvent.defaultPrevented) {
+          if (!isDefaultPrevented(displayEvent)) {
             window.cordova.exec(noop, noop, 'OneSignalPush', 'proceedWithWillDisplay', [
               notification.notificationId,
             ]);


### PR DESCRIPTION
# Description

## One Line Summary

Keep foreground notification prevention state out of listener event objects.

## Details

### Motivation

The `_defaultPrevented` implementation field appeared when logging or serializing `NotificationWillDisplayEvent`, exposing internal SDK state to applications.

### Scope

Stores prevention state in an internal `WeakSet` while preserving foreground notification display behavior. Updates the demo logging example to access the notification object directly.

### Public API compatibility

This removes the published `defaultPrevented` getter from `NotificationWillDisplayEvent`. The pre-PR multi-model review flagged that removal as a compatibility risk for consumers using the getter.

# Testing

## Unit testing

- `vp check`
- `vp test` (186 tests passed)
- `vp run build`

## Manual testing

Not tested on a physical device; behavior is covered by foreground listener unit tests.

# Affected code checklist

- [x] Notifications
  - [x] Display
  - [ ] Open
  - [x] Push Processing
  - [ ] Confirm Deliveries
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [x] Public API changes

# Checklist

## Overview

- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
- [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [x] I have included test coverage for these changes, or explained why they are not needed
- [x] All automated tests pass, or I explained why that is not possible
- [x] I have personally tested this on my device, or explained why that is not possible

## Final pass

- [x] Code is as readable as possible.
- [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)